### PR TITLE
zookeeper recommended settings

### DIFF
--- a/manifests/zookeeper/advanced/05-stateful-set-persistent-volume.yaml
+++ b/manifests/zookeeper/advanced/05-stateful-set-persistent-volume.yaml
@@ -42,8 +42,8 @@ spec:
           image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
           resources:
             requests:
-              memory: "1Gi"
-              cpu: "0.5"
+              memory: "2Gi"
+              cpu: "1"
           ports:
             - containerPort: 2181
               name: client
@@ -51,6 +51,8 @@ spec:
               name: server
             - containerPort: 3888
               name: leader-election
+# https://github.com/kow3ns/kubernetes-zookeeper/blob/master/docker/scripts/start-zookeeper
+# https://clickhouse.yandex/docs/en/operations/tips/#zookeeper
           command:
             - sh
             - -c
@@ -63,13 +65,13 @@ spec:
           --election_port=3888 \
           --server_port=2888 \
           --tick_time=2000 \
-          --init_limit=10 \
-          --sync_limit=5 \
-          --heap=512M \
-          --max_client_cnxns=60 \
-          --snap_retain_count=3 \
-          --purge_interval=12 \
-          --max_session_timeout=40000 \
+          --init_limit=30000 \
+          --sync_limit=10 \
+          --heap=1G \
+          --max_client_cnxns=2000 \
+          --snap_retain_count=10 \
+          --purge_interval=1 \
+          --max_session_timeout=60000000 \
           --min_session_timeout=4000 \
           --log_level=INFO"
           readinessProbe:


### PR DESCRIPTION
1) log4u  settings differs (rather not important),
2) I've increased the heap size to 1Gb to avoid additional costs, but default 2Gb used in kubernetes-zookeeper sound better
3) kubernetes-zookeeper image from google fixes both lower and upper size of the heap (rather it's ok).
4) preAllocSize and snapCount can't be changed in that image
https://github.com/yandex/ClickHouse/blob/master/docs/en/operations/tips.md#zookeeper
