### PR TITLE
Add the "system_replicas_is_session_expired" metric to the exporter.

### DIFF
--- a/pkg/apis/metrics/clickhouse_fetcher.go
+++ b/pkg/apis/metrics/clickhouse_fetcher.go
@@ -68,14 +68,7 @@ const (
         'metric.DiskFreeBytes'    AS metric,
         toString(filesystemFree()) AS value,
         'Free disk space available at file system' AS description,
-		'gauge'                   AS type
-	UNION ALL
-	SELECT
-        concat('metric.IsSessionExpired', '{', 'database=', database, ',table=', table, '}') AS metric,
-        toString(is_session_expired)                                                         AS value,
-        'Whether the Zookeeper session has expired'                                          AS description,
-        'gauge'                                                                              AS type
-    FROM system.replicas
+        'gauge'                   AS type
 	`
 
 	queryTableSizesSQL = `
@@ -92,7 +85,6 @@ const (
 	GROUP BY database, table`
 )
 
-// ClickHouseFetcher describes a fetcher for a particular ClickHouse host
 type ClickHouseFetcher struct {
 	Hostname string
 	Username string
@@ -100,7 +92,6 @@ type ClickHouseFetcher struct {
 	Port     int
 }
 
-// NewClickHouseFetcher creates a new fetcher to retrieve metrics from a particular ClickHouse host
 func NewClickHouseFetcher(hostname, username, password string, port int) *ClickHouseFetcher {
 	return &ClickHouseFetcher{
 		Hostname: hostname,
@@ -119,16 +110,16 @@ func (f *ClickHouseFetcher) newConn() *clickhouse.Conn {
 func (f *ClickHouseFetcher) clickHouseQueryMetrics() ([][]string, error) {
 	data := make([][]string, 0)
 	conn := f.newConn()
-	rows, err := conn.Query(heredoc.Doc(queryMetricsSQL))
-	if err != nil {
+	if rows, err := conn.Query(heredoc.Doc(queryMetricsSQL)); err != nil {
 		return nil, err
-	}
-	for rows.Next() {
-		var metric, value, description, _type string
-		if err := rows.Scan(&metric, &value, &description, &_type); err == nil {
-			data = append(data, []string{metric, value, description, _type})
-		} else {
-			// Skip erroneous line
+	} else {
+		for rows.Next() {
+			var metric, value, description, _type string
+			if err := rows.Scan(&metric, &value, &description, &_type); err == nil {
+				data = append(data, []string{metric, value, description, _type})
+			} else {
+				// Skip erroneous line
+			}
 		}
 	}
 	return data, nil
@@ -139,16 +130,16 @@ func (f *ClickHouseFetcher) clickHouseQueryMetrics() ([][]string, error) {
 func (f *ClickHouseFetcher) clickHouseQueryTableSizes() ([][]string, error) {
 	data := make([][]string, 0)
 	conn := f.newConn()
-	rows, err := conn.Query(heredoc.Doc(queryTableSizesSQL))
-	if err != nil {
+	if rows, err := conn.Query(heredoc.Doc(queryTableSizesSQL)); err != nil {
 		return nil, err
-	}
-	for rows.Next() {
-		var database, table, partitions, parts, bytes, uncompressed, _rows string
-		if err := rows.Scan(&database, &table, &partitions, &parts, &bytes, &uncompressed, &_rows); err == nil {
-			data = append(data, []string{database, table, partitions, parts, bytes, uncompressed, _rows})
-		} else {
-			// Skip erroneous line
+	} else {
+		for rows.Next() {
+			var database, table, partitions, parts, bytes, uncompressed, _rows string
+			if err := rows.Scan(&database, &table, &partitions, &parts, &bytes, &uncompressed, &_rows); err == nil {
+				data = append(data, []string{database, table, partitions, parts, bytes, uncompressed, _rows})
+			} else {
+				// Skip erroneous line
+			}
 		}
 	}
 	return data, nil

--- a/pkg/apis/metrics/exporter.go
+++ b/pkg/apis/metrics/exporter.go
@@ -226,4 +226,15 @@ func (e *Exporter) collectFromHost(chi *WatchedChi, hostname string, c chan<- pr
 		e.enqueueToRemoveFromWatched(chi)
 		return
 	}
+
+	glog.Infof("Querying system replicas for %s\n", hostname)
+	if systemReplicas, err := fetcher.clickHouseQuerySystemReplicas(); err == nil {
+		glog.Infof("Extracted %d system replicas for %s\n", len(systemReplicas), hostname)
+		writer.WriteSystemReplicas(systemReplicas)
+	} else {
+		// In case of an error fetching data from clickhouse store CHI name in e.cleanup
+		glog.Infof("Error querying system replicas for %s: %s\n", hostname, err)
+		e.enqueueToRemoveFromWatched(chi)
+		return
+	}
 }

--- a/pkg/apis/metrics/exporter.go
+++ b/pkg/apis/metrics/exporter.go
@@ -190,7 +190,7 @@ func (e *Exporter) newFetcher(hostname string) *ClickHouseFetcher {
 	return NewClickHouseFetcher(hostname, e.chAccessInfo.Username, e.chAccessInfo.Password, e.chAccessInfo.Port)
 }
 
-// UpdateWatch ensures hostnames of the Pods from CHI object included into chopmetrics.Exporter state
+// Ensure hostnames of the Pods from CHI object included into chopmetrics.Exporter state
 func (e *Exporter) UpdateWatch(namespace, chiName string, hostnames []string) {
 	chi := &WatchedChi{
 		Namespace: namespace,

--- a/pkg/apis/metrics/exporter.go
+++ b/pkg/apis/metrics/exporter.go
@@ -190,7 +190,7 @@ func (e *Exporter) newFetcher(hostname string) *ClickHouseFetcher {
 	return NewClickHouseFetcher(hostname, e.chAccessInfo.Username, e.chAccessInfo.Password, e.chAccessInfo.Port)
 }
 
-// Ensure hostnames of the Pods from CHI object included into chopmetrics.Exporter state
+// UpdateWatch ensures hostnames of the Pods from CHI object included into chopmetrics.Exporter state
 func (e *Exporter) UpdateWatch(namespace, chiName string, hostnames []string) {
 	chi := &WatchedChi{
 		Namespace: namespace,

--- a/pkg/apis/metrics/prometheus_writer.go
+++ b/pkg/apis/metrics/prometheus_writer.go
@@ -15,10 +15,11 @@
 package metrics
 
 import (
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -44,7 +45,7 @@ func NewPrometheusWriter(
 	}
 }
 
-// writeMetricsDataToPrometheus pushes set of prometheus.Metric objects created from the ClickHouse system data
+// WriteMetrics pushes set of prometheus.Metric objects created from the ClickHouse system data
 // Expected data structure: metric, value, description, type (gauge|counter)
 // TODO add namespace handling. It is just skipped for now
 func (w *PrometheusWriter) WriteMetrics(data [][]string) {
@@ -70,7 +71,7 @@ func (w *PrometheusWriter) WriteMetrics(data [][]string) {
 	}
 }
 
-// writeTableSizesDataToPrometheus pushes set of prometheus.Metric objects created from the ClickHouse system data
+// WriteTableSizes pushes set of prometheus.Metric objects created from the ClickHouse system data
 // Expected data structure: database, table, partitions, parts, bytes, uncompressed_bytes, rows
 // TODO add namespace handling. It is just skipped for now
 func (w *PrometheusWriter) WriteTableSizes(data [][]string) {
@@ -91,6 +92,14 @@ func (w *PrometheusWriter) WriteTableSizes(data [][]string) {
 			[]string{"chi", "hostname", "database", "table"},
 			w.chi.Name, w.hostname, metric[0], metric[1])
 		writeSingleMetricToPrometheus(w.out, "table_parts_rows", "Number of rows in the table", metric[6], prometheus.GaugeValue,
+			[]string{"chi", "hostname", "database", "table"},
+			w.chi.Name, w.hostname, metric[0], metric[1])
+	}
+}
+
+func (w *PrometheusWriter) WriteSystemReplicas(data [][]string) {
+	for _, metric := range data {
+		writeSingleMetricToPrometheus(w.out, "system_replicas_is_session_expired", "Number of expired Zookeeper sessions of the table", metric[2], prometheus.GaugeValue,
 			[]string{"chi", "hostname", "database", "table"},
 			w.chi.Name, w.hostname, metric[0], metric[1])
 	}

--- a/pkg/apis/metrics/rest.go
+++ b/pkg/apis/metrics/rest.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// startMetricsExporter start Prometheus metrics exporter in background
+// StartMetricsREST start Prometheus metrics exporter in background
 func StartMetricsREST(
 	username, password string, port int,
 	metricsAddress, metricsPath string,


### PR DESCRIPTION
This metric reports which replicated tables have seen their Zookeeper sessions expired. This metric is labeled by database and table, plus additional labels that are added by default (e.g. ClickHouse hostname).

Expired Zookeeper sessions cause ClickHouse to start switching tables to read/only which is likely a symptom that something is wrong with Zookeeper or the network itself. In general, when this happens, the operator needs to take action in order to fix this situation.