### PR TITLE
fix metrics-exporter goroutine leak: DB connection is created per query

### DIFF
--- a/pkg/apis/metrics/clickhouse_fetcher.go
+++ b/pkg/apis/metrics/clickhouse_fetcher.go
@@ -18,8 +18,14 @@ import (
 	sqlmodule "database/sql"
 
 	"github.com/MakeNowJust/heredoc"
-
 	"github.com/altinity/clickhouse-operator/pkg/model/clickhouse"
+	"time"
+	"context"
+)
+
+
+const (
+	defaultTimeout  = 10 * time.Second
 )
 
 const (
@@ -191,7 +197,11 @@ func (f *ClickHouseFetcher) clickHouseQueryScanRows(
 		data *[][]string,
 	) error,
 ) ([][]string, error) {
-	if rows, err := f.newConn().Query(heredoc.Doc(sql)); err != nil {
+	// Query should be deadlined
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(defaultTimeout))
+	defer cancel()
+
+	if rows, err := f.newConn().QueryContext(ctx, heredoc.Doc(sql)); err != nil {
 		return nil, err
 	} else {
 		data := make([][]string, 0)


### PR DESCRIPTION
1. keep DB connection in global variable and initialize each DB connection once, instead of creating a DB connection for each query.
2. Move deadline context to clickHouseQueryScanRows, to prevent the case that Rows is closed before scan is finished.  