### PR TITLE
add prometheus.io/ to annotations in clickhouse-operator Deployment

### DIFF
--- a/deploy/dev/clickhouse-operator-install-dev.yaml
+++ b/deploy/dev/clickhouse-operator-install-dev.yaml
@@ -1625,6 +1625,9 @@ spec:
     metadata:
       labels:
         app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
     spec:
       serviceAccountName: clickhouse-operator
       volumes:

--- a/deploy/dev/clickhouse-operator-install-yaml-template-04-section-deployment-with-configmap.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-04-section-deployment-with-configmap.yaml
@@ -22,6 +22,9 @@ spec:
     metadata:
       labels:
         app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
     spec:
       serviceAccountName: clickhouse-operator
       volumes:

--- a/deploy/dev/clickhouse-operator-install-yaml-template-04-section-deployment.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-04-section-deployment.yaml
@@ -13,6 +13,9 @@ metadata:
   namespace: ${OPERATOR_NAMESPACE}
   labels:
     app: clickhouse-operator
+  annotations:
+    prometheus.io/port: '8888'
+    prometheus.io/scrape: 'true'
 spec:
   replicas: 1
   selector:

--- a/deploy/operator/clickhouse-operator-install-deployment.yaml
+++ b/deploy/operator/clickhouse-operator-install-deployment.yaml
@@ -339,6 +339,9 @@ spec:
     metadata:
       labels:
         app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
     spec:
       serviceAccountName: clickhouse-operator
       volumes:

--- a/deploy/operator/clickhouse-operator-install-template-deployment.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-deployment.yaml
@@ -345,6 +345,9 @@ spec:
     metadata:
       labels:
         app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
     spec:
       serviceAccountName: clickhouse-operator
       volumes:

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -1625,6 +1625,9 @@ spec:
     metadata:
       labels:
         app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
     spec:
       serviceAccountName: clickhouse-operator
       volumes:

--- a/deploy/operator/clickhouse-operator-install.yaml
+++ b/deploy/operator/clickhouse-operator-install.yaml
@@ -1625,6 +1625,9 @@ spec:
     metadata:
       labels:
         app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
     spec:
       serviceAccountName: clickhouse-operator
       volumes:


### PR DESCRIPTION
fix https://github.com/Altinity/clickhouse-operator/issues/269
add annotations for clickhouse-operator deployment which can help when prometheus setup via helm chart, https://github.com/helm/charts/blob/master/stable/prometheus/

Signed-off-by: Eugene Klimov <eklimov@altinity.com>