### PR TITLE
README: Update grafana-service (to be the same as grafana-operator name)

### DIFF
--- a/deploy/grafana/grafana-manually/grafana.yaml
+++ b/deploy/grafana/grafana-manually/grafana.yaml
@@ -66,7 +66,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana
+  name: grafana-service
   labels:
     app: grafana
 spec:

--- a/docs/grafana_setup.md
+++ b/docs/grafana_setup.md
@@ -50,7 +50,7 @@ At this point Grafana is up and running. Let's check it out.
 Grafana is running in k8s cluster and is available via Service of type ClusterIP and named as `grafana`.
 It is located in the same namespace as Grafana:
 ```bash
-kubectl --namespace=grafana get service grafana 
+kubectl --namespace=grafana get service grafana-service
 ```
 ```text
 NAME      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
@@ -58,7 +58,7 @@ grafana   ClusterIP   10.98.42.192   <none>        3000/TCP   14h
 ```
 Let's get access to Grafana. Port-forward Grafana to `localhost` as:
 ```bash
-kubectl --namespace=grafana port-forward service/grafana 3000
+kubectl --namespace=grafana port-forward service/grafana-service 3000
 ```
 and navigate browser to `http://localhost:3000` Grafana should appear.
 Login credentials:

--- a/docs/grafana_setup.md
+++ b/docs/grafana_setup.md
@@ -21,7 +21,7 @@ bash install-grafana-with-operator.sh
 ```
 Run port forward for access to Grafana instance as `localhost`:
 ```bash
-kubectl --namespace=grafana port-forward service/grafana 3000
+kubectl --namespace=grafana port-forward service/grafana-service 3000
 ```
 and navigate browser to `http://localhost:3000` Grafana should appear.
 Login credentials:

--- a/docs/k8s_cluster_access.md
+++ b/docs/k8s_cluster_access.md
@@ -11,7 +11,7 @@ kubectl config set-context altinity.k8s.local
 We can access any service inside k8s cluster on `localhost` via port-forwarding feature.
 Example: forwarding Graphana dashboard to `localhost:3090`
 ```bash
-kubectl --namespace=grafana port-forward service/grafana 3090:3000
+kubectl --namespace=grafana port-forward service/grafana-service 3090:3000
 ```
 Point browser to `http://localhost:3090` in order to access Grafana  
 


### PR DESCRIPTION
Grafana service name is changed when created using grafana-operator.
Here is this change in `grafana-operator` repo: https://github.com/integr8ly/grafana-operator/blob/master/pkg/controller/model/constants.go