### PR TITLE
bump testflows to 1.4 and adapt test cases

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,8 +59,9 @@ Vagrant.configure(2) do |config|
     # minikube
     wget -c --progress=bar:force:noscroll -O /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
     chmod +x /usr/local/bin/minikube
-
-    K8S_VERSION=${K8S_VERSION:-1.17.3}
+    # 1.14.10
+    # 1.15.11
+    K8S_VERSION=${K8S_VERSION:-1.14.10}
     minikube config set vm-driver none
     minikube config set kubernetes-version ${K8S_VERSION}
     minikube start
@@ -111,8 +112,11 @@ Vagrant.configure(2) do |config|
         docker pull ${image}
     done
 
-    python3 /vagrant/tests/test.py
-    python3 /vagrant/tests/test_examples.py
-    python3 /vagrant/tests/test_metrics_exporter.py
+    # currently test_clickhouse.py broke on test_ch_001 last step, `we can't reach quorum after previouse instert`
+    python3 /vagrant/tests/test.py --only=operator/* -o short
+    python3 /vagrant/tests/test.py --only=clickhouse/* -o short
+    # currently test_metrics_exporter.py failed cause /chi doesn't clear after `kubectl delete ns test`
+    python3 /vagrant/tests/test_metrics_exporter.py -o short
+    python3 /vagrant/tests/test_examples.py -o short
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,6 +86,8 @@ Vagrant.configure(2) do |config|
     fi
 
     export PROMETHEUS_NAMESPACE=${PROMETHEUS_NAMESPACE:-prometheus}
+    # strange behavior for 1.14.10
+    export VALIDATE_YAML=false
     cd /vagrant/deploy/prometheus/
     bash -e ./create-prometheus.sh
     cd /vagrant/

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,65 @@
+import settings
+from kubectl import *
+
+
+def set_operator_version(version, ns="kube-system", timeout=60):
+    kubectl(
+        f"set image deployment.v1.apps/clickhouse-operator clickhouse-operator=altinity/clickhouse-operator:{version}",
+        ns=ns
+    )
+    kubectl(
+        f"set image deployment.v1.apps/clickhouse-operator metrics-exporter=altinity/metrics-exporter:{version}",
+        ns=ns
+    )
+    kubectl("rollout status deployment.v1.apps/clickhouse-operator", ns=ns, timeout=timeout)
+    assert kube_get_count("pod", ns=ns, label="-l app=clickhouse-operator") > 0, error()
+
+
+def restart_operator(ns="kube-system", timeout=60):
+    pod_name = kube_get("pod", name="", ns=ns, label="-l app=clickhouse-operator")["items"][0]["metadata"]["name"]
+    kubectl(f"delete pod {pod_name}", ns=ns, timeout=timeout)
+    kube_wait_object("pod", name="", ns=ns, label="-l app=clickhouse-operator")
+    pod_name = kube_get("pod", name="", ns=ns, label="-l app=clickhouse-operator")["items"][0]["metadata"]["name"]
+    kube_wait_pod_status(pod_name, "Running", ns=ns)
+    time.sleep(5)
+
+
+def require_zookeeper():
+    with Given("Install Zookeeper if missing"):
+        if kube_get_count("service", name="zookeepers") == 0:
+            config = get_full_path("../deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-1-node.yaml")
+            kube_apply(config)
+            kube_wait_object("pod", "zookeeper-0")
+            kube_wait_pod_status("zookeeper-0", "Running")
+
+
+def test_operator_upgrade(config, version_from, version_to=settings.version):
+    with Given(f"clickhouse-operator {version_from}"):
+        set_operator_version(version_from)
+        config = get_full_path(config)
+        chi = get_chi_name(config)
+
+        create_and_check(config, {"object_counts": [1, 1, 2], "do_not_delete": 1})
+
+        with When(f"upgrade operator to {version_to}"):
+            set_operator_version(version_to, timeout=120)
+            kube_wait_chi_status(chi, "Completed", retries=5)
+            kube_wait_objects(chi, [1, 1, 2])
+
+        kube_delete_chi(chi)
+
+
+def test_operator_restart(config, version=settings.version):
+    with Given(f"clickhouse-operator {version}"):
+        set_operator_version(version)
+        config = get_full_path(config)
+        chi = get_chi_name(config)
+
+        create_and_check(config, {"object_counts": [1, 1, 2], "do_not_delete": 1})
+
+        with When("Restart operator"):
+            restart_operator()
+            kube_wait_chi_status(chi, "Completed")
+            kube_wait_objects(chi, [1, 1, 2])
+
+        kube_delete_chi(chi)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,1 @@
-testflows>=1.3.44
+testflows==1.4.2

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
+import os
+import pathlib
 import kubectl
 
-version = "0.9.7"
+version = open(os.path.join(pathlib.Path(__file__).parent.absolute(),"../release")).read(1024)
 test_namespace = "test"
 clickhouse_template = "templates/tpl-clickhouse-stable.yaml"
 # clickhouse_template = "templates/tpl-clickhouse-19.11.yaml"

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,11 +1,7 @@
-from clickhouse import * 
-from kubectl import *
-import settings 
-from test_operator import *
-from test_clickhouse import *  
+from testflows.core import Given, main, run, Module, TE
 
-from testflows.core import TestScenario, Name, When, Then, Given, And, main, run, Module, TE, args
-from testflows.asserts import error
+from test_clickhouse import *
+from test_operator import *
 
 if main():
     with Module("main", flags=TE):
@@ -28,7 +24,7 @@ if main():
             kube_apply(get_full_path(settings.clickhouse_template), settings.test_namespace)
 
         with Given(f"ClickHouse version {settings.clickhouse_version}"):
-            1 == 1
+            pass
 
         # python3 tests/test.py --only operator*
         with Module("operator", flags=TE):
@@ -64,7 +60,7 @@ if main():
                 if callable(t):
                     run(test=t, flags=TE)
                 else:
-                    run(test = t[0], args = t[1], flags=TE)
+                    run(test=t[0], args=t[1], flags=TE)
 
         # python3 tests/test.py --only clickhouse*
         with Module("clickhouse", flags=TE):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,28 +1,30 @@
-from testflows.core import TestScenario, Name, When, Then, Given, And, main, run, Module, TE
-from testflows.asserts import error
-
+from testflows.core import TestScenario, Name, main, run, Module, TE
 from kubectl import create_and_check
+
 
 @TestScenario
 @Name("Empty installation, creates 1 node")
-def test_examples01_1():
-    create_and_check("../docs/chi-examples/01-simple-layout-01-1shard-1repl.yaml", {"object_counts": [1,1,2]})
+def test_examples01_1(self):
+    create_and_check("../docs/chi-examples/01-simple-layout-01-1shard-1repl.yaml", {"object_counts": [1, 1, 2]})
+
 
 @TestScenario
 @Name("1 shard 2 replicas")
-def test_examples01_2():
-    create_and_check("../docs/chi-examples/01-simple-layout-02-1shard-2repl.yaml", {"object_counts": [2,2,3]})
+def test_examples01_2(self):
+    create_and_check("../docs/chi-examples/01-simple-layout-02-1shard-2repl.yaml", {"object_counts": [2, 2, 3]})
+
 
 @TestScenario
 @Name("Persistent volume mapping via defaults")
-def test_examples02_1():
+def test_examples02_1(self):
     create_and_check("../docs/chi-examples/03-persistent-volume-01-default-volume.yaml",
                      {"pod_count": 1,
                       "pod_volumes": {"/var/lib/clickhouse", "/var/log/clickhouse-server"}})
 
+
 @TestScenario
 @Name("Persistent volume mapping via podTemplate")
-def test_examples02_2():
+def test_examples02_2(self):
     create_and_check("../docs/chi-examples/03-persistent-volume-02-pod-template.yaml",
                      {"pod_count": 1,
                       "pod_image": "yandex/clickhouse-server:19.3.7",

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,52 +1,58 @@
-from clickhouse import * 
-from kubectl import * 
-import settings 
-
-from testflows.core import TestScenario, Name, When, Then, Given, And, main, run, Module, TE
 from testflows.asserts import error
+from testflows.core import TestScenario, Name, When, Then, Given, And
+
+import settings
+from clickhouse import *
+from kubectl import *
+from helpers import *
 
 
 @TestScenario
 @Name("test_001. 1 node")
-def test_001():
+def test_001(self):
     create_and_check("configs/test-001.yaml", {"object_counts": [1, 1, 2]})
-    
+
+
 @TestScenario
 @Name("test_002. useTemplates for pod and volume templates")
-def test_002():
+def test_002(self):
     create_and_check("configs/test-002-tpl.yaml", 
                      {"pod_count": 1,
                       "apply_templates": {settings.clickhouse_template, "templates/tpl-log-volume.yaml"},
                       "pod_image": settings.clickhouse_version,
                       "pod_volumes": {"/var/log/clickhouse-server"}})
 
+
 @TestScenario
 @Name("test_003. useTemplates for pod and distribution templates")
-def test_003():
+def test_003(self):
     create_and_check("configs/test-003-tpl.yaml", 
                      {"pod_count": 1,
                       "apply_templates": {settings.clickhouse_template, "templates/tpl-one-per-host.yaml"},
                       "pod_image": settings.clickhouse_version,
                       "pod_podAntiAffinity": 1})
 
+
 @TestScenario
 @Name("test_004. Compatibility test if old syntax with volumeClaimTemplate is still supported")
-def test_004():
+def test_004(self):
     create_and_check("configs/test-004-tpl.yaml", 
                      {"pod_count": 1,
                       "pod_volumes": {"/var/lib/clickhouse"}})
 
+
 @TestScenario
 @Name("test_005. Test manifest created by ACM")
-def test_005():
+def test_005(self):
     create_and_check("configs/test-005-acm.yaml", 
                      {"pod_count": 1,
                       "pod_image": "yandex/clickhouse-server:19.11.8.46",
                       "pod_volumes": {"/var/lib/clickhouse"}})
 
+
 @TestScenario
 @Name("test_006. Test clickhouse version upgrade from one version to another using podTemplate change")
-def test_006():
+def test_006(self):
     create_and_check("configs/test-006-ch-upgrade-1.yaml", 
                      {"pod_count": 2,
                       "pod_image": "yandex/clickhouse-server:19.11.8.46",
@@ -61,83 +67,34 @@ def test_006():
                              {"pod_count": 2,
                               "pod_image": "yandex/clickhouse-server:19.11.8.46"})
 
+
 @TestScenario
 @Name("test_007. Test template with custom clickhouse ports")
-def test_007():
+def test_007(self):
     create_and_check("configs/test-007-custom-ports.yaml", 
                      {"pod_count": 1,
                       "apply_templates": {"templates/tpl-custom-ports.yaml"},
                       "pod_image": "yandex/clickhouse-server:19.11.8.46",
-                      "pod_ports": [8124,9001,9010]})
+                      "pod_ports": [8124, 9001, 9010]})
 
-def test_operator_upgrade(config, version_from, version_to = settings.version):
-    version_to = settings.version
-    with Given(f"clickhouse-operator {version_from}"):
-        set_operator_version(version_from)
-        config = get_full_path(config)
-        chi = get_chi_name(config)
-
-        create_and_check(config, {"object_counts": [1, 1, 2], "do_not_delete": 1})
-
-        with When(f"upgrade operator to {version_to}"):
-            set_operator_version(version_to, timeout=120)
-            kube_wait_chi_status(chi, "Completed", retries = 5)
-            kube_wait_objects(chi, [1,1,2])
-
-        kube_delete_chi(chi)
-
-def test_operator_restart(config, version = settings.version):
-    with Given(f"clickhouse-operator {version}"):
-        set_operator_version(version)
-        config = get_full_path(config)
-        chi = get_chi_name(config)
-
-        create_and_check(config, {"object_counts": [1, 1, 2], "do_not_delete": 1})
-
-        with When("Restart operator"):
-            restart_operator()
-            kube_wait_chi_status(chi, "Completed")
-            kube_wait_objects(chi, [1,1,2])
-
-        kube_delete_chi(chi)
 
 @TestScenario
 @Name("test_008. Test operator restart")
-def test_008():
+def test_008(self):
     test_operator_restart("configs/test-009-operator-upgrade.yaml")
     test_operator_restart("configs/test-009-operator-upgrade-2.yaml")
 
+
 @TestScenario
 @Name("test_009. Test operator upgrade")
-def test_009(version_from = "0.8.0", version_to = settings.version):
+def test_009(self, version_from="0.8.0", version_to=settings.version):
     test_operator_upgrade("configs/test-009-operator-upgrade.yaml", version_from, version_to)
     test_operator_upgrade("configs/test-009-operator-upgrade-2.yaml", version_from, version_to)
 
-def set_operator_version(version, ns="kube-system", timeout=60):
-    kubectl(f"set image deployment.v1.apps/clickhouse-operator clickhouse-operator=altinity/clickhouse-operator:{version}", ns=ns)
-    kubectl(f"set image deployment.v1.apps/clickhouse-operator metrics-exporter=altinity/metrics-exporter:{version}", ns=ns)
-    kubectl("rollout status deployment.v1.apps/clickhouse-operator", ns=ns, timeout=timeout)
-    assert kube_get_count("pod", ns=ns, label="-l app=clickhouse-operator") > 0, error()
-    
-def restart_operator(ns = "kube-system", timeout=60):
-    pod_name = kube_get("pod", name="", ns=ns, label="-l app=clickhouse-operator")["items"][0]["metadata"]["name"]
-    kubectl(f"delete pod {pod_name}", ns = ns, timeout = timeout)
-    kube_wait_object("pod", name="", ns = ns, label="-l app=clickhouse-operator")
-    pod_name = kube_get("pod", name="", ns = ns, label="-l app=clickhouse-operator")["items"][0]["metadata"]["name"]
-    kube_wait_pod_status(pod_name, "Running", ns = ns)
-    time.sleep(5)
-
-def require_zookeeper():
-    with Given("Install Zookeeper if missing"):
-        if kube_get_count("service", name="zookeepers") == 0:
-            config = get_full_path("../deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-1-node.yaml")
-            kube_apply(config)
-            kube_wait_object("pod", "zookeeper-0")
-            kube_wait_pod_status("zookeeper-0", "Running")
 
 @TestScenario
 @Name("test_010. Test zookeeper initialization")
-def test_010():
+def test_010(self):
     require_zookeeper()
 
     create_and_check("configs/test-010-zkroot.yaml", 
@@ -147,12 +104,13 @@ def test_010():
     with And("ClickHouse should complain regarding zookeeper path"):
         out = clickhouse_query_with_error("test-010-zkroot", "select * from system.zookeeper where path = '/'")
         assert "You should create root node /clickhouse/test-010-zkroot before start" in out, error()
-    
+
     kube_delete_chi("test-010-zkroot")
 
+
 @TestScenario
-@Name("test_011. Test user security and network isolation")    
-def test_011():
+@Name("test_011. Test user security and network isolation")
+def test_011(self):
     
     with Given("test-011-secured-cluster.yaml and test-011-insecured-cluster.yaml"):
         create_and_check("configs/test-011-secured-cluster.yaml", 
@@ -191,8 +149,9 @@ def test_011():
             assert "Password required" in out
     
         with And("Connection from insecured to secured host should work for user with password"):
-            out = clickhouse_query_with_error("test-011-insecured-cluster","select 'OK'", 
-                                              host = "chi-test-011-secured-cluster-default-1-0", user = "user1", pwd = "topsecret")
+            out = clickhouse_query_with_error("test-011-insecured-cluster", "select 'OK'",
+                                              host="chi-test-011-secured-cluster-default-1-0", user="user1",
+                                              pwd="topsecret")
             assert out == 'OK'
 
         with And("Password should be encrypted"):
@@ -202,23 +161,26 @@ def test_011():
             assert "<password_sha256_hex>" in users_xml
 
         with And("User with no password should get default automatically"):
-            out = clickhouse_query_with_error("test-011-secured-cluster", "select 'OK'", user = "user2", pwd = "default")
+            out = clickhouse_query_with_error("test-011-secured-cluster", "select 'OK'", user="user2", pwd="default")
             assert out == 'OK'
 
         with And("User with both plain and sha256 password should get the latter one"):
-            out = clickhouse_query_with_error("test-011-secured-cluster", "select 'OK'", user = "user3", pwd = "clickhouse_operator_password")
+            out = clickhouse_query_with_error("test-011-secured-cluster", "select 'OK'", user="user3",
+                                              pwd="clickhouse_operator_password")
             assert out == 'OK'
         
         with And("User with row-level security should have it applied"):
-            out = clickhouse_query_with_error("test-011-secured-cluster", "select * from system.numbers limit 1", user = "restricted", pwd = "secret")
+            out = clickhouse_query_with_error("test-011-secured-cluster", "select * from system.numbers limit 1",
+                                              user="restricted", pwd="secret")
             assert out == '1000'
 
         kube_delete_chi("test-011-secured-cluster")
         kube_delete_chi("test-011-insecured-cluster")
 
+
 @TestScenario
-@Name("test_011_1. Test default user security")    
-def test_011_1():    
+@Name("test_011_1. Test default user security")
+def test_011_1(self):
     with Given("test-011-secured-default.yaml with password_sha256_hex for default user"):
         create_and_check("configs/test-011-secured-default.yaml", 
                          {"pod_count": 1,
@@ -230,7 +192,8 @@ def test_011_1():
             assert chi["status"]["normalized"]["configuration"]["users"]["default/password"] == "_removed_"
     
         with And("Connection to localhost should succeed with default user"):
-            out = clickhouse_query_with_error("test-011-secured-default", "select 'OK'", pwd = "clickhouse_operator_password")
+            out = clickhouse_query_with_error("test-011-secured-default", "select 'OK'",
+                                              pwd="clickhouse_operator_password")
             assert out == 'OK'
     
         with When("Trigger installation update"):
@@ -251,23 +214,24 @@ def test_011_1():
 
 @TestScenario
 @Name("test_012. Test service templates")
-def test_012():
-    create_and_check("configs/test-012-service-template.yaml", 
-                     {"object_counts": [2,2,4],
-                      "service": ["service-test-012","ClusterIP"],
+def test_012(self):
+    create_and_check("configs/test-012-service-template.yaml",
+                     {"object_counts": [2, 2, 4],
+                      "service": ["service-test-012", "ClusterIP"],
                       "do_not_delete": 1})
     with Then("There should be a service for shard 0"):
-        kube_check_service("service-test-012-0-0","ClusterIP")
+        kube_check_service("service-test-012-0-0", "ClusterIP")
     with And("There should be a service for shard 1"):
-        kube_check_service("service-test-012-1-0","ClusterIP")
+        kube_check_service("service-test-012-1-0", "ClusterIP")
     with And("There should be a service for default cluster"):
-        kube_check_service("service-default","ClusterIP")
+        kube_check_service("service-default", "ClusterIP")
 
     kube_delete_chi("test-012")
 
+
 @TestScenario
 @Name("test_013. Test adding shards and creating local and distributed tables automatically")
-def test_013():
+def test_013(self):
     create_and_check("configs/test-013-add-shards-1.yaml",
                      {"apply_templates": {settings.clickhouse_template},
                       "object_counts": [1, 1, 2], "do_not_delete": 1})
@@ -286,11 +250,12 @@ def test_013():
         assert out == "1"
     
     with Then("Remove shard"):
-        create_and_check("configs/test-013-add-shards-1.yaml", {"object_counts": [1,1,2]})
+        create_and_check("configs/test-013-add-shards-1.yaml", {"object_counts": [1, 1, 2]})
+
 
 @TestScenario
 @Name("test_014. Test that replication works")
-def test_014():
+def test_014(self):
     require_zookeeper()
  
     create_table = """
@@ -298,10 +263,11 @@ def test_014():
     Engine = ReplicatedMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
     partition by tuple() order by a""".replace('\r', '').replace('\n', '')
 
-    create_and_check("configs/test-014-replication.yaml", 
-                    {"apply_templates": {settings.clickhouse_template},
-                     "pod_count": 2,
-                     "do_not_delete": 1})
+    create_and_check("configs/test-014-replication.yaml", {
+        "apply_templates": {settings.clickhouse_template},
+        "pod_count": 2,
+        "do_not_delete": 1
+    })
 
     with Given("Table is created on a first replica and data is inserted"):
         clickhouse_query("test-014-replication", create_table, host="chi-test-014-replication-default-0-0")
@@ -326,9 +292,10 @@ def test_014():
 
     kube_delete_chi("test-014-replication")
 
+
 @TestScenario
 @Name("test_015. Test circular replication with hostNetwork")
-def test_015():
+def test_015(self):
     create_and_check("configs/test-015-host-network.yaml", 
                      {"pod_count": 2,
                       "do_not_delete": 1})
@@ -344,23 +311,25 @@ def test_015():
     
     kube_delete_chi("test-015-host-network")
 
+
 @TestScenario
 @Name("test_016. Test files and dictionaries setup")
-def test_016():
+def test_016(self):
     create_and_check("configs/test-016-dict.yaml",
                      {"apply_templates": {settings.clickhouse_template},
                       "pod_count": 1,
                       "do_not_delete": 1})
 
     with Then("dictGet() should work"):
-        out = clickhouse_query("test-016-dict", query = "select dictGet('one', 'one', toUInt64(0))")
+        out = clickhouse_query("test-016-dict", query="select dictGet('one', 'one', toUInt64(0))")
         assert out == "0"
 
     kube_delete_chi("test-016-dict")
 
+
 @TestScenario
 @Name("test-017-multi-version. Test certain functions across multiple versions")
-def test_017():
+def test_017(self):
     create_and_check("configs/test-017-multi-version.yaml", {"pod_count": 4, "do_not_delete": 1})
     chi = "test-017-multi-version"
 
@@ -377,10 +346,11 @@ def test_017():
         print(f"logged: {out}")
 
     kube_delete_chi(chi)
-    
+
+
 @TestScenario
 @Name("test-018-configmap. Test that configuration is properly updated")
-def test_018():
+def test_018(self):
     create_and_check("configs/test-018-configmap.yaml", {"pod_count": 1, "do_not_delete": 1})
     
     with Then("user1/networks/ip should be in config"):
@@ -393,12 +363,13 @@ def test_018():
         assert "user2/networks/ip" in chi["spec"]["configuration"]["users"]
         with And("user1/networks/ip should NOT be in config"):
             assert "user1/networks/ip" not in chi["spec"]["configuration"]["users"]
-    
+
     kube_delete_chi("test-018-configmap")
+
 
 @TestScenario
 @Name("test-019-retain-volume. Test that volume is correctly retained and can be re-attached")
-def test_019(config = "configs/test-019-retain-volume.yaml"):
+def test_019(self, config="configs/test-019-retain-volume.yaml"):
     require_zookeeper()
 
     chi = get_chi_name(get_full_path(config))
@@ -412,8 +383,8 @@ def test_019(config = "configs/test-019-retain-volume.yaml"):
     as select 1 as a""".replace('\r', '').replace('\n', '')
 
     with Given("ClickHouse has some data in place"):
-        clickhouse_query(chi, query = create_nonreplicated_table)
-        clickhouse_query(chi, query = create_replicated_table)
+        clickhouse_query(chi, query=create_nonreplicated_table)
+        clickhouse_query(chi, query=create_replicated_table)
 
     with When("CHI with retained volume is deleted"):
         pvc_count = kube_get_count("pvc")
@@ -430,10 +401,10 @@ def test_019(config = "configs/test-019-retain-volume.yaml"):
     
     with Then("PVC should be re-mounted"):
         with And("Non-replicated table should have data"):
-            out = clickhouse_query(chi, query = "select a from t1")
+            out = clickhouse_query(chi, query="select a from t1")
             assert out == "1"
         with And("Replicated table should have data"):
-            out = clickhouse_query(chi, query = "select a from t2")
+            out = clickhouse_query(chi, query="select a from t2")
             assert out == "1"
 
     kube_delete_chi(chi)


### PR DESCRIPTION
I made a following changes:
- `settings.version` read from /release
- update testflows to 1.4 in Vagrant
- adapt all test_cases for use with testflows 1.4

please run `pip3 install -U testflows`
if you will check results locally

test results on kubernetes 1.14.10
```
    python3 /vagrant/tests/test.py --only=operator/* -o short
    PASS

   # currently test_clickhouse.py broke on test_ch_001 last step, `we can't reach quorum after previous instert`
    python3 /vagrant/tests/test.py --only=clickhouse/* -o short
    FAIL

    # currently test_metrics_exporter.py failed cause /chi doesn't clear after `kubectl delete ns test`
    python3 /vagrant/tests/test_metrics_exporter.py -o short
    FAIL

    python3 /vagrant/tests/test_examples.py -o short
    PASS
```
