### PR TITLE
add env variable used to populate inter server http host

### DIFF
--- a/docs/operator_configuration.md
+++ b/docs/operator_configuration.md
@@ -98,6 +98,9 @@ chConfigUserDefaultNetworksIP:
   - "::/0"
 chConfigUserDefaultPassword: "default"
 
+## Default env variable used to populate inter server http host
+chConfigInterServerHttpHost: "pod_ip"
+
 ################################################
 ##
 ## Operator's access to ClickHouse instances

--- a/pkg/apis/clickhouse.altinity.com/v1/type_config.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_config.go
@@ -437,6 +437,7 @@ func (config *OperatorConfig) String(hideCredentials bool) string {
 	}
 	util.Fprintf(b, "CHConfigUserDefaultPassword: %s\n", password)
 	util.Fprintf(b, "CHConfigNetworksHostRegexpTemplate: %s\n", config.CHConfigNetworksHostRegexpTemplate)
+	util.Fprintf(b, "CHConfigInterServerHttpHost: %s\n", config.CHConfigInterServerHttpHost)
 
 	username = config.CHUsername
 	password = config.CHPassword

--- a/pkg/apis/clickhouse.altinity.com/v1/types.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/types.go
@@ -437,6 +437,9 @@ type OperatorConfig struct {
 	CHConfigUserDefaultNetworksIP []string `json:"chConfigUserDefaultNetworksIP" yaml:"chConfigUserDefaultNetworksIP"`
 	CHConfigUserDefaultPassword   string   `json:"chConfigUserDefaultPassword"   yaml:"chConfigUserDefaultPassword"`
 
+	// Default env variable used to populate inter server http host
+	CHConfigInterServerHttpHost string `json:"chConfigInterServerHttpHost"   yaml:"chConfigInterServerHttpHost"`
+
 	CHConfigNetworksHostRegexpTemplate string `json:"chConfigNetworksHostRegexpTemplate" yaml:"chConfigNetworksHostRegexpTemplate"`
 	// Username and Password to be used by operator to connect to ClickHouse instances for
 	// 1. Metrics requests

--- a/pkg/model/ch_config.go
+++ b/pkg/model/ch_config.go
@@ -254,6 +254,21 @@ func (c *ClickHouseConfigGenerator) GetRemoteServers() string {
 	return b.String()
 }
 
+// GetInterServer creates "inter_server.xml" content
+func (c *ClickHouseConfigGenerator) GetInterServer(interserver string) string {
+	b := &bytes.Buffer{}
+
+	// <yandex>
+	//		<interserver_http_host from_env="INTERSERVER_HOST"/>
+	cline(b, 0, "<"+xmlTagYandex+">")
+	cline(b, 4, "<interserver_http_host from_env=\"%s\" />", interserver)
+
+	// </yandex>
+	cline(b, 0, "</"+xmlTagYandex+">")
+
+	return b.String()
+}
+
 // GetHostMacros creates "macros.xml" content
 func (c *ClickHouseConfigGenerator) GetHostMacros(host *chiv1.ChiHost) string {
 	b := &bytes.Buffer{}

--- a/pkg/model/ch_config_sections.go
+++ b/pkg/model/ch_config_sections.go
@@ -46,6 +46,9 @@ func (c *configSections) CreateConfigsCommon() {
 	// 2. settings
 	// 3. files
 	util.IncludeNonEmpty(c.commonConfigSections, filenameRemoteServersXML, c.chConfigGenerator.GetRemoteServers())
+	if len(c.chopConfig.CHConfigInterServerHttpHost) > 0 {
+		util.IncludeNonEmpty(c.commonConfigSections, filenameInterServerXML, c.chConfigGenerator.GetInterServer(c.chopConfig.CHConfigInterServerHttpHost))
+	}
 	util.IncludeNonEmpty(c.commonConfigSections, filenameSettingsXML, c.chConfigGenerator.GetSettings())
 	util.MergeStringMaps(c.commonConfigSections, c.chConfigGenerator.GetFiles())
 	// Extra user-specified config files

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -24,6 +24,7 @@ const (
 	configProfiles      = "profiles"
 	configQuotas        = "quotas"
 	configRemoteServers = "remote_servers"
+	configInterServer   = "interserver_http_host"
 	configSettings      = "settings"
 	configUsers         = "users"
 	configZookeeper     = "zookeeper"
@@ -45,6 +46,8 @@ const (
 	filenameQuotasXML = configQuotas + dotXML
 	// remote_servers.xml
 	filenameRemoteServersXML = configRemoteServers + dotXML
+	// inter_server.xml
+	filenameInterServerXML = configInterServer + dotXML
 	// settings.xml
 	filenameSettingsXML = configSettings + dotXML
 	// users.xml


### PR DESCRIPTION
Sometime FQDN is not reliable and rely on external DNS service reliability, we might need to expose IP used by other servers to access this sever.

Signed-off-by: xiancli <xiancli@ebay.com>