### PR TITLE
examples: Fix replicas service template 

### DIFF
--- a/docs/chi-examples/99-clickhouseinstallation-max.yaml
+++ b/docs/chi-examples/99-clickhouseinstallation-max.yaml
@@ -260,7 +260,7 @@ spec:
             - name: interserver
               port: 9009
           type: ClusterIP
-          ClusterIP: None
+          clusterIP: None
 
       - name: preserve-client-source-ip
         # For more details on Preserving Client Source IP check


### PR DESCRIPTION
This typo leads to fail due to replicas dns resolution:

> Poco::Exception. Code: 1000, e.code() = 0, e.displayText() = Host not found: chi-clickhouse-analytics-0-1-0.chi-clickhouse-analytics-0-1.clickhouse.svc.cluster.local (version 20.3.7.46 (official build))

Copied and spent many hours unsuccessfully trying to fix replication.