### PR TITLE
fix RBAC ClusterRoleBinding name pattern to allow install multiple clickhouse-operator instances in different namespaces

### DIFF
--- a/deploy/dev/clickhouse-operator-install-dev.yaml
+++ b/deploy/dev/clickhouse-operator-install-dev.yaml
@@ -1376,7 +1376,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: clickhouse-operator
+  name: clickhouse-operator-dev
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -1575,13 +1575,22 @@ data:
 
   03-clickhouse-querylog.xml: |
     <yandex>
-    <query_log>
+    <query_log replace="1">
         <database>system</database>
         <table>query_log</table>
-        <partition_by>toMonday(event_date)</partition_by>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>
     <query_thread_log remove="1"/>
+    </yandex>
+  04-clickhouse-partlog.xml: |
+    <yandex>
+    <part_log replace="1">
+        <database>system</database>
+        <table>part_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </part_log>
     </yandex>
 ---
 # Possible Template Parameters:
@@ -1714,6 +1723,7 @@ data:
         <profiles>
             <clickhouse_operator>
                 <log_queries>0</log_queries>
+                <skip_unavailable_shards>1</skip_unavailable_shards>
             </clickhouse_operator>
         </profiles>
     </yandex>

--- a/deploy/dev/clickhouse-operator-install-yaml-template-02-section-rbac.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-02-section-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: clickhouse-operator
+  name: clickhouse-operator-${OPERATOR_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/operator/clickhouse-operator-install-deployment.yaml
+++ b/deploy/operator/clickhouse-operator-install-deployment.yaml
@@ -184,13 +184,22 @@ data:
 
   03-clickhouse-querylog.xml: |
     <yandex>
-    <query_log>
+    <query_log replace="1">
         <database>system</database>
         <table>query_log</table>
-        <partition_by>toMonday(event_date)</partition_by>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>
     <query_thread_log remove="1"/>
+    </yandex>
+  04-clickhouse-partlog.xml: |
+    <yandex>
+    <part_log replace="1">
+        <database>system</database>
+        <table>part_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </part_log>
     </yandex>
 ---
 # Possible Template Parameters:
@@ -321,6 +330,7 @@ data:
         <profiles>
             <clickhouse_operator>
                 <log_queries>0</log_queries>
+                <skip_unavailable_shards>1</skip_unavailable_shards>
             </clickhouse_operator>
         </profiles>
     </yandex>

--- a/deploy/operator/clickhouse-operator-install-template-deployment.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-deployment.yaml
@@ -187,13 +187,22 @@ data:
 
   03-clickhouse-querylog.xml: |
     <yandex>
-    <query_log>
+    <query_log replace="1">
         <database>system</database>
         <table>query_log</table>
-        <partition_by>toMonday(event_date)</partition_by>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>
     <query_thread_log remove="1"/>
+    </yandex>
+  04-clickhouse-partlog.xml: |
+    <yandex>
+    <part_log replace="1">
+        <database>system</database>
+        <table>part_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </part_log>
     </yandex>
 ---
 # Possible Template Parameters:
@@ -326,6 +335,7 @@ data:
         <profiles>
             <clickhouse_operator>
                 <log_queries>0</log_queries>
+                <skip_unavailable_shards>1</skip_unavailable_shards>
             </clickhouse_operator>
         </profiles>
     </yandex>

--- a/deploy/operator/clickhouse-operator-install-template-rbac.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: clickhouse-operator
+  name: clickhouse-operator-$OPERATOR_NAMESPACE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -1376,7 +1376,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: clickhouse-operator
+  name: clickhouse-operator-$OPERATOR_NAMESPACE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -1575,13 +1575,22 @@ data:
 
   03-clickhouse-querylog.xml: |
     <yandex>
-    <query_log>
+    <query_log replace="1">
         <database>system</database>
         <table>query_log</table>
-        <partition_by>toMonday(event_date)</partition_by>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>
     <query_thread_log remove="1"/>
+    </yandex>
+  04-clickhouse-partlog.xml: |
+    <yandex>
+    <part_log replace="1">
+        <database>system</database>
+        <table>part_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </part_log>
     </yandex>
 ---
 # Possible Template Parameters:
@@ -1714,6 +1723,7 @@ data:
         <profiles>
             <clickhouse_operator>
                 <log_queries>0</log_queries>
+                <skip_unavailable_shards>1</skip_unavailable_shards>
             </clickhouse_operator>
         </profiles>
     </yandex>

--- a/deploy/operator/clickhouse-operator-install.yaml
+++ b/deploy/operator/clickhouse-operator-install.yaml
@@ -1376,7 +1376,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: clickhouse-operator
+  name: clickhouse-operator-kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -1575,13 +1575,22 @@ data:
 
   03-clickhouse-querylog.xml: |
     <yandex>
-    <query_log>
+    <query_log replace="1">
         <database>system</database>
         <table>query_log</table>
-        <partition_by>toMonday(event_date)</partition_by>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </query_log>
     <query_thread_log remove="1"/>
+    </yandex>
+  04-clickhouse-partlog.xml: |
+    <yandex>
+    <part_log replace="1">
+        <database>system</database>
+        <table>part_log</table>
+        <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    </part_log>
     </yandex>
 ---
 # Possible Template Parameters:
@@ -1714,6 +1723,7 @@ data:
         <profiles>
             <clickhouse_operator>
                 <log_queries>0</log_queries>
+                <skip_unavailable_shards>1</skip_unavailable_shards>
             </clickhouse_operator>
         </profiles>
     </yandex>

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,10 +10,9 @@ def get_ch_version(test_file):
 kubectlcmd="kubectl"
 test_namespace = "test"
 
-operator_version = open(os.path.join(pathlib.Path(__file__).parent.absolute(),"../release")).read(1024)
+operator_version = open(os.path.join(pathlib.Path(__file__).parent.absolute(), "../release")).read(1024)
 # operator_version = "0.11.0"
 operator_namespace = os.getenv('OPERATOR_NAMESPACE') if 'OPERATOR_NAMESPACE' in os.environ else 'kube-system'
-operator_namespace = test_namespace
 
 clickhouse_template = "templates/tpl-clickhouse-stable.yaml"
 # clickhouse_template = "templates/tpl-clickhouse-19.11.yaml"

--- a/tests/test.py
+++ b/tests/test.py
@@ -59,7 +59,7 @@ if main():
             
             # placeholder for selective test running
             # run_tests = [(test_009, {"version_from": "0.9.9"})]
-            run_tests = [test_002]
+            # run_tests = [test_002]
 
             for t in run_tests:
                 if callable(t):

--- a/tests/test_metrics_exporter.py
+++ b/tests/test_metrics_exporter.py
@@ -28,7 +28,7 @@ def test_metrics_exporter_reboot():
         with And(f"metrics-exporter /chi enpoint result should return {expect_result}"):
             for i in range(1, max_retries):
                 out = kubectl.kubectl(
-                    f"exec {operator_pod} -c metrics-exporter wget -- -O- -q http://127.0.0.1:8888/chi",
+                    f"exec {operator_pod} -c metrics-exporter -- wget -O- -q http://127.0.0.1:8888/chi",
                     ns=operator_namespace
                 )
                 out = json.loads(out)
@@ -75,7 +75,7 @@ def test_metrics_exporter_with_multiple_clickhouse_version():
         with And(f"metrics-exporter /metrics enpoint result should match with {expect_result}"):
             for i in range(1, max_retries):
                 out = kubectl.kubectl(
-                    f"exec {operator_pod} -c metrics-exporter wget -- -O- -q http://127.0.0.1:8888/metrics",
+                    f"exec {operator_pod} -c metrics-exporter -- wget -O- -q http://127.0.0.1:8888/metrics",
                     ns=operator_namespace
                 )
                 all_strings_expected_done = True


### PR DESCRIPTION
allow run multiple operator instances in different namespaces via change `ClusterRoleBindig.metadata.name` pattern

fix `test_metrics_exporter.py` for compatible with `kubectl` v1.18
fix `test.py` which run only `test_002` instead of run `all_tests`
current failed test_013, test_015, test_016

Signed-off-by: Eugene Klimov <eklimov@altinity.com>