### PR TITLE
Add proper timeout support to metrics and connection

### DIFF
--- a/pkg/apis/metrics/clickhouse_fetcher.go
+++ b/pkg/apis/metrics/clickhouse_fetcher.go
@@ -24,10 +24,6 @@ import (
 )
 
 const (
-	defaultTimeout = 10 * time.Second
-)
-
-const (
 	querySystemReplicasSQL = `
 		SELECT
 			database,
@@ -135,6 +131,10 @@ func NewClickHouseFetcher(hostname, username, password string, port int) *ClickH
 	return &ClickHouseFetcher{
 		chConnectionParams: clickhouse.NewCHConnectionParams(hostname, username, password, port),
 	}
+}
+
+func (f *ClickHouseFetcher) SetTimeout(timeout time.Duration) {
+	f.chConnectionParams.SetTimeout(timeout)
 }
 
 func (f *ClickHouseFetcher) getCHConnection() *clickhouse.CHConnection {

--- a/pkg/apis/metrics/type_ch_access_info.go
+++ b/pkg/apis/metrics/type_ch_access_info.go
@@ -14,10 +14,14 @@
 
 package metrics
 
+import "time"
+
 type CHAccessInfo struct {
 	Username string
 	Password string
 	Port     int
+
+	Timeout time.Duration
 }
 
 func NewCHAccessInfo(username, password string, port int) *CHAccessInfo {

--- a/pkg/model/clickhouse/connection.go
+++ b/pkg/model/clickhouse/connection.go
@@ -46,7 +46,7 @@ func (c *CHConnection) connect() {
 	}
 
 	// Ping should be deadlined
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(defaultTimeout))
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(c.params.timeout))
 	defer cancel()
 
 	if err := dbConnection.PingContext(ctx); err != nil {
@@ -75,7 +75,7 @@ func (c *CHConnection) Query(sql string) (*Query, error) {
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(defaultTimeout))
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(c.params.timeout))
 
 	if !c.ensureConnected() {
 		cancel()
@@ -103,7 +103,7 @@ func (c *CHConnection) Exec(sql string) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(defaultTimeout))
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(c.params.timeout))
 	defer cancel()
 
 	if !c.ensureConnected() {

--- a/pkg/model/clickhouse/connection_params.go
+++ b/pkg/model/clickhouse/connection_params.go
@@ -64,6 +64,10 @@ func NewCHConnectionParams(hostname, username, password string, port int) *CHCon
 	return params
 }
 
+func (c *CHConnectionParams) SetTimeout(timeout time.Duration) {
+	c.timeout = timeout
+}
+
 // makeUsernamePassword makes "username:password" pair for connection
 func (c *CHConnectionParams) makeUsernamePassword(hidden bool) string {
 


### PR DESCRIPTION
`metrics.defaultTimeout` was defined but not used. `CHConnectionParams` has a `timeout` property which was unused.