### PR TITLE
add ClickHouseTooMuchMutations alert and DO_NOT_CHOWN=1 example

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure(2) do |config|
 
     # docker
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8D81803C0EBFCD88
-    add-apt-repository "deb https://download.docker.com/linux/ubuntu focal testing"
+    add-apt-repository "deb https://download.docker.com/linux/ubuntu focal test"
     apt-get install --no-install-recommends -y docker-ce pigz
 
     # docker compose

--- a/deploy/prometheus/prometheus-alert-rules.yaml
+++ b/deploy/prometheus/prometheus-alert-rules.yaml
@@ -470,7 +470,7 @@ spec:
             description: |-
               `chi_clickhouse_table_mutations` = {{ with printf "chi_clickhouse_table_mutations{hostname='%s',exported_namespace='%s',database='%s',table='%s'}" .Labels.hostname .Labels.exported_namespace .Labels.database .Labels.table | query }}{{ . | first | value | printf "%.0f" }}{{ end }}
               `chi_clickhouse_table_mutations_parts_to_do` = {{ with printf "chi_clickhouse_table_mutations_parts_to_do{hostname='%s',exported_namespace='%s',database='%s',table='%s'}" .Labels.hostname .Labels.exported_namespace .Labels.database .Labels.table | query }}{{ . | first | value | printf "%.0f" }}{{ end }}
-              `system.mutations` show too much incomplete mutation.
+              `system.mutations` show too much active mutations.
               It mean something wrong with ALTER TABLE DELETE/UPDATE queries.
               Please check mutations errors ```kubectl exec -n {{ $labels.exported_namespace }} pod/$(kubectl get pods -n {{ $labels.exported_namespace }} | grep $( echo {{ $labels.hostname }} | cut -d '.' -f 1) | cut -d " " -f 1) -- clickhouse-client -q "SELECT * FROM system.mutations WHERE is_done=0 FORMAT Vertical"```
               Read about how to run KILL MUTATION

--- a/deploy/prometheus/prometheus-alert-rules.yaml
+++ b/deploy/prometheus/prometheus-alert-rules.yaml
@@ -460,6 +460,22 @@ spec:
               System will reduce the number of threads which used for processing queries.
               Check you disks utilization and hardware failures.
 
+        - alert: ClickHouseTooMuchMutations
+          expr: chi_clickhouse_table_mutations > 100
+          labels:
+            severity: high
+          annotations:
+            identifier: "{{ $labels.hostname }}"
+            summary: "Too much incomplete system.mutations"
+            description: |-
+              `chi_clickhouse_table_mutations` = {{ with printf "chi_clickhouse_table_mutations{hostname='%s',exported_namespace='%s',database='%s',table='%s'}" .Labels.hostname .Labels.exported_namespace .Labels.database .Labels.table | query }}{{ . | first | value | printf "%.0f" }}{{ end }}
+              `chi_clickhouse_table_mutations_parts_to_do` = {{ with printf "chi_clickhouse_table_mutations_parts_to_do{hostname='%s',exported_namespace='%s',database='%s',table='%s'}" .Labels.hostname .Labels.exported_namespace .Labels.database .Labels.table | query }}{{ . | first | value | printf "%.0f" }}{{ end }}
+              `system.mutations` show too much incomplete mutation.
+              It mean something wrong with ALTER TABLE DELETE/UPDATE queries.
+              Please check mutations errors ```kubectl exec -n {{ $labels.exported_namespace }} pod/$(kubectl get pods -n {{ $labels.exported_namespace }} | grep $( echo {{ $labels.hostname }} | cut -d '.' -f 1) | cut -d " " -f 1) -- clickhouse-client -q "SELECT * FROM system.mutations WHERE is_done=0 FORMAT Vertical"```
+              Read about how to run KILL MUTATION
+              https://clickhouse.tech/docs/en/sql-reference/statements/kill/#kill-mutation
+
     # based on https://blog.serverdensity.com/how-to-monitor-zookeeper/
     # and https://github.com/apache/zookeeper/blob/master/zookeeper-contrib/zookeeper-contrib-monitoring/nagios/services.cfg
     - name: ZookeeperRules

--- a/docs/chi-examples/03-persistent-volume-07-do-not-chown.yaml
+++ b/docs/chi-examples/03-persistent-volume-07-do-not-chown.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseInstallation"
+metadata:
+  name: "pv-do-not-chown"
+spec:
+  configuration:
+    clusters:
+      - name: "pv-do-not-chown"
+        templates:
+          podTemplate: pod-template-with-volumes-do-not-chown
+        layout:
+          shardsCount: 1
+          replicasCount: 1
+
+  templates:
+    podTemplates:
+      - name: pod-template-with-volumes-do-not-chown
+        spec:
+          securityContext:
+            runAsUser: 101
+            runAsGroup: 101
+            fsGroup: 101
+          containers:
+            - name: clickhouse
+              image: yandex/clickhouse-server:latest
+              volumeMounts:
+                - name: data-storage-vc-template-1
+                  mountPath: /var/lib/clickhouse
+#              command:
+#                - /bin/bash
+#                - -c
+#                - chown clickhouse /var/lib/clickhouse && /entrypoint.sh
+              env:
+                - name: CLICKHOUSE_DO_NOT_CHOWN
+                  value: "1"
+
+    volumeClaimTemplates:
+      - name: data-storage-vc-template-1
+        spec:
+          storageClassName: standard
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
+++ b/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
@@ -3332,7 +3332,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Number of mutations (ALTER DELETE/ALTER UPDATE) which not complete and how much parts should be mutate",
+      "description": "Number of active mutations (ALTER DELETE/ALTER UPDATE) and how much parts should be mutate",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
+++ b/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
@@ -3332,7 +3332,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Number of active mutations (ALTER DELETE/ALTER UPDATE) and how much parts should be mutate",
+      "description": "Number of active mutations (ALTER DELETE/ALTER UPDATE) and parts to mutate",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
+++ b/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
@@ -3231,12 +3231,12 @@
         {
           "targetBlank": true,
           "title": "FETCH PARTITION",
-          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/#alter_fetch-partition"
+          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/partition/#alter_fetch-partition"
         },
         {
           "targetBlank": true,
           "title": "Mutations of data",
-          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/#alter-mutations"
+          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/#mutations"
         },
         {
           "targetBlank": true,
@@ -3246,7 +3246,7 @@
         {
           "targetBlank": true,
           "title": "MOVE PARTITION",
-          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/#alter_move-partition"
+          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/partition/#alter_move-partition"
         }
       ],
       "nullPointMode": "null",
@@ -3332,7 +3332,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Number of mutations (ALTER DELETE/ALTER UPDATE)",
+      "description": "Number of mutations (ALTER DELETE/ALTER UPDATE) which not complete and how much parts should be mutate",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3358,7 +3358,17 @@
         {
           "targetBlank": true,
           "title": "Mutations",
-          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/#alter-mutations"
+          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/alter/#mutations"
+        },
+        {
+          "targetBlank": true,
+          "title": "system.mutations",
+          "url": "https://clickhouse.tech/docs/en/operations/system-tables/mutations/"
+        },
+        {
+          "targetBlank": true,
+          "title": "KILL MUTATION",
+          "url": "https://clickhouse.tech/docs/en/sql-reference/statements/kill/#kill-mutation"
         }
       ],
       "nullPointMode": "null",
@@ -3375,9 +3385,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "chi_clickhouse_metric_PartMutation{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}",
-          "legendFormat": "{{hostname}}",
+          "expr": "chi_clickhouse_table_mutations{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}",
+          "legendFormat": "mutations {{database}} {{table}} {{hostname}}",
           "refId": "A"
+        },
+        {
+          "expr": "chi_clickhouse_table_mutations_parts_to_do{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}",
+          "legendFormat": "parts_to_do {{database}} {{table}} {{hostname}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],

--- a/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
+++ b/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
@@ -3385,13 +3385,13 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "chi_clickhouse_table_mutations{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}",
-          "legendFormat": "mutations {{database}} {{table}} {{hostname}}",
+          "expr": "sum by (hostname) (chi_clickhouse_table_mutations{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"})",
+          "legendFormat": "mutations {{hostname}}",
           "refId": "A"
         },
         {
-          "expr": "chi_clickhouse_table_mutations_parts_to_do{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}",
-          "legendFormat": "parts_to_do {{database}} {{table}} {{hostname}}",
+          "expr": "sum by (hostname) (chi_clickhouse_table_mutations_parts_to_do{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"})",
+          "legendFormat": "parts_to_do {{hostname}}",
           "refId": "B"
         }
       ],

--- a/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
+++ b/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
@@ -3371,7 +3371,7 @@
           "url": "https://clickhouse.tech/docs/en/sql-reference/statements/kill/#kill-mutation"
         }
       ],
-      "nullPointMode": "null",
+      "nullPointMode": "null as zero",
       "options": {
         "dataLinks": []
       },
@@ -3382,7 +3382,7 @@
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
-      "steppedLine": false,
+      "steppedLine": true,
       "targets": [
         {
           "expr": "chi_clickhouse_table_mutations{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}",


### PR DESCRIPTION
- add ClickHouseTooMuchMutations alert
- add chi_clickhouse_table_mutations chi_clickhouse_table_mutations_parts_to_do metrics to Grafana Dashboard
- add securityContext example without chown -R with clickhouse-server:latest image

Signed-off-by: Eugene Klimov <eklimov@altinity.com>