### PR TITLE
Optimization of pod batch restart in cluster upgrade

### DIFF
--- a/pkg/controller/chi/creator.go
+++ b/pkg/controller/chi/creator.go
@@ -50,12 +50,18 @@ func (c *Controller) createStatefulSet(statefulSet *apps.StatefulSet, host *chop
 // updateStatefulSet is an internal function, used in reconcileStatefulSet only
 func (c *Controller) updateStatefulSet(oldStatefulSet *apps.StatefulSet, newStatefulSet *apps.StatefulSet, host *chop.ChiHost) error {
 	log.V(2).M(host).F().P()
-	// update labels
-	diffLabelsBytes := DiffLabels(oldStatefulSet, newStatefulSet)
+
+	// diff labels
+	diffLabelsBytes, err := DiffLabels(oldStatefulSet, newStatefulSet)
+	if err != nil {
+		log.V(1).M(host).A().Error("%v", err)
+		return err
+	}
+	// Patch labels
 	updatedStatefulSet, err := c.kubeClient.AppsV1().StatefulSets(newStatefulSet.Namespace).
 		Patch(oldStatefulSet.GetName(), types.JSONPatchType, diffLabelsBytes)
 	if err == nil {
-		log.V(1).M(host).F().Info("labels change")
+		log.V(2).M(host).F().Info("labels changed")
 	} else {
 		log.V(1).M(host).A().Error("%v", err)
 		return err

--- a/pkg/controller/chi/types.go
+++ b/pkg/controller/chi/types.go
@@ -92,6 +92,14 @@ const (
 	reconcileDelete = "delete"
 )
 
+const (
+	labelAdd = "add"
+	labelReplace = "replace"
+	labelRemove = "remove"
+)
+
+const labelPath = "/metadata/labels/"
+
 type ReconcileChi struct {
 	cmd string
 	old *chi.ClickHouseInstallation

--- a/pkg/controller/chi/worker.go
+++ b/pkg/controller/chi/worker.go
@@ -253,7 +253,7 @@ func (w *worker) updateCHI(old, new *chop.ClickHouseInstallation) error {
 		WithStatusAction(new).
 		M(new).F().
 		Info("reconcile started")
-	w.a.V(2).M(new).F().Info("action plan\n%s\n", actionPlan.String())
+	//w.a.V(2).M(new).F().Info("action plan\n%s\n", actionPlan.String())
 
 	if new.IsStopped() {
 		w.a.V(1).


### PR DESCRIPTION
Optimize the statefulset update, patching labels first will not trigger forbidden error when updating statefulset.
codes will not enter the subsequent process of deleting and reconstructing statefulset.
Pods are no longer restarted when new shards/replicas are added, modified and deleted.
