### PR TITLE
Support label exclusions

### DIFF
--- a/deploy/dev/clickhouse-operator-install-dev.yaml
+++ b/deploy/dev/clickhouse-operator-install-dev.yaml
@@ -1556,6 +1556,10 @@ spec:
               type: string
             reconcileWaitInclude:
               type: string
+            labelsIgnore:
+              type: array
+              items:
+                type: string
 ---
 # Possible Template Parameters:
 #

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
@@ -94,3 +94,7 @@ spec:
               type: string
             reconcileWaitInclude:
               type: string
+            labelsIgnore:
+              type: array
+              items:
+                type: string

--- a/deploy/operator/clickhouse-operator-install-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-crd.yaml
@@ -1556,3 +1556,7 @@ spec:
               type: string
             reconcileWaitInclude:
               type: string
+            labelsIgnore:
+              type: array
+              items:
+                type: string

--- a/deploy/operator/clickhouse-operator-install-template-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-crd.yaml
@@ -1556,3 +1556,7 @@ spec:
               type: string
             reconcileWaitInclude:
               type: string
+            labelsIgnore:
+              type: array
+              items:
+                type: string

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -1556,6 +1556,10 @@ spec:
               type: string
             reconcileWaitInclude:
               type: string
+            labelsIgnore:
+              type: array
+              items:
+                type: string
 ---
 # Possible Template Parameters:
 #

--- a/deploy/operator/clickhouse-operator-install.yaml
+++ b/deploy/operator/clickhouse-operator-install.yaml
@@ -1556,6 +1556,10 @@ spec:
               type: string
             reconcileWaitInclude:
               type: string
+            labelsIgnore:
+              type: array
+              items:
+                type: string
 ---
 # Possible Template Parameters:
 #

--- a/pkg/apis/clickhouse.altinity.com/v1/type_config_chop.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_config_chop.go
@@ -152,6 +152,9 @@ type OperatorConfig struct {
 	ReconcileWaitExclude   bool `json:"reconcileWaitExclude"   yaml:"reconcileWaitExclude"`
 	ReconcileWaitInclude   bool `json:"reconcileWaitInclude"   yaml:"reconcileWaitInclude"`
 
+	// When transferring labels from the CRD, ignore these labels.
+	LabelsIgnore []string `json:"labelsIgnore" yaml:"labelsIgnore"`
+
 	//
 	// The end of OperatorConfig
 	//
@@ -571,6 +574,8 @@ func (config *OperatorConfig) String(hideCredentials bool) string {
 	util.Fprintf(b, "Log_backtrace_at string: %s\n", config.Log_backtrace_at)
 
 	util.Fprintf(b, "ReconcileThreadsNumber: %d\n", config.ReconcileThreadsNumber)
+
+	util.Fprintf(b, "%s", util.Slice2String("LabelsIgnore", config.LabelsIgnore))
 
 	return b.String()
 }

--- a/pkg/model/labeler.go
+++ b/pkg/model/labeler.go
@@ -297,7 +297,8 @@ func (l *Labeler) GetSelectorHostScope(host *chi.ChiHost) map[string]string {
 
 // appendCHILabels appends CHI-provided labels to labels set
 func (l *Labeler) appendCHILabels(dst map[string]string) map[string]string {
-	return util.MergeStringMapsOverwrite(dst, l.chi.Labels)
+	sourceLabels := util.CopyMapExcept(l.chi.Labels, l.chop.Config().LabelsIgnore...)
+	return util.MergeStringMapsOverwrite(dst, sourceLabels)
 }
 
 // appendReadyLabels appends "Ready" label to labels set

--- a/pkg/util/map.go
+++ b/pkg/util/map.go
@@ -32,6 +32,27 @@ func IncludeNonEmpty(dst map[string]string, key, src string) {
 	return
 }
 
+// CopyMap creates a copy of the given map by copying over key by key.
+// It doesn't perform a deep-copy.
+func CopyMap(src map[string]string) map[string]string {
+	result := make(map[string]string, len(src))
+	for k, v := range src {
+		result[k] = v
+	}
+	return result
+}
+
+// CopyMapExcept creates a copy of the given map but will exclude the given set of keys.
+func CopyMapExcept(src map[string]string, exceptKeys ...string) map[string]string {
+	result := CopyMap(src)
+
+	for _, k := range exceptKeys {
+		delete(result, k)
+	}
+
+	return result
+}
+
 // MergeStringMapsOverwrite inserts (and overwrites) data into dst map object from src
 func MergeStringMapsOverwrite(dst, src map[string]string, keys ...string) map[string]string {
 	if len(src) == 0 {


### PR DESCRIPTION
As mentioned in issue #487, CD systems like Flux or Argo tend to put labels on resources they manage. If those labels get propagated, weird stuff can start happening.

This PR introduces a new config settings `labelsIgnore` which will filter those labels before propagating them.