### PR TITLE
Default watch all Namespaces

### DIFF
--- a/pkg/apis/clickhouse.altinity.com/v1/type_config_chop.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_config_chop.go
@@ -474,14 +474,8 @@ func (config *OperatorConfig) applyDefaultWatchNamespace() {
 	}
 
 	// No namespaces specified
-
-	namespace := os.Getenv(OPERATOR_POD_NAMESPACE)
-	if namespace == "kube-system" {
-		// Do nothing, we already have len(config.WatchNamespaces) == 0
-	} else {
-		// We have WATCH_NAMESPACE specified
-		config.WatchNamespaces = []string{namespace}
-	}
+	// Default watch all namespace
+	// Do nothing, we already have len(config.WatchNamespaces) == 0
 }
 
 // readClickHouseCustomConfigFiles reads all extra user-specified ClickHouse config files


### PR DESCRIPTION
If config.WatchNamespaces is empty we should watch all Namseapces in the k8s.
https://github.com/Altinity/clickhouse-operator/issues/686
