### PR TITLE
Update clickhouse-operator-install.sh

### DIFF
--- a/deploy/operator-web-installer/clickhouse-operator-install.sh
+++ b/deploy/operator-web-installer/clickhouse-operator-install.sh
@@ -81,7 +81,7 @@ function get_file() {
 #
 
 # Namespace to install operator
-OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kube-system}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-clickhouse-operator}"
 METRICS_EXPORTER_NAMESPACE="${OPERATOR_NAMESPACE}"
 
 # Operator's docker image


### PR DESCRIPTION
Documentation states the default installation namespace is `clickhouse-operator`, not `kube-system`.

It is also `clickhouse-operator` in the deletion script, so this just makes them match.

I think this counts as "supplementary material", so PR is against master. Feel free to change if necessary.