### PR TITLE
separate `ClickHouseMetricsExporterFetchErrors` from `ClickHouseServerDown` and remove "fail fast" strategy from metrics-exporter

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,9 +126,9 @@ Vagrant.configure(2) do |config|
 
     # k9s CLI
     K9S_VERSION=$(curl -sL https://github.com/derailed/k9s/releases/latest -H "Accept: application/json" | jq -r .tag_name)
-    wget -c --progress=bar:force:noscroll -O /usr/local/bin/k9s_${K9S_VERSION}_Linux_x86_64.tar.gz https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_${K9S_VERSION}_Linux_x86_64.tar.gz
+    wget -c --progress=bar:force:noscroll -O /usr/local/bin/k9s_${K9S_VERSION}_Linux_x86_64.tar.gz https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_x86_64.tar.gz
     curl -sL https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/checksums.txt | grep Linux_x86_64.tar.gz > /usr/local/bin/k9s.sha256
-    sed -i -e "s/k9s_${K9S_VERSION}_Linux_x86_64\.tar\.gz/\\/usr\\/local\\/bin\\/k9s_${K9S_VERSION}_Linux_x86_64\\.tar\\.gz/g" /usr/local/bin/k9s.sha256
+    sed -i -e "s/k9s_Linux_x86_64\.tar\.gz/\\/usr\\/local\\/bin\\/k9s_${K9S_VERSION}_Linux_x86_64\\.tar\\.gz/g" /usr/local/bin/k9s.sha256
     sha256sum -c /usr/local/bin/k9s.sha256
     tar --verbose -zxvf /usr/local/bin/k9s_${K9S_VERSION}_Linux_x86_64.tar.gz -C /usr/local/bin k9s
 

--- a/deploy/prometheus/prometheus-alert-rules-clickhouse.yaml
+++ b/deploy/prometheus/prometheus-alert-rules-clickhouse.yaml
@@ -22,7 +22,7 @@ spec:
               Please check instance status
               ```kubectl logs -n {{ $labels.namespace }} {{ $labels.pod_name }} -c metrics-exporter -f```
 
-        - alert: ClickHouseServerDown
+        - alert: ClickHouseServerPossibleDown
           expr: chi_clickhouse_metric_fetch_errors > 0
           labels:
             severity: critical

--- a/deploy/prometheus/prometheus-alert-rules-clickhouse.yaml
+++ b/deploy/prometheus/prometheus-alert-rules-clickhouse.yaml
@@ -22,10 +22,22 @@ spec:
               Please check instance status
               ```kubectl logs -n {{ $labels.namespace }} {{ $labels.pod_name }} -c metrics-exporter -f```
 
-        - alert: ClickHouseServerPossibleDown
-          expr: chi_clickhouse_metric_fetch_errors > 0
+        - alert: ClickHouseServerDown
+          expr: chi_clickhouse_metric_fetch_errors{fetch_type='system.metrics'} > 0
           labels:
             severity: critical
+          annotations:
+            identifier: "{{ $labels.hostname }}"
+            summary: "clickhouse-server possible down"
+            description: |-
+              `metrics-exporter` failed metrics fetch `{{ $labels.fetch_type }}`.
+              Please check instance status
+              ```kubectl get pods -n {{ $labels.exported_namespace }} | grep $( echo {{ $labels.hostname }} | cut -d '.' -f 1)```
+
+        - alert: ClickHouseMetricsExporterFetchErrors
+          expr: chi_clickhouse_metric_fetch_errors{fetch_type!='system.metrics'} > 0
+          labels:
+            severity: high
           annotations:
             identifier: "{{ $labels.hostname }}"
             summary: "clickhouse-server possible down"

--- a/pkg/apis/metrics/exporter.go
+++ b/pkg/apis/metrics/exporter.go
@@ -194,8 +194,6 @@ func (e *Exporter) collectFromHost(chi *WatchedCHI, hostname string, c chan<- pr
 		// In case of an error fetching data from clickhouse store CHI name in e.cleanup
 		log.V(2).Infof("Error querying metrics for %s: %s\n", hostname, err)
 		writer.WriteErrorFetch("system.metrics")
-		//e.enqueueToRemoveFromWatched(chi)
-		return
 	}
 
 	log.V(2).Infof("Querying table sizes for %s\n", hostname)
@@ -207,8 +205,6 @@ func (e *Exporter) collectFromHost(chi *WatchedCHI, hostname string, c chan<- pr
 		// In case of an error fetching data from clickhouse store CHI name in e.cleanup
 		log.V(2).Infof("Error querying table sizes for %s: %s\n", hostname, err)
 		writer.WriteErrorFetch("table sizes")
-		// e.enqueueToRemoveFromWatched(chi)
-		return
 	}
 
 	log.V(2).Infof("Querying system replicas for %s\n", hostname)
@@ -220,8 +216,6 @@ func (e *Exporter) collectFromHost(chi *WatchedCHI, hostname string, c chan<- pr
 		// In case of an error fetching data from clickhouse store CHI name in e.cleanup
 		log.V(2).Infof("Error querying system replicas for %s: %s\n", hostname, err)
 		writer.WriteErrorFetch("system.replicas")
-		// e.enqueueToRemoveFromWatched(chi)
-		return
 	}
 
 	log.V(2).Infof("Querying mutations for %s\n", hostname)
@@ -233,8 +227,6 @@ func (e *Exporter) collectFromHost(chi *WatchedCHI, hostname string, c chan<- pr
 		// In case of an error fetching data from clickhouse store CHI name in e.cleanup
 		log.V(2).Infof("Error querying mutations for %s: %s\n", hostname, err)
 		writer.WriteErrorFetch("system.mutations")
-		//e.enqueueToRemoveFromWatched(chi)
-		return
 	}
 
 	log.V(2).Infof("Querying disks for %s\n", hostname)
@@ -246,8 +238,6 @@ func (e *Exporter) collectFromHost(chi *WatchedCHI, hostname string, c chan<- pr
 		// In case of an error fetching data from clickhouse store CHI name in e.cleanup
 		log.V(2).Infof("Error querying disks for %s: %s\n", hostname, err)
 		writer.WriteErrorFetch("system.disks")
-		//e.enqueueToRemoveFromWatched(chi)
-		return
 	}
 
 	log.V(2).Infof("Querying detached parts for %s\n", hostname)
@@ -259,8 +249,6 @@ func (e *Exporter) collectFromHost(chi *WatchedCHI, hostname string, c chan<- pr
 		// In case of an error fetching data from clickhouse store CHI name in e.cleanup
 		log.V(2).Infof("Error querying detached parts for %s: %s\n", hostname, err)
 		writer.WriteErrorFetch("system.detached_parts")
-		//e.enqueueToRemoveFromWatched(chi)
-		return
 	}
 }
 

--- a/tests/test_metrics_alerts.py
+++ b/tests/test_metrics_alerts.py
@@ -88,7 +88,7 @@ def test_metrics_exporter_down(self):
 
 
 @TestScenario
-@Name("test_clickhouse_server_reboot. Check ClickHouseServerPossibleDown, ClickHouseServerRestartRecently")
+@Name("test_clickhouse_server_reboot. Check ClickHouseServerDown, ClickHouseServerRestartRecently")
 def test_clickhouse_server_reboot(self):
     random_idx = random.randint(0, 1)
     clickhouse_pod = chi["status"]["pods"][random_idx]
@@ -102,21 +102,21 @@ def test_clickhouse_server_reboot(self):
 
     with When("reboot clickhouse-server pod"):
         fired = alerts.wait_alert_state(
-            "ClickHouseServerPossibleDown", "firing", True, callback=reboot_clickhouse_server,
+            "ClickHouseServerDown", "firing", True, callback=reboot_clickhouse_server,
             labels={"hostname": clickhouse_svc, "chi": chi["metadata"]["name"]},
             sleep_time=settings.prometheus_scrape_interval, time_range='30s', max_try=30,
         )
-        assert fired, error("can't get ClickHouseServerPossibleDown alert in firing state")
+        assert fired, error("can't get ClickHouseServerDown alert in firing state")
 
-    with Then("check ClickHouseServerPossibleDown gone away"):
-        resolved = alerts.wait_alert_state("ClickHouseServerPossibleDown", "firing", False, labels={"hostname": clickhouse_svc}, time_range='5s',
+    with Then("check ClickHouseServerDown gone away"):
+        resolved = alerts.wait_alert_state("ClickHouseServerDown", "firing", False, labels={"hostname": clickhouse_svc}, time_range='5s',
                                            sleep_time=settings.prometheus_scrape_interval, max_try=100)
-        assert resolved, error("can't check ClickHouseServerPossibleDown alert is gone away")
+        assert resolved, error("can't check ClickHouseServerDown alert is gone away")
 
     with Then("check ClickHouseServerRestartRecently firing and gone away"):
         fired = alerts.wait_alert_state("ClickHouseServerRestartRecently", "firing", True,
                                         labels={"hostname": clickhouse_svc, "chi": chi["metadata"]["name"]}, time_range="30s")
-        assert fired, error("after ClickHouseServerPossibleDown gone away, ClickHouseServerRestartRecently shall firing")
+        assert fired, error("after ClickHouseServerDown gone away, ClickHouseServerRestartRecently shall firing")
 
         resolved = alerts.wait_alert_state("ClickHouseServerRestartRecently", "firing", False, sleep_time=10,
                                            labels={"hostname": clickhouse_svc})


### PR DESCRIPTION
After discussion with @alex-zaitsev we decide a little bit  improve alerts and metrics-exporter

Signed-off-by: Slach <bloodjazman@gmail.com>