### PR TITLE
rollback zookeeper to 3.6.3 and setup standaloneEnabled=false and add server.X by default to zoo.cfg, rollback maxResponseCacheSize, maxGetChildrenResponseCacheSize to default, add test_zookeeper.py which allow test ZK scale-out/scale-down all tests 0.15.0 PASSED

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -139,7 +139,8 @@ Vagrant.configure(2) do |config|
     # minikube
     # MINIKUBE_VERSION=1.18.1
     # MINIKUBE_VERSION=1.19.0
-    MINIKUBE_VERSION=1.20.0
+    # MINIKUBE_VERSION=1.20.0
+    MINIKUBE_VERSION=1.22.0
     wget -c --progress=bar:force:noscroll -O /usr/local/bin/minikube https://github.com/kubernetes/minikube/releases/download/v${MINIKUBE_VERSION}/minikube-linux-amd64
     chmod +x /usr/local/bin/minikube
     # required for k8s 1.18+
@@ -149,13 +150,13 @@ Vagrant.configure(2) do |config|
 #    export VALIDATE_YAML=false # only for 1.14
 #    K8S_VERSION=${K8S_VERSION:-1.15.12}
 #    K8S_VERSION=${K8S_VERSION:-1.16.15}
-    K8S_VERSION=${K8S_VERSION:-1.17.17}
+#    K8S_VERSION=${K8S_VERSION:-1.17.17}
 #    K8S_VERSION=${K8S_VERSION:-1.18.19}
-#    K8S_VERSION=${K8S_VERSION:-1.19.11}
+#    K8S_VERSION=${K8S_VERSION:-1.19.12}
 #    performance issue 1.20.x, 1.21.x, only 1.22 will good to start
 # https://github.com/kubernetes/kubeadm/issues/2395
-#    K8S_VERSION=${K8S_VERSION:-1.20.7}
-#    K8S_VERSION=${K8S_VERSION:-1.21.1}
+#    K8S_VERSION=${K8S_VERSION:-1.20.8}
+    K8S_VERSION=${K8S_VERSION:-1.21.2}
     export VALIDATE_YAML=true
 
     killall kubectl || true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -274,8 +274,9 @@ EOF
 
     pip3 install -r /vagrant/tests/requirements.txt
 
-    python3 /vagrant/tests/test_backup_alerts.py
     python3 /vagrant/tests/test_metrics_alerts.py
+    python3 /vagrant/tests/test_zookeeper.py
+    python3 /vagrant/tests/test_backup_alerts.py
     python3 /vagrant/tests/test_examples.py
     python3 /vagrant/tests/test_metrics_exporter.py
     python3 /vagrant/tests/test.py

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -152,11 +152,11 @@ Vagrant.configure(2) do |config|
 #    K8S_VERSION=${K8S_VERSION:-1.16.15}
 #    K8S_VERSION=${K8S_VERSION:-1.17.17}
 #    K8S_VERSION=${K8S_VERSION:-1.18.19}
-#    K8S_VERSION=${K8S_VERSION:-1.19.12}
+#    K8S_VERSION=${K8S_VERSION:-1.19.13}
 #    performance issue 1.20.x, 1.21.x, only 1.22 will good to start
 # https://github.com/kubernetes/kubeadm/issues/2395
-#    K8S_VERSION=${K8S_VERSION:-1.20.8}
-    K8S_VERSION=${K8S_VERSION:-1.21.2}
+#    K8S_VERSION=${K8S_VERSION:-1.20.9}
+    K8S_VERSION=${K8S_VERSION:-1.21.3}
     export VALIDATE_YAML=true
 
     killall kubectl || true

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node.yaml
@@ -92,7 +92,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.7.0"
+          image: "docker.io/zookeeper:3.6.3"
           resources:
             requests:
               memory: "512M"
@@ -141,10 +141,8 @@ spec:
                 echo 'preAllocSize=131072'
                 echo 'snapCount=3000000'
                 echo 'leaderServes=yes'
-                echo 'standaloneEnabled=true'
+                echo 'standaloneEnabled=false'
                 echo '4lw.commands.whitelist=*'
-                echo 'maxResponseCacheSize=1200'
-                echo 'maxGetChildrenResponseCacheSize=1200'
                 echo 'metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider'
                 echo "metricsProvider.httpPort=${PROMETHEUS_PORT}"
               } > /conf/zoo.cfg &&
@@ -169,11 +167,9 @@ spec:
               mkdir -p ${ZOO_DATA_LOG_DIR} &&
               export MY_ID=$((ORD+1)) &&
               echo $MY_ID > $ZOO_DATA_DIR/myid &&
-              if [[ $SERVERS -gt 1 ]]; then
-                for (( i=1; i<=$SERVERS; i++ )); do
-                    echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
-                done
-              fi &&
+              for (( i=1; i<=$SERVERS; i++ )); do
+                  echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
+              done &&
               chown -Rv zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR" &&
               zkServer.sh start-foreground
           readinessProbe:
@@ -195,7 +191,6 @@ spec:
           volumeMounts:
             - name: datadir-volume
               mountPath: /var/lib/zookeeper
-
       # Run as a non-privileged user
       securityContext:
         runAsUser: 1000

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node.yaml
@@ -92,11 +92,14 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.6.1"
+          image: "docker.io/zookeeper:3.7.0"
           resources:
             requests:
-              memory: "4Gi"
+              memory: "512M"
               cpu: "1"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
           ports:
             - containerPort: 2181
               name: client
@@ -139,7 +142,9 @@ spec:
                 echo 'snapCount=3000000'
                 echo 'leaderServes=yes'
                 echo 'standaloneEnabled=true'
-                echo '4lw.commands.whitelist=stat, ruok, conf, isro, mntr'
+                echo '4lw.commands.whitelist=*'
+                echo 'maxResponseCacheSize=1200'
+                echo 'maxGetChildrenResponseCacheSize=1200'
                 echo 'metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider'
                 echo "metricsProvider.httpPort=${PROMETHEUS_PORT}"
               } > /conf/zoo.cfg &&
@@ -190,6 +195,7 @@ spec:
           volumeMounts:
             - name: datadir-volume
               mountPath: /var/lib/zookeeper
+
       # Run as a non-privileged user
       securityContext:
         runAsUser: 1000

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes-1GB-for-tests-only.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes-1GB-for-tests-only.yaml
@@ -64,7 +64,7 @@ spec:
     matchLabels:
       app: zookeeper
   serviceName: zookeepers
-  replicas: 1
+  replicas: 3
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
@@ -106,7 +106,7 @@ spec:
             - -x
             - -c
             - |
-              SERVERS=1 &&
+              SERVERS=3 &&
               HOST=`hostname -s` &&
               DOMAIN=`hostname -d` &&
               CLIENT_PORT=2181 &&

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes.yaml
@@ -90,11 +90,14 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.6.1"
+          image: "docker.io/zookeeper:3.7.0"
           resources:
             requests:
-              memory: "4Gi"
+              memory: "512M"
               cpu: "1"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
           ports:
             - containerPort: 2181
               name: client
@@ -136,8 +139,10 @@ spec:
                 echo 'preAllocSize=131072'
                 echo 'snapCount=3000000'
                 echo 'leaderServes=yes'
-                echo 'standaloneEnabled=true'
-                echo '4lw.commands.whitelist=stat, ruok, conf, isro, mntr'
+                echo 'standaloneEnabled=false'
+                echo '4lw.commands.whitelist=*'
+                echo 'maxResponseCacheSize=1200'
+                echo 'maxGetChildrenResponseCacheSize=1200'
                 echo 'metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider'
                 echo "metricsProvider.httpPort=${PROMETHEUS_PORT}"
               } > /conf/zoo.cfg &&
@@ -188,6 +193,7 @@ spec:
           volumeMounts:
             - name: datadir-volume
               mountPath: /var/lib/zookeeper
+
       # Run as a non-privileged user
       securityContext:
         runAsUser: 1000

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes.yaml
@@ -90,7 +90,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.7.0"
+          image: "docker.io/zookeeper:3.6.3"
           resources:
             requests:
               memory: "512M"
@@ -141,8 +141,6 @@ spec:
                 echo 'leaderServes=yes'
                 echo 'standaloneEnabled=false'
                 echo '4lw.commands.whitelist=*'
-                echo 'maxResponseCacheSize=1200'
-                echo 'maxGetChildrenResponseCacheSize=1200'
                 echo 'metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider'
                 echo "metricsProvider.httpPort=${PROMETHEUS_PORT}"
               } > /conf/zoo.cfg &&
@@ -167,11 +165,9 @@ spec:
               mkdir -p ${ZOO_DATA_LOG_DIR} &&
               export MY_ID=$((ORD+1)) &&
               echo $MY_ID > $ZOO_DATA_DIR/myid &&
-              if [[ $SERVERS -gt 1 ]]; then
-                for (( i=1; i<=$SERVERS; i++ )); do
-                    echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
-                done
-              fi &&
+              for (( i=1; i<=$SERVERS; i++ )); do
+                  echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
+              done &&
               chown -Rv zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR" &&
               zkServer.sh start-foreground
           readinessProbe:
@@ -193,7 +189,6 @@ spec:
           volumeMounts:
             - name: datadir-volume
               mountPath: /var/lib/zookeeper
-
       # Run as a non-privileged user
       securityContext:
         runAsUser: 1000

--- a/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-1-node.yaml
+++ b/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-1-node.yaml
@@ -90,11 +90,14 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.6.1"
+          image: "docker.io/zookeeper:3.6.3"
           resources:
             requests:
-              memory: "1Gi"
-              cpu: "0.5"
+              memory: "512M"
+              cpu: "1"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
           ports:
             - containerPort: 2181
               name: client
@@ -136,8 +139,8 @@ spec:
                 echo 'preAllocSize=131072'
                 echo 'snapCount=3000000'
                 echo 'leaderServes=yes'
-                echo 'standaloneEnabled=true'
-                echo '4lw.commands.whitelist=stat, ruok, conf, isro, mntr'
+                echo 'standaloneEnabled=false'
+                echo '4lw.commands.whitelist=*'
                 echo 'metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider'
                 echo "metricsProvider.httpPort=${PROMETHEUS_PORT}"
               } > /conf/zoo.cfg &&
@@ -150,7 +153,7 @@ spec:
                 echo "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout"
                 echo "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n"
               } > /conf/log4j.properties &&
-              echo 'JVMFLAGS="-Xms128M -Xmx1G -XX:+UseG1GC -XX:+CMSParallelRemarkEnabled"' > /conf/java.env &&
+              echo 'JVMFLAGS="-Xms128M -Xmx4G -XX:+UseG1GC -XX:+CMSParallelRemarkEnabled"' > /conf/java.env &&
               if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
                   NAME=${BASH_REMATCH[1]}
                   ORD=${BASH_REMATCH[2]}
@@ -162,11 +165,9 @@ spec:
               mkdir -p ${ZOO_DATA_LOG_DIR} &&
               export MY_ID=$((ORD+1)) &&
               echo $MY_ID > $ZOO_DATA_DIR/myid &&
-              if [[ $SERVERS -gt 1 ]]; then
-                for (( i=1; i<=$SERVERS; i++ )); do
-                    echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
-                done
-              fi &&
+              for (( i=1; i<=$SERVERS; i++ )); do
+                  echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
+              done &&
               chown -Rv zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR" &&
               zkServer.sh start-foreground
           readinessProbe:

--- a/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-3-nodes.yaml
+++ b/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-3-nodes.yaml
@@ -90,11 +90,14 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.6.1"
+          image: "docker.io/zookeeper:3.6.3"
           resources:
             requests:
-              memory: "1Gi"
-              cpu: "0.5"
+              memory: "512M"
+              cpu: "1"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
           ports:
             - containerPort: 2181
               name: client
@@ -136,8 +139,8 @@ spec:
                 echo 'preAllocSize=131072'
                 echo 'snapCount=3000000'
                 echo 'leaderServes=yes'
-                echo 'standaloneEnabled=true'
-                echo '4lw.commands.whitelist=stat, ruok, conf, isro, mntr'
+                echo 'standaloneEnabled=false'
+                echo '4lw.commands.whitelist=*'
                 echo 'metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider'
                 echo "metricsProvider.httpPort=${PROMETHEUS_PORT}"
               } > /conf/zoo.cfg &&
@@ -162,11 +165,9 @@ spec:
               mkdir -p ${ZOO_DATA_LOG_DIR} &&
               export MY_ID=$((ORD+1)) &&
               echo $MY_ID > $ZOO_DATA_DIR/myid &&
-              if [[ $SERVERS -gt 1 ]]; then
-                for (( i=1; i<=$SERVERS; i++ )); do
-                    echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
-                done
-              fi &&
+              for (( i=1; i<=$SERVERS; i++ )); do
+                  echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
+              done &&
               chown -Rv zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR" &&
               zkServer.sh start-foreground
           readinessProbe:

--- a/tests/clickhouse.py
+++ b/tests/clickhouse.py
@@ -75,3 +75,29 @@ def query_with_error(
         pod=pod,
         container=container
     )
+
+
+def drop_table_on_cluster(chi, cluster_name='all-sharded', table='default.test'):
+    drop_local_sql = f'DROP TABLE {table} ON CLUSTER \'{cluster_name}\' SYNC'
+    query(chi["metadata"]["name"], drop_local_sql, timeout=120)
+
+
+def create_table_on_cluster(chi, cluster_name='all-sharded', table='default.test',
+                            create_definition='(event_time DateTime, test UInt64) ENGINE MergeTree() ORDER BY tuple()'):
+    create_local_sql = f'CREATE TABLE {table} ON CLUSTER \'{cluster_name}\' {create_definition}'
+    query(chi["metadata"]["name"], create_local_sql, timeout=120)
+
+
+def drop_distributed_table_on_cluster(chi, cluster_name='all-sharded', distr_table='default.test_distr', local_table='default.test'):
+    drop_distr_sql = f'DROP TABLE {distr_table} ON CLUSTER \'{cluster_name}\''
+    query(chi["metadata"]["name"], drop_distr_sql, timeout=120)
+    drop_table_on_cluster(chi, cluster_name, local_table)
+
+
+def create_distributed_table_on_cluster(chi, cluster_name='all-sharded', distr_table='default.test_distr', local_table='default.test',
+                                        fields_definition='(event_time DateTime, test UInt64)',
+                                        local_engine='ENGINE MergeTree() ORDER BY tuple()',
+                                        distr_engine='ENGINE Distributed(\'all-sharded\',default, test, test)'):
+    create_table_on_cluster(chi, cluster_name, local_table, fields_definition + ' ' + local_engine)
+    create_distr_sql = f'CREATE TABLE {distr_table} ON CLUSTER \'{cluster_name}\' {fields_definition} {distr_engine}'
+    query(chi["metadata"]["name"], create_distr_sql, timeout=120)

--- a/tests/configs/test-005-acm.yaml
+++ b/tests/configs/test-005-acm.yaml
@@ -39,7 +39,7 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/clickhouse
               name: default-gp2
-        - image: altinity/clickhouse-backup:1.0.11
+        - image: altinity/clickhouse-backup:1.0.14
           name: clickhouse-backup
           ports:
             - containerPort: 7171

--- a/tests/configs/test-cluster-for-zookeeper.yaml
+++ b/tests/configs/test-cluster-for-zookeeper.yaml
@@ -1,0 +1,21 @@
+apiVersion: "clickhouse.altinity.com/v1"
+
+kind: "ClickHouseInstallation"
+
+metadata:
+  name: test-cluster-for-zk
+
+spec:
+  useTemplates:
+    - name: clickhouse-latest-version
+    - name: persistent-volume
+  configuration:
+    zookeeper:
+      nodes:
+        - host: zookeeper
+          port: 2181
+    clusters:
+      - name: default
+        layout:
+          shardsCount: 1
+          replicasCount: 2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-testflows==1.6.72
+testflows==1.7.4
 PyYAML

--- a/tests/templates/tpl-clickhouse-backups.yaml
+++ b/tests/templates/tpl-clickhouse-backups.yaml
@@ -31,7 +31,7 @@ spec:
                 - --config-file=/etc/clickhouse-server/config.xml
 
             - name: clickhouse-backup
-              image: altinity/clickhouse-backup:1.0.11
+              image: altinity/clickhouse-backup:1.0.14
               imagePullPolicy: Always
               command:
                 - bash

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -1,0 +1,67 @@
+import kubectl
+import clickhouse
+import settings
+import util
+
+from testflows.core import When, Then, main, Scenario, Module, TestScenario, Name
+
+
+@TestScenario
+@Name("test_zookeeper_rescale. Check ZK scale-up / scale-down cases")
+def test_zookeeper_rescale(self):
+    with When('create replicated table'):
+        clickhouse.create_table_on_cluster(
+            chi, 'all-sharded', 'default.zk_repl',
+            '(id UInt64) ENGINE=ReplicatedMergeTree(\'/clickhouse/tables/default.zk_repl/{shard}\',\'{replica}\') ORDER BY (id)'
+        )
+    with Then('insert data x1'):
+        clickhouse.query(
+            chi['metadata']['name'], 'INSERT INTO default.zk_repl SELECT number FROM numbers(1000)',
+            pod="chi-test-cluster-for-zk-default-0-0-0"
+        )
+    with Then('scale up zookeeper to 3 nodes'):
+        util.require_zookeeper('zookeeper-3-nodes-1GB-for-tests-only.yaml', force_install=True)
+        kubectl.wait_pod_status('zookeeper-0', 'Running', settings.test_namespace)
+        kubectl.wait_pod_status('zookeeper-1', 'Running', settings.test_namespace)
+        kubectl.wait_pod_status('zookeeper-2', 'Running', settings.test_namespace)
+
+    with Then('insert data x2'):
+        clickhouse.query(
+            chi['metadata']['name'], 'INSERT INTO default.zk_repl SELECT number*2 FROM numbers(1000)',
+            pod="chi-test-cluster-for-zk-default-0-1-0"
+        )
+
+    with Then('scale down zookeeper to 1 nodes'):
+        util.require_zookeeper('zookeeper-1-node-1GB-for-tests-only.yaml', force_install=True)
+        kubectl.wait_pod_status('zookeeper-0', 'Running', settings.test_namespace)
+
+    with Then('insert data x2'):
+        clickhouse.query(
+            chi['metadata']['name'], 'INSERT INTO default.zk_repl SELECT number*3 FROM numbers(1000)',
+            pod="chi-test-cluster-for-zk-default-0-0-0"
+        )
+
+    assert clickhouse.query(
+        chi['metadata']['name'], 'SELECT count() FROM default.zk_repl', pod="chi-test-cluster-for-zk-default-0-1-0"
+    ) == '3000', "Invalid rows after 3x1000 inserts"
+
+    clickhouse.drop_table_on_cluster(chi, 'all-sharded', 'default.zk_repl')
+
+
+if main():
+    with Module("main"):
+        clickhouse_operator_spec, chi = util.install_clickhouse_and_zookeeper(
+            chi_file='configs/test-cluster-for-zookeeper.yaml',
+            chi_template_file='templates/tpl-clickhouse-latest.yaml',
+            chi_name='test-cluster-for-zk',
+        )
+        util.wait_clickhouse_cluster_ready(chi)
+
+        all_tests = [
+            test_zookeeper_rescale
+        ]
+        for t in all_tests:
+            if callable(t):
+                Scenario(test=t)()
+            else:
+                Scenario(test=t[0], args=t[1])()


### PR DESCRIPTION
- setup standaloneEnabled=false and add server.X by default to zoo.cfg, 
- add test_zookeeper.py which allow test ZK scale-out/scale-down 
- rollback zookeeper to 3.6.3 
- rollback maxResponseCacheSize, maxGetChildrenResponseCacheSize to default
- all tests 0.15.0 PASSED

Signed-off-by: Slach <bloodjazman@gmail.com>

Items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)