### PR TITLE
export environment variable OPERATOR_NAMESPACE on quick start page [doc]

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -34,7 +34,7 @@ curl -s https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/de
 ```
 Take into account explicitly specified namespace
 ```bash
-OPERATOR_NAMESPACE=test-clickhouse-operator
+export OPERATOR_NAMESPACE=test-clickhouse-operator
 ```
 This namespace would be created and used to install `clickhouse-operator` into.
 Install script would download some `.yaml` and `.xml` files and install `clickhouse-operator` into specified namespace.


### PR DESCRIPTION



Exporting environment variable `OPERATOR_NAMESPACE` for making it exported to child-processes.

Currently, ClickHouse installed always in `kube-system` namespace
```bash
$ OPERATOR_NAMESPACE=dev

$ curl -s https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/operator-web-installer/clickhouse-operator-install.sh | bash

Setup ClickHouse Operator into 'kube-system' namespace
Namespace 'kube-system' already exists
Looks like clickhouse-operator is not installed in 'kube-system' namespace. Going to install
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/clickhouseinstallations.clickhouse.altinity.com created
customresourcedefinition.apiextensions.k8s.io/clickhouseinstallationtemplates.clickhouse.altinity.com created
customresourcedefinition.apiextensions.k8s.io/clickhouseoperatorconfigurations.clickhouse.altinity.com created
serviceaccount/clickhouse-operator created
clusterrole.rbac.authorization.k8s.io/clickhouse-operator-kube-system created
clusterrolebinding.rbac.authorization.k8s.io/clickhouse-operator-kube-system created
configmap/etc-clickhouse-operator-files created
configmap/etc-clickhouse-operator-confd-files created
configmap/etc-clickhouse-operator-configd-files created
configmap/etc-clickhouse-operator-templatesd-files created
configmap/etc-clickhouse-operator-usersd-files created
deployment.apps/clickhouse-operator created
service/clickhouse-operator-metrics created

$ kubectl get ns
NAME              STATUS   AGE
default           Active   67m
kube-node-lease   Active   67m
kube-public       Active   67m
kube-system       Active   67m

$ echo $OPERATOR_NAMESPACE
dev
```

If I use command `export` script works correctly:
```bash
$ export OPERATOR_NAMESPACE=dev

$ curl -s https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/operator-web-installer/clickhouse-operator-install.sh | bash
Setup ClickHouse Operator into 'dev' namespace
No 'dev' namespace found. Going to create
namespace/dev created
.....

---

Signed-off-by: Denis Gorobets orginux@protonmail.com