### PR TITLE
Switch to 'apiextensions.k8s.io/v1'.

### DIFF
--- a/deploy/dev/clickhouse-operator-install-dev.yaml
+++ b/deploy/dev/clickhouse-operator-install-dev.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,834 +11,837 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,834 +849,837 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,119 +1687,123 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            watchNamespaces:
-              type: array
-              items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      jsonPath: .status
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              watchNamespaces:
+                type: array
+                items:
+                  type: string
+              chCommonConfigsPath:
                 type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
+              chHostConfigsPath:
                 type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
+              chUsersConfigsPath:
                 type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+              chiTemplatesPath:
+                type: string
+              statefulSetUpdateTimeout:
+                type: integer
+              statefulSetUpdatePollPeriod:
+                type: integer
+              onStatefulSetCreateFailureAction:
+                type: string
+              onStatefulSetUpdateFailureAction:
+                type: string
+              chConfigUserDefaultProfile:
+                type: string
+              chConfigUserDefaultQuota:
+                type: string
+              chConfigUserDefaultNetworksIP:
+                type: array
+                items:
+                  type: string
+              chConfigUserDefaultPassword:
+                type: string
+              chConfigNetworksHostRegexpTemplate:
+                type: string
+              chUsername:
+                type: string
+              chPassword:
+                type: string
+              chCredentialsSecretNamespace:
+                type: string
+              chCredentialsSecretName:
+                type: string
+              chPort:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              logtostderr:
+                type: string
+              alsologtostderr:
+                type: string
+              v:
+                type: string
+              stderrthreshold:
+                type: string
+              vmodule:
+                type: string
+              log_backtrace_at:
+                type: string
+              reconcileThreadsNumber:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              reconcileWaitExclude:
+                type: string
+              reconcileWaitInclude:
+                type: string
+              excludeFromPropagationLabels:
+                type: array
+                items:
+                  type: string
+              appendScopeLabels:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
 ---
 # Possible Template Parameters:
 #

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-01-chi.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-01-chi.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,823 +11,827 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-02-chit.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-02-chit.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -12,823 +11,827 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -12,116 +11,120 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            watchNamespaces:
-              type: array
-              items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      jsonPath: .status
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              watchNamespaces:
+                type: array
+                items:
+                  type: string
+              chCommonConfigsPath:
                 type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
+              chHostConfigsPath:
                 type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
+              chUsersConfigsPath:
                 type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+              chiTemplatesPath:
+                type: string
+              statefulSetUpdateTimeout:
+                type: integer
+              statefulSetUpdatePollPeriod:
+                type: integer
+              onStatefulSetCreateFailureAction:
+                type: string
+              onStatefulSetUpdateFailureAction:
+                type: string
+              chConfigUserDefaultProfile:
+                type: string
+              chConfigUserDefaultQuota:
+                type: string
+              chConfigUserDefaultNetworksIP:
+                type: array
+                items:
+                  type: string
+              chConfigUserDefaultPassword:
+                type: string
+              chConfigNetworksHostRegexpTemplate:
+                type: string
+              chUsername:
+                type: string
+              chPassword:
+                type: string
+              chCredentialsSecretNamespace:
+                type: string
+              chCredentialsSecretName:
+                type: string
+              chPort:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              logtostderr:
+                type: string
+              alsologtostderr:
+                type: string
+              v:
+                type: string
+              stderrthreshold:
+                type: string
+              vmodule:
+                type: string
+              log_backtrace_at:
+                type: string
+              reconcileThreadsNumber:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              reconcileWaitExclude:
+                type: string
+              reconcileWaitInclude:
+                type: string
+              excludeFromPropagationLabels:
+                type: array
+                items:
+                  type: string
+              appendScopeLabels:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"

--- a/deploy/operator/clickhouse-operator-install-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,834 +11,837 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,834 +849,837 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,116 +1687,120 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            watchNamespaces:
-              type: array
-              items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      jsonPath: .status
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              watchNamespaces:
+                type: array
+                items:
+                  type: string
+              chCommonConfigsPath:
                 type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
+              chHostConfigsPath:
                 type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
+              chUsersConfigsPath:
                 type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+              chiTemplatesPath:
+                type: string
+              statefulSetUpdateTimeout:
+                type: integer
+              statefulSetUpdatePollPeriod:
+                type: integer
+              onStatefulSetCreateFailureAction:
+                type: string
+              onStatefulSetUpdateFailureAction:
+                type: string
+              chConfigUserDefaultProfile:
+                type: string
+              chConfigUserDefaultQuota:
+                type: string
+              chConfigUserDefaultNetworksIP:
+                type: array
+                items:
+                  type: string
+              chConfigUserDefaultPassword:
+                type: string
+              chConfigNetworksHostRegexpTemplate:
+                type: string
+              chUsername:
+                type: string
+              chPassword:
+                type: string
+              chCredentialsSecretNamespace:
+                type: string
+              chCredentialsSecretName:
+                type: string
+              chPort:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              logtostderr:
+                type: string
+              alsologtostderr:
+                type: string
+              v:
+                type: string
+              stderrthreshold:
+                type: string
+              vmodule:
+                type: string
+              log_backtrace_at:
+                type: string
+              reconcileThreadsNumber:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              reconcileWaitExclude:
+                type: string
+              reconcileWaitInclude:
+                type: string
+              excludeFromPropagationLabels:
+                type: array
+                items:
+                  type: string
+              appendScopeLabels:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"

--- a/deploy/operator/clickhouse-operator-install-template-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,834 +11,837 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,834 +849,837 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,116 +1687,120 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            watchNamespaces:
-              type: array
-              items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      jsonPath: .status
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              watchNamespaces:
+                type: array
+                items:
+                  type: string
+              chCommonConfigsPath:
                 type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
+              chHostConfigsPath:
                 type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
+              chUsersConfigsPath:
                 type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+              chiTemplatesPath:
+                type: string
+              statefulSetUpdateTimeout:
+                type: integer
+              statefulSetUpdatePollPeriod:
+                type: integer
+              onStatefulSetCreateFailureAction:
+                type: string
+              onStatefulSetUpdateFailureAction:
+                type: string
+              chConfigUserDefaultProfile:
+                type: string
+              chConfigUserDefaultQuota:
+                type: string
+              chConfigUserDefaultNetworksIP:
+                type: array
+                items:
+                  type: string
+              chConfigUserDefaultPassword:
+                type: string
+              chConfigNetworksHostRegexpTemplate:
+                type: string
+              chUsername:
+                type: string
+              chPassword:
+                type: string
+              chCredentialsSecretNamespace:
+                type: string
+              chCredentialsSecretName:
+                type: string
+              chPort:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              logtostderr:
+                type: string
+              alsologtostderr:
+                type: string
+              v:
+                type: string
+              stderrthreshold:
+                type: string
+              vmodule:
+                type: string
+              log_backtrace_at:
+                type: string
+              reconcileThreadsNumber:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              reconcileWaitExclude:
+                type: string
+              reconcileWaitInclude:
+                type: string
+              excludeFromPropagationLabels:
+                type: array
+                items:
+                  type: string
+              appendScopeLabels:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,834 +11,837 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,834 +849,837 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,119 +1687,123 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            watchNamespaces:
-              type: array
-              items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      jsonPath: .status
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              watchNamespaces:
+                type: array
+                items:
+                  type: string
+              chCommonConfigsPath:
                 type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
+              chHostConfigsPath:
                 type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
+              chUsersConfigsPath:
                 type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+              chiTemplatesPath:
+                type: string
+              statefulSetUpdateTimeout:
+                type: integer
+              statefulSetUpdatePollPeriod:
+                type: integer
+              onStatefulSetCreateFailureAction:
+                type: string
+              onStatefulSetUpdateFailureAction:
+                type: string
+              chConfigUserDefaultProfile:
+                type: string
+              chConfigUserDefaultQuota:
+                type: string
+              chConfigUserDefaultNetworksIP:
+                type: array
+                items:
+                  type: string
+              chConfigUserDefaultPassword:
+                type: string
+              chConfigNetworksHostRegexpTemplate:
+                type: string
+              chUsername:
+                type: string
+              chPassword:
+                type: string
+              chCredentialsSecretNamespace:
+                type: string
+              chCredentialsSecretName:
+                type: string
+              chPort:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              logtostderr:
+                type: string
+              alsologtostderr:
+                type: string
+              v:
+                type: string
+              stderrthreshold:
+                type: string
+              vmodule:
+                type: string
+              log_backtrace_at:
+                type: string
+              reconcileThreadsNumber:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              reconcileWaitExclude:
+                type: string
+              reconcileWaitInclude:
+                type: string
+              excludeFromPropagationLabels:
+                type: array
+                items:
+                  type: string
+              appendScopeLabels:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
 ---
 # Possible Template Parameters:
 #

--- a/deploy/operator/clickhouse-operator-install.yaml
+++ b/deploy/operator/clickhouse-operator-install.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,834 +11,837 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,834 +849,837 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
-                # Need to be StringBool
-                replicasUseFQDN:
-                  type: string
-                  enum:
-                    # List StringBoolXXX constants from model
-                    - ""
-                    - "0"
-                    - "1"
-                    - "False"
-                    - "false"
-                    - "True"
-                    - "true"
-                    - "No"
-                    - "no"
-                    - "Yes"
-                    - "yes"
-                    - "Off"
-                    - "off"
-                    - "On"
-                    - "on"
-                    - "Disable"
-                    - "disable"
-                    - "Enable"
-                    - "enable"
-                    - "Disabled"
-                    - "disabled"
-                    - "Enabled"
-                    - "enabled"
-                distributedDDL:
-                  type: object
-                  nullable: true
-                  properties:
-                    profile:
-                      type: string
-                templates:
-                  type: object
-                  nullable: true
-                  properties:
-                    hostTemplate:
-                      type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
-                  type: object
-                  nullable: true
-                  properties:
-                    nodes:
-                      type: array
-                      nullable: true
-                      items:
-                        type: object
-                        #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      jsonPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      jsonPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      jsonPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      jsonPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      jsonPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      jsonPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      jsonPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      jsonPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      jsonPath: .status.endpoint
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              taskID:
+                type: string
+              # Need to be StringBool
+              stop:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              # Need to be StringBool
+              troubleshoot:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
+              namespaceDomainPattern:
+                type: string
+              templating:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+              reconciling:
+                type: object
+                nullable: true
+                properties:
+                  policy:
+                    type: string
+                  configMapPropagationTimeout:
+                    type: integer
+                    minimum: 0
+                    maximum: 3600
+                  cleanup:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
+                      unknownObjects:
                         type: object
                         nullable: true
                         properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
+                          statefulSet:
                             type: string
-                          identity:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
+                            type: string
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                      reconcileFailedObjects:
                         type: object
                         nullable: true
                         properties:
-                          hostTemplate:
+                          statefulSet:
                             type: string
-                          podTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          pvc:
                             type: string
-                          dataVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          configMap:
                             type: string
-                          logVolumeClaimTemplate:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+                          service:
                             type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                            enum:
+                              # List ObjectsCleanupXXX constants from model
+                              - "Retain"
+                              - "Delete"
+              defaults:
+                type: object
+                nullable: true
+                properties:
+                  # Need to be StringBool
+                  replicasUseFQDN:
+                    type: string
+                    enum:
+                      # List StringBoolXXX constants from model
+                      - ""
+                      - "0"
+                      - "1"
+                      - "False"
+                      - "false"
+                      - "True"
+                      - "true"
+                      - "No"
+                      - "no"
+                      - "Yes"
+                      - "yes"
+                      - "Off"
+                      - "off"
+                      - "On"
+                      - "on"
+                      - "Disable"
+                      - "disable"
+                      - "Enable"
+                      - "enable"
+                      - "Disabled"
+                      - "disabled"
+                      - "Enabled"
+                      - "enabled"
+                  distributedDDL:
                     type: object
-                    #required:
-                    #  - name
+                    nullable: true
                     properties:
-                      name:
+                      profile:
                         type: string
-                      portDistribution:
+                  templates:
+                    type: object
+                    nullable: true
+                    properties:
+                      hostTemplate:
+                        type: string
+                      podTemplate:
+                        type: string
+                      dataVolumeClaimTemplate:
+                        type: string
+                      logVolumeClaimTemplate:
+                        type: string
+                      serviceTemplate:
+                        type: string
+                      clusterServiceTemplate:
+                        type: string
+                      shardServiceTemplate:
+                        type: string
+                      replicaServiceTemplate:
+                        type: string
+              configuration:
+                type: object
+                nullable: true
+                properties:
+                  zookeeper:
+                    type: object
+                    nullable: true
+                    properties:
+                      nodes:
                         type: array
                         nullable: true
                         items:
                           type: object
                           #required:
-                          #  - type
+                          #  - host
                           properties:
-                            type:
+                            host:
                               type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
-                        properties:
-                          name:
-                            type: string
-                            minLength: 1
-                            # See namePartReplicaMaxLen const
-                            maxLength: 15
-                            pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          settings:
-                            type: object
-                            nullable: true
-                          files:
-                            type: object
-                            nullable: true
-                          templates:
-                            type: object
-                            nullable: true
-                            properties:
-                              hostTemplate:
-                                type: string
-                              podTemplate:
-                                type: string
-                              dataVolumeClaimTemplate:
-                                type: string
-                              logVolumeClaimTemplate:
-                                type: string
-                              serviceTemplate:
-                                type: string
-                              clusterServiceTemplate:
-                                type: string
-                              shardServiceTemplate:
-                                type: string
-                              replicaServiceTemplate:
-                                type: string
-
-                podTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
-                        type: object
-                        #required:
-                        #  - values
-                        properties:
-                          key:
-                            type: string
-                          values:
-                            type: array
-                            nullable: true
-                            items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
+                            port:
                               type: integer
                               minimum: 0
                               maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
-                        type: object
-                        nullable: true
-                volumeClaimTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                      session_timeout_ms:
+                        type: integer
+                      operation_timeout_ms:
+                        type: integer
+                      root:
+                        type: string
+                      identity:
+                        type: string
+                  users:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      reclaimPolicy:
-                        type: string
-                        enum:
-                          - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
+                    nullable: true
+                  profiles:
                     type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
+                    nullable: true
+                  quotas:
+                    type: object
+                    nullable: true
+                  settings:
+                    type: object
+                    nullable: true
+                  files:
+                    type: object
+                    nullable: true
+                  clusters:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          # See namePartClusterMaxLen const
+                          maxLength: 15
+                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                        zookeeper:
+                          type: object
+                          nullable: true
+                          properties:
+                            nodes:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                #required:
+                                #  - host
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 65535
+                            session_timeout_ms:
+                              type: integer
+                            operation_timeout_ms:
+                              type: integer
+                            root:
+                              type: string
+                            identity:
+                              type: string
+                        settings:
+                          type: object
+                          nullable: true
+                        files:
+                          type: object
+                          nullable: true
+                        templates:
+                          type: object
+                          nullable: true
+                          properties:
+                            hostTemplate:
+                              type: string
+                            podTemplate:
+                              type: string
+                            dataVolumeClaimTemplate:
+                              type: string
+                            logVolumeClaimTemplate:
+                              type: string
+                            serviceTemplate:
+                              type: string
+                            clusterServiceTemplate:
+                              type: string
+                            shardServiceTemplate:
+                              type: string
+                            replicaServiceTemplate:
+                              type: string
+                        layout:
+                          type: object
+                          nullable: true
+                          properties:
+                            # DEPRECATED - to be removed soon
+                            type:
+                              type: string
+                            shardsCount:
+                              type: integer
+                            replicasCount:
+                              type: integer
+                            shards:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  # DEPRECATED - to be removed soon
+                                  definitionType:
+                                    type: string
+                                  weight:
+                                    type: integer
+                                  # Need to be StringBool
+                                  internalReplication:
+                                    type: string
+                                    enum:
+                                      # List StringBoolXXX constants from model
+                                      - ""
+                                      - "0"
+                                      - "1"
+                                      - "False"
+                                      - "false"
+                                      - "True"
+                                      - "true"
+                                      - "No"
+                                      - "no"
+                                      - "Yes"
+                                      - "yes"
+                                      - "Off"
+                                      - "off"
+                                      - "On"
+                                      - "on"
+                                      - "Disable"
+                                      - "disable"
+                                      - "Enable"
+                                      - "enable"
+                                      - "Disabled"
+                                      - "disabled"
+                                      - "Enabled"
+                                      - "enabled"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTemplate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  replicasCount:
+                                    type: integer
+                                    minimum: 1
+                                  replicas:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+                            replicas:
+                              type: array
+                              nullable: true
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                    minLength: 1
+                                    # See namePartShardMaxLen const
+                                    maxLength: 15
+                                    pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                  settings:
+                                    type: object
+                                    nullable: true
+                                  files:
+                                    type: object
+                                    nullable: true
+                                  templates:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      hostTeampate:
+                                        type: string
+                                      podTemplate:
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        type: string
+                                      logVolumeClaimTemplate:
+                                        type: string
+                                      serviceTemplate:
+                                        type: string
+                                      clusterServiceTemplate:
+                                        type: string
+                                      shardServiceTemplate:
+                                        type: string
+                                      replicaServiceTemplate:
+                                        type: string
+                                  shardsCount:
+                                    type: integer
+                                    minimum: 1
+                                  shards:
+                                    type: array
+                                    nullable: true
+                                    items:
+                                      # Host
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                          minLength: 1
+                                          # See namePartReplicaMaxLen const
+                                          maxLength: 15
+                                          pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                        tcpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        httpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        interserverHttpPort:
+                                          type: integer
+                                          minimum: 1
+                                          maximum: 65535
+                                        settings:
+                                          type: object
+                                          nullable: true
+                                        files:
+                                          type: object
+                                          nullable: true
+                                        templates:
+                                          type: object
+                                          nullable: true
+                                          properties:
+                                            hostTemplate:
+                                              type: string
+                                            podTemplate:
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              type: string
+                                            logVolumeClaimTemplate:
+                                              type: string
+                                            serviceTemplate:
+                                              type: string
+                                            clusterServiceTemplate:
+                                              type: string
+                                            shardServiceTemplate:
+                                              type: string
+                                            replicaServiceTemplate:
+                                              type: string
+              templates:
                 type: object
-                #required:
-                #  - name
+                nullable: true
                 properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                  hostTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        portDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PortDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClusterScopeIndex"
+                        spec:
+                          # Host
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                              # See namePartReplicaMaxLen const
+                              maxLength: 15
+                              pattern: "^[a-zA-Z0-9-]{0,15}$"
+                            tcpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            httpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            interserverHttpPort:
+                              type: integer
+                              minimum: 1
+                              maximum: 65535
+                            settings:
+                              type: object
+                              nullable: true
+                            files:
+                              type: object
+                              nullable: true
+                            templates:
+                              type: object
+                              nullable: true
+                              properties:
+                                hostTemplate:
+                                  type: string
+                                podTemplate:
+                                  type: string
+                                dataVolumeClaimTemplate:
+                                  type: string
+                                logVolumeClaimTemplate:
+                                  type: string
+                                serviceTemplate:
+                                  type: string
+                                clusterServiceTemplate:
+                                  type: string
+                                shardServiceTemplate:
+                                  type: string
+                                replicaServiceTemplate:
+                                  type: string
+
+                  podTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        zone:
+                          type: object
+                          #required:
+                          #  - values
+                          properties:
+                            key:
+                              type: string
+                            values:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                        distribution:
+                          # DEPRECATED
+                          type: string
+                          enum:
+                            - ""
+                            - "Unspecified"
+                            - "OnePerHost"
+                        podDistribution:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  # List PodDistributionXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "ClickHouseAntiAffinity"
+                                  - "ShardAntiAffinity"
+                                  - "ReplicaAntiAffinity"
+                                  - "AnotherNamespaceAntiAffinity"
+                                  - "AnotherClickHouseInstallationAntiAffinity"
+                                  - "AnotherClusterAntiAffinity"
+                                  - "MaxNumberPerNode"
+                                  - "NamespaceAffinity"
+                                  - "ClickHouseInstallationAffinity"
+                                  - "ClusterAffinity"
+                                  - "ShardAffinity"
+                                  - "ReplicaAffinity"
+                                  - "PreviousTailAffinity"
+                                  - "CircularReplication"
+                              scope:
+                                type: string
+                                enum:
+                                  # list PodDistributionScopeXXX constants
+                                  - ""
+                                  - "Unspecified"
+                                  - "Shard"
+                                  - "Replica"
+                                  - "Cluster"
+                                  - "ClickHouseInstallation"
+                                  - "Namespace"
+                              number:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        spec:
+                          # TODO specify PodSpec
+                          type: object
+                          nullable: true
+                  volumeClaimTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        reclaimPolicy:
+                          type: string
+                          enum:
+                            - ""
+                            - "Retain"
+                            - "Delete"
+                        metadata:
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify PersistentVolumeClaimSpec
+                          type: object
+                          nullable: true
+                  serviceTemplates:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      #required:
+                      #  - name
+                      #  - spec
+                      properties:
+                        name:
+                          type: string
+                        generateName:
+                          type: string
+                        metadata:
+                          # TODO specify ObjectMeta
+                          type: object
+                          nullable: true
+                        spec:
+                          # TODO specify ServiceSpec
+                          type: object
+                          nullable: true
+              useTemplates:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  #required:
+                  #  - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    useType:
+                      type: string
+                      enum:
+                        # List useTypeXXX constants from model
+                        - ""
+                        - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,119 +1687,123 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
   # TODO return to this feature later
   # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
   # Probably full specification may be needed
   #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            watchNamespaces:
-              type: array
-              items:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      jsonPath: .status
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              watchNamespaces:
+                type: array
+                items:
+                  type: string
+              chCommonConfigsPath:
                 type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
+              chHostConfigsPath:
                 type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
+              chUsersConfigsPath:
                 type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+              chiTemplatesPath:
+                type: string
+              statefulSetUpdateTimeout:
+                type: integer
+              statefulSetUpdatePollPeriod:
+                type: integer
+              onStatefulSetCreateFailureAction:
+                type: string
+              onStatefulSetUpdateFailureAction:
+                type: string
+              chConfigUserDefaultProfile:
+                type: string
+              chConfigUserDefaultQuota:
+                type: string
+              chConfigUserDefaultNetworksIP:
+                type: array
+                items:
+                  type: string
+              chConfigUserDefaultPassword:
+                type: string
+              chConfigNetworksHostRegexpTemplate:
+                type: string
+              chUsername:
+                type: string
+              chPassword:
+                type: string
+              chCredentialsSecretNamespace:
+                type: string
+              chCredentialsSecretName:
+                type: string
+              chPort:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              logtostderr:
+                type: string
+              alsologtostderr:
+                type: string
+              v:
+                type: string
+              stderrthreshold:
+                type: string
+              vmodule:
+                type: string
+              log_backtrace_at:
+                type: string
+              reconcileThreadsNumber:
+                type: integer
+                minimum: 1
+                maximum: 65535
+              reconcileWaitExclude:
+                type: string
+              reconcileWaitInclude:
+                type: string
+              excludeFromPropagationLabels:
+                type: array
+                items:
+                  type: string
+              appendScopeLabels:
+                type: string
+                enum:
+                  # List StringBoolXXX constants from model
+                  - ""
+                  - "0"
+                  - "1"
+                  - "False"
+                  - "false"
+                  - "True"
+                  - "true"
+                  - "No"
+                  - "no"
+                  - "Yes"
+                  - "yes"
+                  - "Off"
+                  - "off"
+                  - "On"
+                  - "on"
+                  - "Disable"
+                  - "disable"
+                  - "Enable"
+                  - "enable"
+                  - "Disabled"
+                  - "disabled"
+                  - "Enabled"
+                  - "enabled"
 ---
 # Possible Template Parameters:
 #


### PR DESCRIPTION
Initial work on migrating to `apiextensions.k8s.io/v1` for Kubernetes 1.22+ support. The intention is to see what breaks and fix it in subsequent iterations — hence being marked as draft.

Closes #762.