### PR TITLE
switch from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1` for CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The ClickHouse Operator for Kubernetes currently provides the following:
  
 ## License
 
-Copyright (c) 2019-2020, Altinity Ltd and/or its affiliates. All rights reserved.
+Copyright (c) 2019-2219, Altinity Ltd and/or its affiliates. All rights reserved.
 
 `clickhouse-operator` is licensed under the Apache License 2.0.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -151,12 +151,13 @@ Vagrant.configure(2) do |config|
 #    K8S_VERSION=${K8S_VERSION:-1.15.12}
 #    K8S_VERSION=${K8S_VERSION:-1.16.15}
 #    K8S_VERSION=${K8S_VERSION:-1.17.17}
-#    K8S_VERSION=${K8S_VERSION:-1.18.19}
+#    K8S_VERSION=${K8S_VERSION:-1.18.20}
 #    K8S_VERSION=${K8S_VERSION:-1.19.14}
-#    performance issue 1.20.x, 1.21.x, only 1.22 will good to start
-# https://github.com/kubernetes/kubeadm/issues/2395
+#    performance issue 1.20.x, 1.21.x
+#    https://github.com/kubernetes/kubeadm/issues/2395
 #    K8S_VERSION=${K8S_VERSION:-1.20.10}
-    K8S_VERSION=${K8S_VERSION:-1.21.4}
+#    K8S_VERSION=${K8S_VERSION:-1.21.4}
+    K8S_VERSION=${K8S_VERSION:-1.22.1}
     export VALIDATE_YAML=true
 
     killall kubectl || true

--- a/deploy/dev/clickhouse-operator-install-dev.yaml
+++ b/deploy/dev/clickhouse-operator-install-dev.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,216 +11,82 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -248,422 +113,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -690,156 +388,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,216 +849,82 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -1083,422 +951,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -1525,156 +1226,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,119 +1687,125 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: namespaces
+          type: string
+          description: Watch namespaces
+          priority: 0 # show in standard view
+          jsonPath: .status
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            watchNamespaces:
-              type: array
-              items:
-                type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
-                type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
-                type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
+              properties:
+                watchNamespaces:
+                  type: array
+                  items:
+                    type: string
+                chCommonConfigsPath:
+                  type: string
+                chHostConfigsPath:
+                  type: string
+                chUsersConfigsPath:
+                  type: string
+                chiTemplatesPath:
+                  type: string
+                statefulSetUpdateTimeout:
+                  type: integer
+                statefulSetUpdatePollPeriod:
+                  type: integer
+                onStatefulSetCreateFailureAction:
+                  type: string
+                onStatefulSetUpdateFailureAction:
+                  type: string
+                chConfigUserDefaultProfile:
+                  type: string
+                chConfigUserDefaultQuota:
+                  type: string
+                chConfigUserDefaultNetworksIP:
+                  type: array
+                  items:
+                    type: string
+                chConfigUserDefaultPassword:
+                  type: string
+                chConfigNetworksHostRegexpTemplate:
+                  type: string
+                chUsername:
+                  type: string
+                chPassword:
+                  type: string
+                chCredentialsSecretNamespace:
+                  type: string
+                chCredentialsSecretName:
+                  type: string
+                chPort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                logtostderr:
+                  type: string
+                alsologtostderr:
+                  type: string
+                v:
+                  type: string
+                stderrthreshold:
+                  type: string
+                vmodule:
+                  type: string
+                log_backtrace_at:
+                  type: string
+                reconcileThreadsNumber:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                reconcileWaitExclude:
+                  type: string
+                reconcileWaitInclude:
+                  type: string
+                excludeFromPropagationLabels:
+                  type: array
+                  items:
+                    type: string
+                appendScopeLabels:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
 ---
 # Possible Template Parameters:
 #

--- a/deploy/dev/clickhouse-operator-install-dev.yaml
+++ b/deploy/dev/clickhouse-operator-install-dev.yaml
@@ -73,21 +73,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -115,12 +139,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -148,89 +174,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -258,41 +311,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -300,36 +376,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -337,17 +456,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -355,75 +479,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -451,193 +621,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -645,6 +941,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -656,31 +953,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -701,7 +1019,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -709,30 +1030,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -740,6 +1067,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -760,6 +1088,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -771,15 +1100,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -787,23 +1128,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -812,19 +1169,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -832,10 +1206,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -916,21 +1293,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -958,12 +1359,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -991,89 +1394,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -1101,41 +1531,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -1143,36 +1596,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1180,17 +1676,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -1198,75 +1699,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -1294,193 +1841,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1488,6 +2161,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -1499,31 +2173,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -1544,7 +2239,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1552,30 +2250,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1583,6 +2287,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -1603,6 +2308,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -1614,15 +2320,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1630,23 +2348,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1655,19 +2389,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1675,10 +2426,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -1707,70 +2461,105 @@ spec:
           description: Watch namespaces
           priority: 0 # show in standard view
           jsonPath: .status
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
-              # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                allows define some of settings for `clickhouse-operator` itself,
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+                look to etc-clickhouse-operator* ConfigMaps if you need more control
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 watchNamespaces:
                   type: array
+                  description: "List of namespaces where clickhouse-operator watches for events."
                   items:
                     type: string
                 chCommonConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
                 chHostConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
                 chUsersConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
                 chiTemplatesPath:
                   type: string
+                  description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
                 statefulSetUpdateTimeout:
                   type: integer
+                  description: "How many seconds to wait for created/updated StatefulSet to be Ready"
                 statefulSetUpdatePollPeriod:
                   type: integer
+                  description: "How many seconds to wait between checks for created/updated StatefulSet status"
                 onStatefulSetCreateFailureAction:
                   type: string
+                  description: |
+                    What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. delete - delete newly created problematic StatefulSet.
+                    3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 onStatefulSetUpdateFailureAction:
                   type: string
+                  description: |
+                    What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                    3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 chConfigUserDefaultProfile:
                   type: string
+                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
                 chConfigUserDefaultQuota:
                   type: string
+                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
                 chConfigUserDefaultNetworksIP:
                   type: array
+                  description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
                   items:
                     type: string
                 chConfigUserDefaultPassword:
+                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
                   type: string
                 chConfigNetworksHostRegexpTemplate:
+                  description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
                   type: string
                 chUsername:
                   type: string
+                  description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chPassword:
                   type: string
+                  description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chCredentialsSecretNamespace:
                   type: string
+                  description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chCredentialsSecretName:
                   type: string
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chPort:
                   type: integer
                   minimum: 1
                   maximum: 65535
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 logtostderr:
                   type: string
+                  description: "boolean, allows logs to stderr"
                 alsologtostderr:
                   type: string
+                  description: "booleanm allows logs to stderr and files both"
                 v:
                   type: string
+                  description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
                 stderrthreshold:
                   type: string
                 vmodule:
@@ -1779,6 +2568,7 @@ spec:
                   type: string
                 reconcileThreadsNumber:
                   type: integer
+                  description: "how much goroutines will use to reconcile in parallel, 10 by default"
                   minimum: 1
                   maximum: 65535
                 reconcileWaitExclude:
@@ -1787,10 +2577,14 @@ spec:
                   type: string
                 excludeFromPropagationLabels:
                   type: array
+                  description: |
+                    When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                    exclude labels from the following list
                   items:
                     type: string
                 appendScopeLabels:
                   type: string
+                  description: "Whether to append *Scope* labels to StatefulSet and Pod"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -1816,6 +2610,16 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                    - "LabelShardScopeIndex"
+                    - "LabelReplicaScopeIndex"
+                    - "LabelCHIScopeIndex"
+                    - "LabelCHIScopeCycleSize"
+                    - "LabelCHIScopeCycleIndex"
+                    - "LabelCHIScopeCycleOffset"
+                    - "LabelClusterScopeIndex"
+                    - "LabelClusterScopeCycleSize"
+                    - "LabelClusterScopeCycleIndex"
+                    - "LabelClusterScopeCycleOffset"
 ---
 # Possible Template Parameters:
 #
@@ -1946,6 +2750,13 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-01-chi.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-01-chi.yaml
@@ -73,21 +73,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -115,12 +139,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -148,89 +174,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -258,41 +311,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -300,36 +376,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -337,17 +456,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -355,75 +479,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -451,193 +621,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -645,6 +941,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -656,31 +953,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -701,7 +1019,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -709,30 +1030,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -740,6 +1067,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -760,6 +1088,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -771,15 +1100,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -787,23 +1128,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -812,19 +1169,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -832,10 +1206,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-01-chi.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-01-chi.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,216 +11,82 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -248,422 +113,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -690,145 +388,450 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-02-chit.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-02-chit.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -12,216 +11,82 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -248,422 +113,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -690,145 +388,450 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-02-chit.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-02-chit.yaml
@@ -73,21 +73,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -115,12 +139,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -148,89 +174,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -258,41 +311,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -300,36 +376,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -337,17 +456,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -355,75 +479,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -451,193 +621,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -645,6 +941,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -656,31 +953,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -701,7 +1019,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -709,30 +1030,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -740,6 +1067,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -760,6 +1088,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -771,15 +1100,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -787,23 +1128,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -812,19 +1169,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -832,10 +1206,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -12,116 +11,122 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: namespaces
+          type: string
+          description: Watch namespaces
+          priority: 0 # show in standard view
+          jsonPath: .status
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            watchNamespaces:
-              type: array
-              items:
-                type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
-                type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
-                type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
+              properties:
+                watchNamespaces:
+                  type: array
+                  items:
+                    type: string
+                chCommonConfigsPath:
+                  type: string
+                chHostConfigsPath:
+                  type: string
+                chUsersConfigsPath:
+                  type: string
+                chiTemplatesPath:
+                  type: string
+                statefulSetUpdateTimeout:
+                  type: integer
+                statefulSetUpdatePollPeriod:
+                  type: integer
+                onStatefulSetCreateFailureAction:
+                  type: string
+                onStatefulSetUpdateFailureAction:
+                  type: string
+                chConfigUserDefaultProfile:
+                  type: string
+                chConfigUserDefaultQuota:
+                  type: string
+                chConfigUserDefaultNetworksIP:
+                  type: array
+                  items:
+                    type: string
+                chConfigUserDefaultPassword:
+                  type: string
+                chConfigNetworksHostRegexpTemplate:
+                  type: string
+                chUsername:
+                  type: string
+                chPassword:
+                  type: string
+                chCredentialsSecretNamespace:
+                  type: string
+                chCredentialsSecretName:
+                  type: string
+                chPort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                logtostderr:
+                  type: string
+                alsologtostderr:
+                  type: string
+                v:
+                  type: string
+                stderrthreshold:
+                  type: string
+                vmodule:
+                  type: string
+                log_backtrace_at:
+                  type: string
+                reconcileThreadsNumber:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                reconcileWaitExclude:
+                  type: string
+                reconcileWaitInclude:
+                  type: string
+                excludeFromPropagationLabels:
+                  type: array
+                  items:
+                    type: string
+                appendScopeLabels:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"

--- a/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-01-section-crd-03-chopconf.yaml
@@ -21,70 +21,105 @@ spec:
           description: Watch namespaces
           priority: 0 # show in standard view
           jsonPath: .status
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
-              # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                allows define some of settings for `clickhouse-operator` itself,
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+                look to etc-clickhouse-operator* ConfigMaps if you need more control
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 watchNamespaces:
                   type: array
+                  description: "List of namespaces where clickhouse-operator watches for events."
                   items:
                     type: string
                 chCommonConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
                 chHostConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
                 chUsersConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
                 chiTemplatesPath:
                   type: string
+                  description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
                 statefulSetUpdateTimeout:
                   type: integer
+                  description: "How many seconds to wait for created/updated StatefulSet to be Ready"
                 statefulSetUpdatePollPeriod:
                   type: integer
+                  description: "How many seconds to wait between checks for created/updated StatefulSet status"
                 onStatefulSetCreateFailureAction:
                   type: string
+                  description: |
+                    What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. delete - delete newly created problematic StatefulSet.
+                    3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 onStatefulSetUpdateFailureAction:
                   type: string
+                  description: |
+                    What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                    3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 chConfigUserDefaultProfile:
                   type: string
+                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
                 chConfigUserDefaultQuota:
                   type: string
+                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
                 chConfigUserDefaultNetworksIP:
                   type: array
+                  description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
                   items:
                     type: string
                 chConfigUserDefaultPassword:
+                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
                   type: string
                 chConfigNetworksHostRegexpTemplate:
+                  description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
                   type: string
                 chUsername:
                   type: string
+                  description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chPassword:
                   type: string
+                  description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chCredentialsSecretNamespace:
                   type: string
+                  description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chCredentialsSecretName:
                   type: string
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chPort:
                   type: integer
                   minimum: 1
                   maximum: 65535
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 logtostderr:
                   type: string
+                  description: "boolean, allows logs to stderr"
                 alsologtostderr:
                   type: string
+                  description: "booleanm allows logs to stderr and files both"
                 v:
                   type: string
+                  description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
                 stderrthreshold:
                   type: string
                 vmodule:
@@ -93,6 +128,7 @@ spec:
                   type: string
                 reconcileThreadsNumber:
                   type: integer
+                  description: "how much goroutines will use to reconcile in parallel, 10 by default"
                   minimum: 1
                   maximum: 65535
                 reconcileWaitExclude:
@@ -101,10 +137,14 @@ spec:
                   type: string
                 excludeFromPropagationLabels:
                   type: array
+                  description: |
+                    When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                    exclude labels from the following list
                   items:
                     type: string
                 appendScopeLabels:
                   type: string
+                  description: "Whether to append *Scope* labels to StatefulSet and Pod"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -130,3 +170,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                    - "LabelShardScopeIndex"
+                    - "LabelReplicaScopeIndex"
+                    - "LabelCHIScopeIndex"
+                    - "LabelCHIScopeCycleSize"
+                    - "LabelCHIScopeCycleIndex"
+                    - "LabelCHIScopeCycleOffset"
+                    - "LabelClusterScopeIndex"
+                    - "LabelClusterScopeCycleSize"
+                    - "LabelClusterScopeCycleIndex"
+                    - "LabelClusterScopeCycleOffset"

--- a/deploy/dev/clickhouse-operator-install-yaml-template-02-section-rbac.yaml
+++ b/deploy/dev/clickhouse-operator-install-yaml-template-02-section-rbac.yaml
@@ -127,6 +127,13 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name

--- a/deploy/grafana/grafana-manually/grafana.yaml
+++ b/deploy/grafana/grafana-manually/grafana.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
   labels:
     app: grafana
 spec:
+  selector:
+    matchLabels:
+      app: grafana
   replicas: 1
   template:
     metadata:

--- a/deploy/operator/build-clickhouse-operator-install-v1beta1-yaml.sh
+++ b/deploy/operator/build-clickhouse-operator-install-v1beta1-yaml.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 # Build clickhouse-operator-install-v1beta1.yaml, need install https://github.com/mikefarah/yq
+# curl -sL https://github.com/mikefarah/yq/releases/download/v4.13.2/yq_linux_amd64 -o /usr/bin/yq
+# chmod +x /usr/bin/yq
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-cp "${CUR_DIR}/clickhouse-operator-install.yaml" "${CUR_DIR}/clickhouse-operator-install-v1beta1.yaml"
-cp "${CUR_DIR}/clickhouse-operator-install-template.yaml" "${CUR_DIR}/clickhouse-operator-install-template-v1beta1.yaml"
+cp -fv "${CUR_DIR}/clickhouse-operator-install.yaml" "${CUR_DIR}/clickhouse-operator-install-v1beta1.yaml"
+cp -fv "${CUR_DIR}/clickhouse-operator-install-template.yaml" "${CUR_DIR}/clickhouse-operator-install-template-v1beta1.yaml"
 declare -a ALL_YAML=("${CUR_DIR}/clickhouse-operator-install-v1beta1.yaml" "${CUR_DIR}/clickhouse-operator-install-template-v1beta1.yaml")
 for YAML in "${ALL_YAML[@]}"; do
   yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .apiVersion) = "apiextensions.k8s.io/v1beta1"' "${YAML}"
   yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.version) = .spec.versions[0].name' "${YAML}"
   yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.additionalPrinterColumns) = .spec.versions[0].additionalPrinterColumns' "${YAML}"
-  sed -i -e 's/jsonPath/JSONPath/g' "${YAML}"
-  # yq eval -e --inplace '(select(.spec.additionalPrinterColumns[].JSONPath) = .spec.additionalPrinterColumns.[].jsonPath' "${YAML}"
+  # sed -i -e 's/jsonPath/JSONPath/g' "${YAML}"
+  yq eval -e --inplace 'with(.spec.additionalPrinterColumns.[]; .JSONPath = .jsonPath )' "${YAML}"
   yq eval -e --inplace 'del(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.additionalPrinterColumns[].jsonPath)' "${YAML}"
   yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.validation ) = .spec.versions[0].schema' "${YAML}"
   yq eval -e --inplace 'del(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.versions)' "${YAML}"

--- a/deploy/operator/build-clickhouse-operator-install-v1beta1-yaml.sh
+++ b/deploy/operator/build-clickhouse-operator-install-v1beta1-yaml.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build clickhouse-operator-install-v1beta1.yaml, need install https://github.com/mikefarah/yq
+CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+cp "${CUR_DIR}/clickhouse-operator-install.yaml" "${CUR_DIR}/clickhouse-operator-install-v1beta1.yaml"
+cp "${CUR_DIR}/clickhouse-operator-install-template.yaml" "${CUR_DIR}/clickhouse-operator-install-template-v1beta1.yaml"
+declare -a ALL_YAML=("${CUR_DIR}/clickhouse-operator-install-v1beta1.yaml" "${CUR_DIR}/clickhouse-operator-install-template-v1beta1.yaml")
+for YAML in "${ALL_YAML[@]}"; do
+  yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .apiVersion) = "apiextensions.k8s.io/v1beta1"' "${YAML}"
+  yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.version) = .spec.versions[0].name' "${YAML}"
+  yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.additionalPrinterColumns) = .spec.versions[0].additionalPrinterColumns' "${YAML}"
+  sed -i -e 's/jsonPath/JSONPath/g' "${YAML}"
+  # yq eval -e --inplace '(select(.spec.additionalPrinterColumns[].JSONPath) = .spec.additionalPrinterColumns.[].jsonPath' "${YAML}"
+  yq eval -e --inplace 'del(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.additionalPrinterColumns[].jsonPath)' "${YAML}"
+  yq eval -e --inplace '(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.validation ) = .spec.versions[0].schema' "${YAML}"
+  yq eval -e --inplace 'del(select(documentIndex == 0 or documentIndex == 1 or documentIndex == 2) | .spec.versions)' "${YAML}"
+done

--- a/deploy/operator/build-clickhouse-operator-install-yaml.sh
+++ b/deploy/operator/build-clickhouse-operator-install-yaml.sh
@@ -182,3 +182,6 @@ OPERATOR_IMAGE="$OPERATOR_IMAGE" \
 METRICS_EXPORTER_IMAGE="$METRICS_EXPORTER_IMAGE" \
 OPERATOR_NAMESPACE="-" \
 "${MANIFEST_ROOT}/dev/cat-clickhouse-operator-install-yaml.sh" > "${CUR_DIR}/clickhouse-operator-install-service.yaml"
+
+# Build clickhouse-operator-install-v1beta1.yaml, need install https://github.com/mikefarah/yq
+source "${CUR_DIR}/build-clickhouse-operator-install-v1beta1-yaml.sh"

--- a/deploy/operator/clickhouse-operator-install-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,216 +11,82 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -248,422 +113,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -690,156 +388,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,216 +849,82 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -1083,422 +951,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -1525,156 +1226,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,116 +1687,122 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: namespaces
+          type: string
+          description: Watch namespaces
+          priority: 0 # show in standard view
+          jsonPath: .status
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            watchNamespaces:
-              type: array
-              items:
-                type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
-                type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
-                type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
+              properties:
+                watchNamespaces:
+                  type: array
+                  items:
+                    type: string
+                chCommonConfigsPath:
+                  type: string
+                chHostConfigsPath:
+                  type: string
+                chUsersConfigsPath:
+                  type: string
+                chiTemplatesPath:
+                  type: string
+                statefulSetUpdateTimeout:
+                  type: integer
+                statefulSetUpdatePollPeriod:
+                  type: integer
+                onStatefulSetCreateFailureAction:
+                  type: string
+                onStatefulSetUpdateFailureAction:
+                  type: string
+                chConfigUserDefaultProfile:
+                  type: string
+                chConfigUserDefaultQuota:
+                  type: string
+                chConfigUserDefaultNetworksIP:
+                  type: array
+                  items:
+                    type: string
+                chConfigUserDefaultPassword:
+                  type: string
+                chConfigNetworksHostRegexpTemplate:
+                  type: string
+                chUsername:
+                  type: string
+                chPassword:
+                  type: string
+                chCredentialsSecretNamespace:
+                  type: string
+                chCredentialsSecretName:
+                  type: string
+                chPort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                logtostderr:
+                  type: string
+                alsologtostderr:
+                  type: string
+                v:
+                  type: string
+                stderrthreshold:
+                  type: string
+                vmodule:
+                  type: string
+                log_backtrace_at:
+                  type: string
+                reconcileThreadsNumber:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                reconcileWaitExclude:
+                  type: string
+                reconcileWaitInclude:
+                  type: string
+                excludeFromPropagationLabels:
+                  type: array
+                  items:
+                    type: string
+                appendScopeLabels:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"

--- a/deploy/operator/clickhouse-operator-install-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-crd.yaml
@@ -73,21 +73,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -115,12 +139,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -148,89 +174,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -258,41 +311,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -300,36 +376,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -337,17 +456,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -355,75 +479,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -451,193 +621,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -645,6 +941,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -656,31 +953,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -701,7 +1019,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -709,30 +1030,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -740,6 +1067,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -760,6 +1088,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -771,15 +1100,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -787,23 +1128,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -812,19 +1169,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -832,10 +1206,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -916,21 +1293,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -958,12 +1359,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -991,89 +1394,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -1101,41 +1531,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -1143,36 +1596,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1180,17 +1676,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -1198,75 +1699,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -1294,193 +1841,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1488,6 +2161,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -1499,31 +2173,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -1544,7 +2239,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1552,30 +2250,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1583,6 +2287,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -1603,6 +2308,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -1614,15 +2320,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1630,23 +2348,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1655,19 +2389,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1675,10 +2426,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -1707,70 +2461,105 @@ spec:
           description: Watch namespaces
           priority: 0 # show in standard view
           jsonPath: .status
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
-              # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                allows define some of settings for `clickhouse-operator` itself,
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+                look to etc-clickhouse-operator* ConfigMaps if you need more control
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 watchNamespaces:
                   type: array
+                  description: "List of namespaces where clickhouse-operator watches for events."
                   items:
                     type: string
                 chCommonConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
                 chHostConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
                 chUsersConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
                 chiTemplatesPath:
                   type: string
+                  description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
                 statefulSetUpdateTimeout:
                   type: integer
+                  description: "How many seconds to wait for created/updated StatefulSet to be Ready"
                 statefulSetUpdatePollPeriod:
                   type: integer
+                  description: "How many seconds to wait between checks for created/updated StatefulSet status"
                 onStatefulSetCreateFailureAction:
                   type: string
+                  description: |
+                    What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. delete - delete newly created problematic StatefulSet.
+                    3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 onStatefulSetUpdateFailureAction:
                   type: string
+                  description: |
+                    What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                    3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 chConfigUserDefaultProfile:
                   type: string
+                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
                 chConfigUserDefaultQuota:
                   type: string
+                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
                 chConfigUserDefaultNetworksIP:
                   type: array
+                  description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
                   items:
                     type: string
                 chConfigUserDefaultPassword:
+                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
                   type: string
                 chConfigNetworksHostRegexpTemplate:
+                  description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
                   type: string
                 chUsername:
                   type: string
+                  description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chPassword:
                   type: string
+                  description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chCredentialsSecretNamespace:
                   type: string
+                  description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chCredentialsSecretName:
                   type: string
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chPort:
                   type: integer
                   minimum: 1
                   maximum: 65535
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 logtostderr:
                   type: string
+                  description: "boolean, allows logs to stderr"
                 alsologtostderr:
                   type: string
+                  description: "booleanm allows logs to stderr and files both"
                 v:
                   type: string
+                  description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
                 stderrthreshold:
                   type: string
                 vmodule:
@@ -1779,6 +2568,7 @@ spec:
                   type: string
                 reconcileThreadsNumber:
                   type: integer
+                  description: "how much goroutines will use to reconcile in parallel, 10 by default"
                   minimum: 1
                   maximum: 65535
                 reconcileWaitExclude:
@@ -1787,10 +2577,14 @@ spec:
                   type: string
                 excludeFromPropagationLabels:
                   type: array
+                  description: |
+                    When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                    exclude labels from the following list
                   items:
                     type: string
                 appendScopeLabels:
                   type: string
+                  description: "Whether to append *Scope* labels to StatefulSet and Pod"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -1816,3 +2610,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                    - "LabelShardScopeIndex"
+                    - "LabelReplicaScopeIndex"
+                    - "LabelCHIScopeIndex"
+                    - "LabelCHIScopeCycleSize"
+                    - "LabelCHIScopeCycleIndex"
+                    - "LabelCHIScopeCycleOffset"
+                    - "LabelClusterScopeIndex"
+                    - "LabelClusterScopeCycleSize"
+                    - "LabelClusterScopeCycleIndex"
+                    - "LabelClusterScopeCycleOffset"

--- a/deploy/operator/clickhouse-operator-install-template-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,216 +11,82 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -248,422 +113,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -690,156 +388,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,216 +849,82 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -1083,422 +951,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -1525,156 +1226,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,116 +1687,122 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: namespaces
+          type: string
+          description: Watch namespaces
+          priority: 0 # show in standard view
+          jsonPath: .status
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            watchNamespaces:
-              type: array
-              items:
-                type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
-                type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
-                type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
+              properties:
+                watchNamespaces:
+                  type: array
+                  items:
+                    type: string
+                chCommonConfigsPath:
+                  type: string
+                chHostConfigsPath:
+                  type: string
+                chUsersConfigsPath:
+                  type: string
+                chiTemplatesPath:
+                  type: string
+                statefulSetUpdateTimeout:
+                  type: integer
+                statefulSetUpdatePollPeriod:
+                  type: integer
+                onStatefulSetCreateFailureAction:
+                  type: string
+                onStatefulSetUpdateFailureAction:
+                  type: string
+                chConfigUserDefaultProfile:
+                  type: string
+                chConfigUserDefaultQuota:
+                  type: string
+                chConfigUserDefaultNetworksIP:
+                  type: array
+                  items:
+                    type: string
+                chConfigUserDefaultPassword:
+                  type: string
+                chConfigNetworksHostRegexpTemplate:
+                  type: string
+                chUsername:
+                  type: string
+                chPassword:
+                  type: string
+                chCredentialsSecretNamespace:
+                  type: string
+                chCredentialsSecretName:
+                  type: string
+                chPort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                logtostderr:
+                  type: string
+                alsologtostderr:
+                  type: string
+                v:
+                  type: string
+                stderrthreshold:
+                  type: string
+                vmodule:
+                  type: string
+                log_backtrace_at:
+                  type: string
+                reconcileThreadsNumber:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                reconcileWaitExclude:
+                  type: string
+                reconcileWaitInclude:
+                  type: string
+                excludeFromPropagationLabels:
+                  type: array
+                  items:
+                    type: string
+                appendScopeLabels:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"

--- a/deploy/operator/clickhouse-operator-install-template-crd.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-crd.yaml
@@ -73,21 +73,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -115,12 +139,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -148,89 +174,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -258,41 +311,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -300,36 +376,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -337,17 +456,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -355,75 +479,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -451,193 +621,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -645,6 +941,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -656,31 +953,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -701,7 +1019,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -709,30 +1030,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -740,6 +1067,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -760,6 +1088,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -771,15 +1100,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -787,23 +1128,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -812,19 +1169,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -832,10 +1206,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -916,21 +1293,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -958,12 +1359,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -991,89 +1394,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -1101,41 +1531,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -1143,36 +1596,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1180,17 +1676,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -1198,75 +1699,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -1294,193 +1841,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1488,6 +2161,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -1499,31 +2173,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -1544,7 +2239,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1552,30 +2250,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1583,6 +2287,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -1603,6 +2308,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -1614,15 +2320,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1630,23 +2348,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1655,19 +2389,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1675,10 +2426,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -1707,70 +2461,105 @@ spec:
           description: Watch namespaces
           priority: 0 # show in standard view
           jsonPath: .status
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
-              # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                allows define some of settings for `clickhouse-operator` itself,
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+                look to etc-clickhouse-operator* ConfigMaps if you need more control
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 watchNamespaces:
                   type: array
+                  description: "List of namespaces where clickhouse-operator watches for events."
                   items:
                     type: string
                 chCommonConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
                 chHostConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
                 chUsersConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
                 chiTemplatesPath:
                   type: string
+                  description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
                 statefulSetUpdateTimeout:
                   type: integer
+                  description: "How many seconds to wait for created/updated StatefulSet to be Ready"
                 statefulSetUpdatePollPeriod:
                   type: integer
+                  description: "How many seconds to wait between checks for created/updated StatefulSet status"
                 onStatefulSetCreateFailureAction:
                   type: string
+                  description: |
+                    What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. delete - delete newly created problematic StatefulSet.
+                    3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 onStatefulSetUpdateFailureAction:
                   type: string
+                  description: |
+                    What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                    3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 chConfigUserDefaultProfile:
                   type: string
+                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
                 chConfigUserDefaultQuota:
                   type: string
+                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
                 chConfigUserDefaultNetworksIP:
                   type: array
+                  description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
                   items:
                     type: string
                 chConfigUserDefaultPassword:
+                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
                   type: string
                 chConfigNetworksHostRegexpTemplate:
+                  description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
                   type: string
                 chUsername:
                   type: string
+                  description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chPassword:
                   type: string
+                  description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chCredentialsSecretNamespace:
                   type: string
+                  description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chCredentialsSecretName:
                   type: string
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chPort:
                   type: integer
                   minimum: 1
                   maximum: 65535
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 logtostderr:
                   type: string
+                  description: "boolean, allows logs to stderr"
                 alsologtostderr:
                   type: string
+                  description: "booleanm allows logs to stderr and files both"
                 v:
                   type: string
+                  description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
                 stderrthreshold:
                   type: string
                 vmodule:
@@ -1779,6 +2568,7 @@ spec:
                   type: string
                 reconcileThreadsNumber:
                   type: integer
+                  description: "how much goroutines will use to reconcile in parallel, 10 by default"
                   minimum: 1
                   maximum: 65535
                 reconcileWaitExclude:
@@ -1787,10 +2577,14 @@ spec:
                   type: string
                 excludeFromPropagationLabels:
                   type: array
+                  description: |
+                    When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                    exclude labels from the following list
                   items:
                     type: string
                 appendScopeLabels:
                   type: string
+                  description: "Whether to append *Scope* labels to StatefulSet and Pod"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -1816,3 +2610,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                    - "LabelShardScopeIndex"
+                    - "LabelReplicaScopeIndex"
+                    - "LabelCHIScopeIndex"
+                    - "LabelCHIScopeCycleSize"
+                    - "LabelCHIScopeCycleIndex"
+                    - "LabelCHIScopeCycleOffset"
+                    - "LabelClusterScopeIndex"
+                    - "LabelClusterScopeCycleSize"
+                    - "LabelClusterScopeCycleIndex"
+                    - "LabelClusterScopeCycleOffset"

--- a/deploy/operator/clickhouse-operator-install-template-rbac.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-rbac.yaml
@@ -127,6 +127,13 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -1,0 +1,2481 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clickhouseinstallations.clickhouse.altinity.com
+spec:
+  group: clickhouse.altinity.com
+  scope: Namespaced
+  names:
+    kind: ClickHouseInstallation
+    singular: clickhouseinstallation
+    plural: clickhouseinstallations
+    shortNames:
+      - chi
+  version: v1
+  additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      JSONPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      JSONPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      JSONPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      JSONPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      JSONPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      JSONPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      JSONPath: .status.endpoint
+  validation:
+    openAPIV3Schema:
+      type: object
+      # x-kubernetes-preserve-unknown-fields: true
+      properties:
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+        spec:
+          type: object
+          # x-kubernetes-preserve-unknown-fields: true
+          properties:
+            taskID:
+              type: string
+            # Need to be StringBool
+            stop:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            # Need to be StringBool
+            troubleshoot:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            namespaceDomainPattern:
+              type: string
+            templating:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+            reconciling:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+                configMapPropagationTimeout:
+                  type: integer
+                  minimum: 0
+                  maximum: 3600
+                cleanup:
+                  type: object
+                  nullable: true
+                  properties:
+                    unknownObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                    reconcileFailedObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+            defaults:
+              type: object
+              nullable: true
+              properties:
+                # Need to be StringBool
+                replicasUseFQDN:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                distributedDDL:
+                  type: object
+                  nullable: true
+                  properties:
+                    profile:
+                      type: string
+                templates:
+                  type: object
+                  nullable: true
+                  properties:
+                    hostTemplate:
+                      type: string
+                    podTemplate:
+                      type: string
+                    dataVolumeClaimTemplate:
+                      type: string
+                    logVolumeClaimTemplate:
+                      type: string
+                    serviceTemplate:
+                      type: string
+                    clusterServiceTemplate:
+                      type: string
+                    shardServiceTemplate:
+                      type: string
+                    replicaServiceTemplate:
+                      type: string
+            configuration:
+              type: object
+              nullable: true
+              properties:
+                zookeeper:
+                  type: object
+                  nullable: true
+                  properties:
+                    nodes:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - host
+                        properties:
+                          host:
+                            type: string
+                          port:
+                            type: integer
+                            minimum: 0
+                            maximum: 65535
+                    session_timeout_ms:
+                      type: integer
+                    operation_timeout_ms:
+                      type: integer
+                    root:
+                      type: string
+                    identity:
+                      type: string
+                users:
+                  type: object
+                  nullable: true
+                profiles:
+                  type: object
+                  nullable: true
+                quotas:
+                  type: object
+                  nullable: true
+                settings:
+                  type: object
+                  nullable: true
+                files:
+                  type: object
+                  nullable: true
+                clusters:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                        # See namePartClusterMaxLen const
+                        maxLength: 15
+                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                      zookeeper:
+                        type: object
+                        nullable: true
+                        properties:
+                          nodes:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - host
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          session_timeout_ms:
+                            type: integer
+                          operation_timeout_ms:
+                            type: integer
+                          root:
+                            type: string
+                          identity:
+                            type: string
+                      settings:
+                        type: object
+                        nullable: true
+                      files:
+                        type: object
+                        nullable: true
+                      templates:
+                        type: object
+                        nullable: true
+                        properties:
+                          hostTemplate:
+                            type: string
+                          podTemplate:
+                            type: string
+                          dataVolumeClaimTemplate:
+                            type: string
+                          logVolumeClaimTemplate:
+                            type: string
+                          serviceTemplate:
+                            type: string
+                          clusterServiceTemplate:
+                            type: string
+                          shardServiceTemplate:
+                            type: string
+                          replicaServiceTemplate:
+                            type: string
+                      layout:
+                        type: object
+                        nullable: true
+                        properties:
+                          # DEPRECATED - to be removed soon
+                          type:
+                            type: string
+                          shardsCount:
+                            type: integer
+                          replicasCount:
+                            type: integer
+                          shards:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                # DEPRECATED - to be removed soon
+                                definitionType:
+                                  type: string
+                                weight:
+                                  type: integer
+                                # Need to be StringBool
+                                internalReplication:
+                                  type: string
+                                  enum:
+                                    # List StringBoolXXX constants from model
+                                    - ""
+                                    - "0"
+                                    - "1"
+                                    - "False"
+                                    - "false"
+                                    - "True"
+                                    - "true"
+                                    - "No"
+                                    - "no"
+                                    - "Yes"
+                                    - "yes"
+                                    - "Off"
+                                    - "off"
+                                    - "On"
+                                    - "on"
+                                    - "Disable"
+                                    - "disable"
+                                    - "Enable"
+                                    - "enable"
+                                    - "Disabled"
+                                    - "disabled"
+                                    - "Enabled"
+                                    - "enabled"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTemplate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                replicasCount:
+                                  type: integer
+                                  minimum: 1
+                                replicas:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+                          replicas:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTeampate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                shardsCount:
+                                  type: integer
+                                  minimum: 1
+                                shards:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+            templates:
+              type: object
+              nullable: true
+              properties:
+                hostTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      portDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PortDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClusterScopeIndex"
+                      spec:
+                        # Host
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            minLength: 1
+                            # See namePartReplicaMaxLen const
+                            maxLength: 15
+                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                          tcpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          httpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          interserverHttpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          settings:
+                            type: object
+                            nullable: true
+                          files:
+                            type: object
+                            nullable: true
+                          templates:
+                            type: object
+                            nullable: true
+                            properties:
+                              hostTemplate:
+                                type: string
+                              podTemplate:
+                                type: string
+                              dataVolumeClaimTemplate:
+                                type: string
+                              logVolumeClaimTemplate:
+                                type: string
+                              serviceTemplate:
+                                type: string
+                              clusterServiceTemplate:
+                                type: string
+                              shardServiceTemplate:
+                                type: string
+                              replicaServiceTemplate:
+                                type: string
+                podTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      zone:
+                        type: object
+                        #required:
+                        #  - values
+                        properties:
+                          key:
+                            type: string
+                          values:
+                            type: array
+                            nullable: true
+                            items:
+                              type: string
+                      distribution:
+                        # DEPRECATED
+                        type: string
+                        enum:
+                          - ""
+                          - "Unspecified"
+                          - "OnePerHost"
+                      podDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PodDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClickHouseAntiAffinity"
+                                - "ShardAntiAffinity"
+                                - "ReplicaAntiAffinity"
+                                - "AnotherNamespaceAntiAffinity"
+                                - "AnotherClickHouseInstallationAntiAffinity"
+                                - "AnotherClusterAntiAffinity"
+                                - "MaxNumberPerNode"
+                                - "NamespaceAffinity"
+                                - "ClickHouseInstallationAffinity"
+                                - "ClusterAffinity"
+                                - "ShardAffinity"
+                                - "ReplicaAffinity"
+                                - "PreviousTailAffinity"
+                                - "CircularReplication"
+                            scope:
+                              type: string
+                              enum:
+                                # list PodDistributionScopeXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "Shard"
+                                - "Replica"
+                                - "Cluster"
+                                - "ClickHouseInstallation"
+                                - "Namespace"
+                            number:
+                              type: integer
+                              minimum: 0
+                              maximum: 65535
+                      spec:
+                        # TODO specify PodSpec
+                        type: object
+                        nullable: true
+                volumeClaimTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      reclaimPolicy:
+                        type: string
+                        enum:
+                          - ""
+                          - "Retain"
+                          - "Delete"
+                      metadata:
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify PersistentVolumeClaimSpec
+                        type: object
+                        nullable: true
+                serviceTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      metadata:
+                        # TODO specify ObjectMeta
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify ServiceSpec
+                        type: object
+                        nullable: true
+            useTemplates:
+              type: array
+              nullable: true
+              items:
+                type: object
+                #required:
+                #  - name
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  useType:
+                    type: string
+                    enum:
+                      # List useTypeXXX constants from model
+                      - ""
+                      - "merge"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clickhouseinstallationtemplates.clickhouse.altinity.com
+spec:
+  group: clickhouse.altinity.com
+  scope: Namespaced
+  names:
+    kind: ClickHouseInstallationTemplate
+    singular: clickhouseinstallationtemplate
+    plural: clickhouseinstallationtemplates
+    shortNames:
+      - chit
+  version: v1
+  additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      JSONPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      JSONPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      JSONPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      JSONPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      JSONPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      JSONPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      JSONPath: .status.endpoint
+  validation:
+    openAPIV3Schema:
+      type: object
+      # x-kubernetes-preserve-unknown-fields: true
+      properties:
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+        spec:
+          type: object
+          # x-kubernetes-preserve-unknown-fields: true
+          properties:
+            taskID:
+              type: string
+            # Need to be StringBool
+            stop:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            # Need to be StringBool
+            troubleshoot:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            namespaceDomainPattern:
+              type: string
+            templating:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+            reconciling:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+                configMapPropagationTimeout:
+                  type: integer
+                  minimum: 0
+                  maximum: 3600
+                cleanup:
+                  type: object
+                  nullable: true
+                  properties:
+                    unknownObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                    reconcileFailedObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+            defaults:
+              type: object
+              nullable: true
+              properties:
+                # Need to be StringBool
+                replicasUseFQDN:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                distributedDDL:
+                  type: object
+                  nullable: true
+                  properties:
+                    profile:
+                      type: string
+                templates:
+                  type: object
+                  nullable: true
+                  properties:
+                    hostTemplate:
+                      type: string
+                    podTemplate:
+                      type: string
+                    dataVolumeClaimTemplate:
+                      type: string
+                    logVolumeClaimTemplate:
+                      type: string
+                    serviceTemplate:
+                      type: string
+                    clusterServiceTemplate:
+                      type: string
+                    shardServiceTemplate:
+                      type: string
+                    replicaServiceTemplate:
+                      type: string
+            configuration:
+              type: object
+              nullable: true
+              properties:
+                zookeeper:
+                  type: object
+                  nullable: true
+                  properties:
+                    nodes:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - host
+                        properties:
+                          host:
+                            type: string
+                          port:
+                            type: integer
+                            minimum: 0
+                            maximum: 65535
+                    session_timeout_ms:
+                      type: integer
+                    operation_timeout_ms:
+                      type: integer
+                    root:
+                      type: string
+                    identity:
+                      type: string
+                users:
+                  type: object
+                  nullable: true
+                profiles:
+                  type: object
+                  nullable: true
+                quotas:
+                  type: object
+                  nullable: true
+                settings:
+                  type: object
+                  nullable: true
+                files:
+                  type: object
+                  nullable: true
+                clusters:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                        # See namePartClusterMaxLen const
+                        maxLength: 15
+                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                      zookeeper:
+                        type: object
+                        nullable: true
+                        properties:
+                          nodes:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - host
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          session_timeout_ms:
+                            type: integer
+                          operation_timeout_ms:
+                            type: integer
+                          root:
+                            type: string
+                          identity:
+                            type: string
+                      settings:
+                        type: object
+                        nullable: true
+                      files:
+                        type: object
+                        nullable: true
+                      templates:
+                        type: object
+                        nullable: true
+                        properties:
+                          hostTemplate:
+                            type: string
+                          podTemplate:
+                            type: string
+                          dataVolumeClaimTemplate:
+                            type: string
+                          logVolumeClaimTemplate:
+                            type: string
+                          serviceTemplate:
+                            type: string
+                          clusterServiceTemplate:
+                            type: string
+                          shardServiceTemplate:
+                            type: string
+                          replicaServiceTemplate:
+                            type: string
+                      layout:
+                        type: object
+                        nullable: true
+                        properties:
+                          # DEPRECATED - to be removed soon
+                          type:
+                            type: string
+                          shardsCount:
+                            type: integer
+                          replicasCount:
+                            type: integer
+                          shards:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                # DEPRECATED - to be removed soon
+                                definitionType:
+                                  type: string
+                                weight:
+                                  type: integer
+                                # Need to be StringBool
+                                internalReplication:
+                                  type: string
+                                  enum:
+                                    # List StringBoolXXX constants from model
+                                    - ""
+                                    - "0"
+                                    - "1"
+                                    - "False"
+                                    - "false"
+                                    - "True"
+                                    - "true"
+                                    - "No"
+                                    - "no"
+                                    - "Yes"
+                                    - "yes"
+                                    - "Off"
+                                    - "off"
+                                    - "On"
+                                    - "on"
+                                    - "Disable"
+                                    - "disable"
+                                    - "Enable"
+                                    - "enable"
+                                    - "Disabled"
+                                    - "disabled"
+                                    - "Enabled"
+                                    - "enabled"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTemplate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                replicasCount:
+                                  type: integer
+                                  minimum: 1
+                                replicas:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+                          replicas:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTeampate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                shardsCount:
+                                  type: integer
+                                  minimum: 1
+                                shards:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+            templates:
+              type: object
+              nullable: true
+              properties:
+                hostTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      portDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PortDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClusterScopeIndex"
+                      spec:
+                        # Host
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            minLength: 1
+                            # See namePartReplicaMaxLen const
+                            maxLength: 15
+                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                          tcpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          httpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          interserverHttpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          settings:
+                            type: object
+                            nullable: true
+                          files:
+                            type: object
+                            nullable: true
+                          templates:
+                            type: object
+                            nullable: true
+                            properties:
+                              hostTemplate:
+                                type: string
+                              podTemplate:
+                                type: string
+                              dataVolumeClaimTemplate:
+                                type: string
+                              logVolumeClaimTemplate:
+                                type: string
+                              serviceTemplate:
+                                type: string
+                              clusterServiceTemplate:
+                                type: string
+                              shardServiceTemplate:
+                                type: string
+                              replicaServiceTemplate:
+                                type: string
+                podTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      zone:
+                        type: object
+                        #required:
+                        #  - values
+                        properties:
+                          key:
+                            type: string
+                          values:
+                            type: array
+                            nullable: true
+                            items:
+                              type: string
+                      distribution:
+                        # DEPRECATED
+                        type: string
+                        enum:
+                          - ""
+                          - "Unspecified"
+                          - "OnePerHost"
+                      podDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PodDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClickHouseAntiAffinity"
+                                - "ShardAntiAffinity"
+                                - "ReplicaAntiAffinity"
+                                - "AnotherNamespaceAntiAffinity"
+                                - "AnotherClickHouseInstallationAntiAffinity"
+                                - "AnotherClusterAntiAffinity"
+                                - "MaxNumberPerNode"
+                                - "NamespaceAffinity"
+                                - "ClickHouseInstallationAffinity"
+                                - "ClusterAffinity"
+                                - "ShardAffinity"
+                                - "ReplicaAffinity"
+                                - "PreviousTailAffinity"
+                                - "CircularReplication"
+                            scope:
+                              type: string
+                              enum:
+                                # list PodDistributionScopeXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "Shard"
+                                - "Replica"
+                                - "Cluster"
+                                - "ClickHouseInstallation"
+                                - "Namespace"
+                            number:
+                              type: integer
+                              minimum: 0
+                              maximum: 65535
+                      spec:
+                        # TODO specify PodSpec
+                        type: object
+                        nullable: true
+                volumeClaimTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      reclaimPolicy:
+                        type: string
+                        enum:
+                          - ""
+                          - "Retain"
+                          - "Delete"
+                      metadata:
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify PersistentVolumeClaimSpec
+                        type: object
+                        nullable: true
+                serviceTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      metadata:
+                        # TODO specify ObjectMeta
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify ServiceSpec
+                        type: object
+                        nullable: true
+            useTemplates:
+              type: array
+              nullable: true
+              items:
+                type: object
+                #required:
+                #  - name
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  useType:
+                    type: string
+                    enum:
+                      # List useTypeXXX constants from model
+                      - ""
+                      - "merge"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clickhouseoperatorconfigurations.clickhouse.altinity.com
+spec:
+  group: clickhouse.altinity.com
+  scope: Namespaced
+  names:
+    kind: ClickHouseOperatorConfiguration
+    singular: clickhouseoperatorconfiguration
+    plural: clickhouseoperatorconfigurations
+    shortNames:
+      - chopconf
+  version: v1
+  additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      JSONPath: .status
+  validation:
+    openAPIV3Schema:
+      type: object
+      # x-kubernetes-preserve-unknown-fields: true
+      properties:
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+        spec:
+          type: object
+          # x-kubernetes-preserve-unknown-fields: true
+          properties:
+            watchNamespaces:
+              type: array
+              items:
+                type: string
+            chCommonConfigsPath:
+              type: string
+            chHostConfigsPath:
+              type: string
+            chUsersConfigsPath:
+              type: string
+            chiTemplatesPath:
+              type: string
+            statefulSetUpdateTimeout:
+              type: integer
+            statefulSetUpdatePollPeriod:
+              type: integer
+            onStatefulSetCreateFailureAction:
+              type: string
+            onStatefulSetUpdateFailureAction:
+              type: string
+            chConfigUserDefaultProfile:
+              type: string
+            chConfigUserDefaultQuota:
+              type: string
+            chConfigUserDefaultNetworksIP:
+              type: array
+              items:
+                type: string
+            chConfigUserDefaultPassword:
+              type: string
+            chConfigNetworksHostRegexpTemplate:
+              type: string
+            chUsername:
+              type: string
+            chPassword:
+              type: string
+            chCredentialsSecretNamespace:
+              type: string
+            chCredentialsSecretName:
+              type: string
+            chPort:
+              type: integer
+              minimum: 1
+              maximum: 65535
+            logtostderr:
+              type: string
+            alsologtostderr:
+              type: string
+            v:
+              type: string
+            stderrthreshold:
+              type: string
+            vmodule:
+              type: string
+            log_backtrace_at:
+              type: string
+            reconcileThreadsNumber:
+              type: integer
+              minimum: 1
+              maximum: 65535
+            reconcileWaitExclude:
+              type: string
+            reconcileWaitInclude:
+              type: string
+            excludeFromPropagationLabels:
+              type: array
+              items:
+                type: string
+            appendScopeLabels:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+#
+# Setup ServiceAccount
+# ServiceAccount would be created in kubectl-specified namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clickhouse-operator
+  namespace: $OPERATOR_NAMESPACE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clickhouse-operator-$OPERATOR_NAMESPACE
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - pods
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resourceNames:
+      - clickhouse-operator
+    resources:
+      - deployments
+    verbs:
+      - get
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations
+      - clickhouseinstallationtemplates
+      - clickhouseoperatorconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
+# ClusterRoleBinding is namespace-less and must have unique name
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clickhouse-operator-$OPERATOR_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clickhouse-operator-$OPERATOR_NAMESPACE
+subjects:
+  - kind: ServiceAccount
+    name: clickhouse-operator
+    namespace: $OPERATOR_NAMESPACE
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+# $OPERATOR_IMAGE
+# etc-clickhouse-operator-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-files
+  namespace: $OPERATOR_NAMESPACE
+  labels:
+    app: clickhouse-operator
+data:
+  config.yaml: |
+    ################################################
+    ##
+    ## Watch Namespaces Section
+    ##
+    ################################################
+
+    # List of namespaces where clickhouse-operator watches for events.
+    # Concurrently running operators should watch on different namespaces
+    #watchNamespaces:
+    #  - dev
+    #  - test
+    #  - info
+    #  - onemore
+
+    ################################################
+    ##
+    ## Additional Configuration Files Section
+    ##
+    ################################################
+
+    # Path to folder where ClickHouse configuration files common for all instances within CHI are located.
+    chCommonConfigsPath: config.d
+
+    # Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located.
+    chHostConfigsPath: conf.d
+
+    # Path to folder where ClickHouse configuration files with users settings are located.
+    # Files are common for all instances within CHI
+    chUsersConfigsPath: users.d
+
+    # Path to folder where ClickHouseInstallation .yaml manifests are located.
+    # Manifests are applied in sorted alpha-numeric order
+    chiTemplatesPath: templates.d
+
+    ################################################
+    ##
+    ## Cluster Create/Update/Delete Objects Section
+    ##
+    ################################################
+
+    # How many seconds to wait for created/updated StatefulSet to be Ready
+    statefulSetUpdateTimeout: 300
+
+    # How many seconds to wait between checks for created/updated StatefulSet status
+    statefulSetUpdatePollPeriod: 5
+
+    # What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+    # Possible options:
+    # 1. abort - do nothing, just break the process and wait for admin
+    # 2. delete - delete newly created problematic StatefulSet
+    # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+    onStatefulSetCreateFailureAction: ignore
+
+    # What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+    # Possible options:
+    # 1. abort - do nothing, just break the process and wait for admin
+    # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
+    # Pod would be recreated by StatefulSet based on rollback-ed configuration
+    # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+    onStatefulSetUpdateFailureAction: rollback
+
+    ################################################
+    ##
+    ## ClickHouse Settings Section
+    ##
+    ################################################
+
+    # Default values for ClickHouse user configuration
+    # 1. user/profile - string
+    # 2. user/quota - string
+    # 3. user/networks/ip - multiple strings
+    # 4. user/password - string
+    chConfigUserDefaultProfile: default
+    chConfigUserDefaultQuota: default
+    chConfigUserDefaultNetworksIP:
+      - "::1"
+      - "127.0.0.1"
+    chConfigUserDefaultPassword: "default"
+
+    # Default host_regexp to limit network connectivity from outside
+    chConfigNetworksHostRegexpTemplate: "(chi-{chi}-[^.]+\\d+-\\d+|clickhouse\\-{chi})\\.{namespace}\\.svc\\.cluster\\.local$"
+
+    ################################################
+    ##
+    ## Access to ClickHouse instances
+    ##
+    ################################################
+
+    # ClickHouse credentials (username, password and port) to be used by operator to connect to ClickHouse instances
+    # for:
+    # 1. Metrics requests
+    # 2. Schema maintenance
+    # 3. DROP DNS CACHE
+    # User with such credentials can be specified in additional ClickHouse .xml config files,
+    # located in `chUsersConfigsPath` folder
+    chUsername: clickhouse_operator
+    chPassword: clickhouse_operator_password
+
+    # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
+    # Can be used instead of explicitly specified username and password
+    chCredentialsSecretNamespace: ""
+    chCredentialsSecretName: ""
+
+    # Port where to connect to ClickHouse instances to
+    chPort: 8123
+
+    ################################################
+    ##
+    ## Log parameters
+    ##
+    ################################################
+
+    logtostderr: "true"
+    alsologtostderr: "false"
+    v: "1"
+    stderrthreshold: ""
+    vmodule: ""
+    log_backtrace_at: ""
+
+    ################################################
+    ##
+    ## Runtime parameters
+    ##
+    ################################################
+
+    # Max number of concurrent reconciles in progress
+    reconcileThreadsNumber: 10
+    reconcileWaitExclude: false
+    reconcileWaitInclude: false
+
+    ################################################
+    ##
+    ## Labels management parameters
+    ##
+    ################################################
+
+    # When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+    # exclude labels from the following list:
+    #excludeFromPropagationLabels:
+    #  - "labelA"
+    #  - "labelB"
+
+    # Whether to append *Scope* labels to StatefulSet and Pod.
+    # Full list of available *scope* labels check in labeler.go
+    #  LabelShardScopeIndex
+    #  LabelReplicaScopeIndex
+    #  LabelCHIScopeIndex
+    #  LabelCHIScopeCycleSize
+    #  LabelCHIScopeCycleIndex
+    #  LabelCHIScopeCycleOffset
+    #  LabelClusterScopeIndex
+    #  LabelClusterScopeCycleSize
+    #  LabelClusterScopeCycleIndex
+    #  LabelClusterScopeCycleOffset
+    appendScopeLabels: "no"
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+# $OPERATOR_IMAGE
+# etc-clickhouse-operator-confd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-confd-files
+  namespace: $OPERATOR_NAMESPACE
+  labels:
+    app: clickhouse-operator
+data:
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+# $OPERATOR_IMAGE
+# etc-clickhouse-operator-configd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-configd-files
+  namespace: $OPERATOR_NAMESPACE
+  labels:
+    app: clickhouse-operator
+data:
+  01-clickhouse-01-listen.xml: |
+    <yandex>
+        <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
+        <listen_host>::</listen_host>
+        <listen_host>0.0.0.0</listen_host>
+        <listen_try>1</listen_try>
+    </yandex>
+  01-clickhouse-02-logger.xml: |
+    <yandex>
+        <logger>
+            <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
+            <level>debug</level>
+            <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+            <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+            <size>1000M</size>
+            <count>10</count>
+            <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->
+            <console>1</console>
+        </logger>
+    </yandex>
+  01-clickhouse-03-query_log.xml: |
+    <yandex>
+        <query_log replace="1">
+            <database>system</database>
+            <table>query_log</table>
+            <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        </query_log>
+        <query_thread_log remove="1"/>
+    </yandex>
+  01-clickhouse-04-part_log.xml: |
+    <yandex>
+        <part_log replace="1">
+            <database>system</database>
+            <table>part_log</table>
+            <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        </part_log>
+    </yandex>
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+# $OPERATOR_IMAGE
+# etc-clickhouse-operator-templatesd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-templatesd-files
+  namespace: $OPERATOR_NAMESPACE
+  labels:
+    app: clickhouse-operator
+data:
+  001-templates.json.example: |
+    {
+      "apiVersion": "clickhouse.altinity.com/v1",
+      "kind": "ClickHouseInstallationTemplate",
+      "metadata": {
+        "name": "01-default-volumeclaimtemplate"
+      },
+      "spec": {
+        "templates": {
+          "volumeClaimTemplates": [
+            {
+              "name": "chi-default-volume-claim-template",
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "2Gi"
+                  }
+                }
+              }
+            }
+          ],
+          "podTemplates": [
+            {
+              "name": "chi-default-oneperhost-pod-template",
+              "distribution": "OnePerHost",
+              "spec": {
+                "containers" : [
+                  {
+                    "name": "clickhouse",
+                    "image": "yandex/clickhouse-server:19.3.7",
+                    "ports": [
+                      {
+                        "name": "http",
+                        "containerPort": 8123
+                      },
+                      {
+                        "name": "client",
+                        "containerPort": 9000
+                      },
+                      {
+                        "name": "interserver",
+                        "containerPort": 9009
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  default-pod-template.yaml.example: |
+    apiVersion: "clickhouse.altinity.com/v1"
+    kind: "ClickHouseInstallationTemplate"
+    metadata:
+      name: "default-oneperhost-pod-template"
+    spec:
+      templates:
+        podTemplates:
+          - name: default-oneperhost-pod-template
+            distribution: "OnePerHost"
+  default-storage-template.yaml.example: |
+    apiVersion: "clickhouse.altinity.com/v1"
+    kind: "ClickHouseInstallationTemplate"
+    metadata:
+      name: "default-storage-template-2Gi"
+    spec:
+      templates:
+        volumeClaimTemplates:
+          - name: default-storage-template-2Gi
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+  readme: |
+    Templates in this folder are packaged with an operator and available via 'useTemplate'
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+# $OPERATOR_IMAGE
+# etc-clickhouse-operator-usersd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-usersd-files
+  namespace: $OPERATOR_NAMESPACE
+  labels:
+    app: clickhouse-operator
+data:
+  01-clickhouse-user.xml: |
+    <yandex>
+        <users>
+            <clickhouse_operator>
+                <networks>
+                    <ip>127.0.0.1</ip>
+                    <ip>0.0.0.0/0</ip>
+                    <ip>::/0</ip>
+                </networks>
+                <password_sha256_hex>716b36073a90c6fe1d445ac1af85f4777c5b7a155cea359961826a030513e448</password_sha256_hex>
+                <profile>clickhouse_operator</profile>
+                <quota>default</quota>
+            </clickhouse_operator>
+        </users>
+        <profiles>
+            <clickhouse_operator>
+                <log_queries>0</log_queries>
+                <skip_unavailable_shards>1</skip_unavailable_shards>
+                <http_connection_timeout>10</http_connection_timeout>
+            </clickhouse_operator>
+        </profiles>
+    </yandex>
+  02-clickhouse-default-profile.xml: |
+    <yandex>
+      <profiles>
+        <default>
+          <log_queries>1</log_queries>
+          <connect_timeout_with_failover_ms>1000</connect_timeout_with_failover_ms>
+          <distributed_aggregation_memory_efficient>1</distributed_aggregation_memory_efficient>
+          <parallel_view_processing>1</parallel_view_processing>
+        </default>
+      </profiles>
+    </yandex>
+  03-database-ordinary.xml: |
+    <!--  Remove it for ClickHouse versions before 20.4 -->
+    <yandex>
+        <profiles>
+            <default>
+                <default_database_engine>Ordinary</default_database_engine>
+            </default>
+        </profiles>
+    </yandex>
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+# $OPERATOR_IMAGE
+# $METRICS_EXPORTER_IMAGE
+#
+# Setup Deployment for clickhouse-operator
+# Deployment would be created in kubectl-specified namespace
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: clickhouse-operator
+  namespace: $OPERATOR_NAMESPACE
+  labels:
+    app: clickhouse-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse-operator
+  template:
+    metadata:
+      labels:
+        app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
+    spec:
+      serviceAccountName: clickhouse-operator
+      volumes:
+        - name: etc-clickhouse-operator-folder
+          configMap:
+            name: etc-clickhouse-operator-files
+        - name: etc-clickhouse-operator-confd-folder
+          configMap:
+            name: etc-clickhouse-operator-confd-files
+        - name: etc-clickhouse-operator-configd-folder
+          configMap:
+            name: etc-clickhouse-operator-configd-files
+        - name: etc-clickhouse-operator-templatesd-folder
+          configMap:
+            name: etc-clickhouse-operator-templatesd-files
+        - name: etc-clickhouse-operator-usersd-folder
+          configMap:
+            name: etc-clickhouse-operator-usersd-files
+      containers:
+        - name: clickhouse-operator
+          image: $OPERATOR_IMAGE
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: etc-clickhouse-operator-folder
+              mountPath: /etc/clickhouse-operator
+            - name: etc-clickhouse-operator-confd-folder
+              mountPath: /etc/clickhouse-operator/conf.d
+            - name: etc-clickhouse-operator-configd-folder
+              mountPath: /etc/clickhouse-operator/config.d
+            - name: etc-clickhouse-operator-templatesd-folder
+              mountPath: /etc/clickhouse-operator/templates.d
+            - name: etc-clickhouse-operator-usersd-folder
+              mountPath: /etc/clickhouse-operator/users.d
+          env:
+            # Pod-specific
+            # spec.nodeName: ip-172-20-52-62.ec2.internal
+            - name: OPERATOR_POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # metadata.name: clickhouse-operator-6f87589dbb-ftcsf
+            - name: OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # metadata.namespace: kube-system
+            - name: OPERATOR_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # status.podIP: 100.96.3.2
+            - name: OPERATOR_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # spec.serviceAccount: clickhouse-operator
+            # spec.serviceAccountName: clickhouse-operator
+            - name: OPERATOR_POD_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            # Container-specific
+            - name: OPERATOR_CONTAINER_CPU_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: requests.cpu
+            - name: OPERATOR_CONTAINER_CPU_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: limits.cpu
+            - name: OPERATOR_CONTAINER_MEM_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: requests.memory
+            - name: OPERATOR_CONTAINER_MEM_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: limits.memory
+        - name: metrics-exporter
+          image: $METRICS_EXPORTER_IMAGE
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: etc-clickhouse-operator-folder
+              mountPath: /etc/clickhouse-operator
+            - name: etc-clickhouse-operator-confd-folder
+              mountPath: /etc/clickhouse-operator/conf.d
+            - name: etc-clickhouse-operator-configd-folder
+              mountPath: /etc/clickhouse-operator/config.d
+            - name: etc-clickhouse-operator-templatesd-folder
+              mountPath: /etc/clickhouse-operator/templates.d
+            - name: etc-clickhouse-operator-usersd-folder
+              mountPath: /etc/clickhouse-operator/users.d
+---
+# Possible Template Parameters:
+#
+# $OPERATOR_NAMESPACE
+#
+# Setup ClusterIP Service to provide monitoring metrics for Prometheus
+# Service would be created in kubectl-specified namespace
+# In order to get access outside of k8s it should be exposed as:
+# kubectl --namespace prometheus port-forward service/prometheus 9090
+# and point browser to localhost:9090
+kind: Service
+apiVersion: v1
+metadata:
+  name: clickhouse-operator-metrics
+  namespace: $OPERATOR_NAMESPACE
+  labels:
+    app: clickhouse-operator
+spec:
+  ports:
+    - port: 8888
+      name: clickhouse-operator-metrics
+  selector:
+    app: clickhouse-operator

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -70,21 +70,41 @@ spec:
       JSONPath: .status.endpoint
   validation:
     openAPIV3Schema:
+      description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
       type: object
-      # x-kubernetes-preserve-unknown-fields: true
+      required:
+        - spec
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         status:
           type: object
+          description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
           x-kubernetes-preserve-unknown-fields: true
         spec:
           type: object
           # x-kubernetes-preserve-unknown-fields: true
+          description: |
+            Specification of the desired behavior of one or more ClickHouse clusters
+            More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
           properties:
             taskID:
               type: string
+              description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
             # Need to be StringBool
             stop:
               type: string
+              description: |
+                Allow stop all ClickHouse clusters described in current chi.
+                Stop mechanism works as follows:
+                 - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                 - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -112,12 +132,14 @@ spec:
                 - "enabled"
             restart:
               type: string
+              description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
               enum:
                 - ""
                 - "RollingUpdate"
             # Need to be StringBool
             troubleshoot:
               type: string
+              description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -145,89 +167,116 @@ spec:
                 - "enabled"
             namespaceDomainPattern:
               type: string
+              description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
             templating:
               type: object
-              nullable: true
+              # nullable: true
+              description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
               properties:
                 policy:
                   type: string
+                  description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                  enum:
+                    - "auto"
+                    - "manual"
             reconciling:
               type: object
-              nullable: true
+              description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+              # nullable: true
               properties:
                 policy:
                   type: string
                 configMapPropagationTimeout:
                   type: integer
+                  description: |
+                    timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                    see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                   minimum: 0
                   maximum: 3600
                 cleanup:
                   type: object
-                  nullable: true
+                  description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                  # nullable: true
                   properties:
                     unknownObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for unknown StatefulSet, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for unknown PVC, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for unknown ConfigMap, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for unknown Service, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                     reconcileFailedObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for failed PVC reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for failed Service reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
             defaults:
               type: object
-              nullable: true
+              description: |
+                define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+              # nullable: true
               properties:
                 # Need to be StringBool
                 replicasUseFQDN:
                   type: string
+                  description: |
+                    define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                    "yes" by default
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -255,41 +304,64 @@ spec:
                     - "enabled"
                 distributedDDL:
                   type: object
-                  nullable: true
+                  description: |
+                    allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                    More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                  # nullable: true
                   properties:
                     profile:
                       type: string
+                      description: "Settings from this profile will be used to execute DDL queries"
                 templates:
                   type: object
-                  nullable: true
+                  description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                  # nullable: true
                   properties:
                     hostTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                     podTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     dataVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     logVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     serviceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                     clusterServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                     shardServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                     replicaServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                    volumeClaimTemplate:
+                      type: string
+                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             configuration:
               type: object
-              nullable: true
+              description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+              # nullable: true
               properties:
                 zookeeper:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                    `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                    currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                    More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                  # nullable: true
                   properties:
                     nodes:
                       type: array
-                      nullable: true
+                      description: "describe every available zookeeper cluster node for interaction"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -297,36 +369,79 @@ spec:
                         properties:
                           host:
                             type: string
+                            description: "dns name or ip address for Zookeeper node"
                           port:
                             type: integer
+                            description: "TCP port which used to connect to Zookeeper node"
                             minimum: 0
                             maximum: 65535
                     session_timeout_ms:
                       type: integer
+                      description: "session timeout during connect to Zookeeper"
                     operation_timeout_ms:
                       type: integer
+                      description: "one operation timeout during Zookeeper transactions"
                     root:
                       type: string
+                      description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                     identity:
                       type: string
+                      description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                 users:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure password hashed, authorization restrictions, database level security row filters etc.
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 profiles:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of settings profile
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 quotas:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of resource quotas
+                    More details: https://clickhouse.tech/docs/en/operations/quotas/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 settings:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 files:
                   type: object
-                  nullable: true
+                  description: |
+                    allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                    every key in this object is the file name
+                    every value in this object is the file content
+                    you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                    each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                    More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 clusters:
                   type: array
-                  nullable: true
+                  description: |
+                    describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                    every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                    all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                    Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                    If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -334,17 +449,22 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                         minLength: 1
                         # See namePartClusterMaxLen const
                         maxLength: 15
                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                       zookeeper:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.zookeeper` settings
+                        # nullable: true
                         properties:
                           nodes:
                             type: array
-                            nullable: true
+                            description: "describe every available zookeeper cluster node for interaction"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -352,75 +472,120 @@ spec:
                               properties:
                                 host:
                                   type: string
+                                  description: "dns name or ip address for Zookeeper node"
                                 port:
                                   type: integer
+                                  description: "TCP port which used to connect to Zookeeper node"
                                   minimum: 0
                                   maximum: 65535
                           session_timeout_ms:
                             type: integer
+                            description: "session timeout during connect to Zookeeper"
                           operation_timeout_ms:
                             type: integer
+                            description: "one operation timeout during Zookeeper transactions"
                           root:
                             type: string
+                            description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                           identity:
                             type: string
+                            description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                       settings:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.settings`
+                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       files:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                          override top-level `chi.spec.configuration.files`
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       templates:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                          override top-level `chi.spec.configuration.templates`
+                        # nullable: true
                         properties:
                           hostTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                           podTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           dataVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           logVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           serviceTemplate:
                             type: string
+                            description: "optional, fully ignores for cluster-level"
                           clusterServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           shardServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           replicaServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                          volumeClaimTemplate:
+                            type: string
+                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                       layout:
                         type: object
-                        nullable: true
+                        description: |
+                          describe current cluster layout, how much shards in cluster, how much replica in shard
+                          allows override settings on each shard and replica separatelly
+                        # nullable: true
                         properties:
-                          # DEPRECATED - to be removed soon
                           type:
                             type: string
+                            description: "DEPRECATED - to be removed soon"
                           shardsCount:
                             type: integer
+                            description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                           replicasCount:
                             type: integer
+                            description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                           shards:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
                                 definitionType:
                                   type: string
+                                  description: "DEPRECATED - to be removed soon"
                                 weight:
                                   type: integer
+                                  description: |
+                                    optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                 # Need to be StringBool
                                 internalReplication:
                                   type: string
+                                  description: |
+                                    optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                    allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                   enum:
                                     # List StringBoolXXX constants from model
                                     - ""
@@ -448,193 +613,319 @@ spec:
                                     - "enabled"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                    override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                    override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
                                     hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 replicasCount:
                                   type: integer
+                                  description: |
+                                    optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                    shard contains 1 replica by default
+                                    override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                   minimum: 1
                                 replicas:
                                   type: array
-                                  nullable: true
+                                  description: |
+                                    optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           replicas:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                    override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  # nullable: true
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                    override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
-                                    hostTeampate:
+                                    hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 shardsCount:
                                   type: integer
+                                  description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                   minimum: 1
                                 shards:
                                   type: array
-                                  nullable: true
+                                  description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             templates:
               type: object
-              nullable: true
+              description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+              # nullable: true
               properties:
                 hostTemplates:
                   type: array
-                  nullable: true
+                  description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                  # nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
                     properties:
                       name:
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                         type: string
                       portDistribution:
                         type: array
-                        nullable: true
+                        description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -642,6 +933,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                               enum:
                                 # List PortDistributionXXX constants
                                 - ""
@@ -653,31 +945,52 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                             minLength: 1
                             # See namePartReplicaMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           tcpPort:
                             type: integer
+                            description: |
+                              optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
                           httpPort:
                             type: integer
+                            description: |
+                              optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/http/
                             minimum: 1
                             maximum: 65535
-                          interserverHttpPort:
+                          interserverHTTPPort:
                             type: integer
+                            description: |
+                              optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                              More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                             minimum: 1
                             maximum: 65535
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
@@ -697,7 +1010,10 @@ spec:
                                 type: string
                 podTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                    More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -705,30 +1021,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                       generateName:
                         type: string
+                        description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       zone:
                         type: object
+                        description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         #required:
                         #  - values
                         properties:
                           key:
                             type: string
+                            description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                           values:
                             type: array
-                            nullable: true
+                            description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                            # nullable: true
                             items:
                               type: string
                       distribution:
-                        # DEPRECATED
                         type: string
+                        description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         enum:
                           - ""
                           - "Unspecified"
                           - "OnePerHost"
                       podDistribution:
                         type: array
-                        nullable: true
+                        description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -736,6 +1058,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "you can define multiple affinity policy types"
                               enum:
                                 # List PodDistributionXXX constants
                                 - ""
@@ -756,6 +1079,7 @@ spec:
                                 - "CircularReplication"
                             scope:
                               type: string
+                              description: "scope for apply each podDistribution"
                               enum:
                                 # list PodDistributionScopeXXX constants
                                 - ""
@@ -767,15 +1091,26 @@ spec:
                                 - "Namespace"
                             number:
                               type: integer
+                              description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                               minimum: 0
                               maximum: 65535
                       spec:
                         # TODO specify PodSpec
                         type: object
-                        nullable: true
+                        description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
+                      metadata:
+                        type: object
+                        description: |
+                          allows pass standard object's metadata from template to Pod
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 volumeClaimTemplates:
                   type: array
-                  nullable: true
+                  description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -783,23 +1118,39 @@ spec:
                     #  - spec
                     properties:
                       name:
+                        description: |
+                          template name, could use to link inside
+                          top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                          cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                         type: string
                       reclaimPolicy:
                         type: string
+                        description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                         enum:
                           - ""
                           - "Retain"
                           - "Delete"
                       metadata:
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to PVC
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
-                        # TODO specify PersistentVolumeClaimSpec
                         type: object
-                        nullable: true
+                        description: |
+                          allows define all aspects of `PVC` resource
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 serviceTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -808,19 +1159,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: |
+                          template name, could use to link inside
+                          chi-level `chi.spec.defaults.templates.serviceTemplate`
+                          cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                       generateName:
                         type: string
+                        description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       metadata:
                         # TODO specify ObjectMeta
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to Service
+                          Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
                         # TODO specify ServiceSpec
                         type: object
-                        nullable: true
+                        description: |
+                          describe behavior of generated Service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
             useTemplates:
               type: array
-              nullable: true
+              description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+              # nullable: true
               items:
                 type: object
                 #required:
@@ -828,10 +1196,13 @@ spec:
                 properties:
                   name:
                     type: string
+                    description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                   namespace:
                     type: string
+                    description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                   useType:
                     type: string
+                    description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                     enum:
                       # List useTypeXXX constants from model
                       - ""
@@ -909,21 +1280,41 @@ spec:
       JSONPath: .status.endpoint
   validation:
     openAPIV3Schema:
+      description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
       type: object
-      # x-kubernetes-preserve-unknown-fields: true
+      required:
+        - spec
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         status:
           type: object
+          description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
           x-kubernetes-preserve-unknown-fields: true
         spec:
           type: object
           # x-kubernetes-preserve-unknown-fields: true
+          description: |
+            Specification of the desired behavior of one or more ClickHouse clusters
+            More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
           properties:
             taskID:
               type: string
+              description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
             # Need to be StringBool
             stop:
               type: string
+              description: |
+                Allow stop all ClickHouse clusters described in current chi.
+                Stop mechanism works as follows:
+                 - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                 - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -951,12 +1342,14 @@ spec:
                 - "enabled"
             restart:
               type: string
+              description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
               enum:
                 - ""
                 - "RollingUpdate"
             # Need to be StringBool
             troubleshoot:
               type: string
+              description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -984,89 +1377,116 @@ spec:
                 - "enabled"
             namespaceDomainPattern:
               type: string
+              description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
             templating:
               type: object
-              nullable: true
+              # nullable: true
+              description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
               properties:
                 policy:
                   type: string
+                  description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                  enum:
+                    - "auto"
+                    - "manual"
             reconciling:
               type: object
-              nullable: true
+              description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+              # nullable: true
               properties:
                 policy:
                   type: string
                 configMapPropagationTimeout:
                   type: integer
+                  description: |
+                    timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                    see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                   minimum: 0
                   maximum: 3600
                 cleanup:
                   type: object
-                  nullable: true
+                  description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                  # nullable: true
                   properties:
                     unknownObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for unknown StatefulSet, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for unknown PVC, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for unknown ConfigMap, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for unknown Service, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                     reconcileFailedObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for failed PVC reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for failed Service reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
             defaults:
               type: object
-              nullable: true
+              description: |
+                define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+              # nullable: true
               properties:
                 # Need to be StringBool
                 replicasUseFQDN:
                   type: string
+                  description: |
+                    define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                    "yes" by default
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -1094,41 +1514,64 @@ spec:
                     - "enabled"
                 distributedDDL:
                   type: object
-                  nullable: true
+                  description: |
+                    allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                    More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                  # nullable: true
                   properties:
                     profile:
                       type: string
+                      description: "Settings from this profile will be used to execute DDL queries"
                 templates:
                   type: object
-                  nullable: true
+                  description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                  # nullable: true
                   properties:
                     hostTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                     podTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     dataVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     logVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     serviceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                     clusterServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                     shardServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                     replicaServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                    volumeClaimTemplate:
+                      type: string
+                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             configuration:
               type: object
-              nullable: true
+              description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+              # nullable: true
               properties:
                 zookeeper:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                    `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                    currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                    More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                  # nullable: true
                   properties:
                     nodes:
                       type: array
-                      nullable: true
+                      description: "describe every available zookeeper cluster node for interaction"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1136,36 +1579,79 @@ spec:
                         properties:
                           host:
                             type: string
+                            description: "dns name or ip address for Zookeeper node"
                           port:
                             type: integer
+                            description: "TCP port which used to connect to Zookeeper node"
                             minimum: 0
                             maximum: 65535
                     session_timeout_ms:
                       type: integer
+                      description: "session timeout during connect to Zookeeper"
                     operation_timeout_ms:
                       type: integer
+                      description: "one operation timeout during Zookeeper transactions"
                     root:
                       type: string
+                      description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                     identity:
                       type: string
+                      description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                 users:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure password hashed, authorization restrictions, database level security row filters etc.
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 profiles:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of settings profile
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 quotas:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of resource quotas
+                    More details: https://clickhouse.tech/docs/en/operations/quotas/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 settings:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 files:
                   type: object
-                  nullable: true
+                  description: |
+                    allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                    every key in this object is the file name
+                    every value in this object is the file content
+                    you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                    each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                    More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 clusters:
                   type: array
-                  nullable: true
+                  description: |
+                    describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                    every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                    all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                    Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                    If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1173,17 +1659,22 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                         minLength: 1
                         # See namePartClusterMaxLen const
                         maxLength: 15
                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                       zookeeper:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.zookeeper` settings
+                        # nullable: true
                         properties:
                           nodes:
                             type: array
-                            nullable: true
+                            description: "describe every available zookeeper cluster node for interaction"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1191,75 +1682,120 @@ spec:
                               properties:
                                 host:
                                   type: string
+                                  description: "dns name or ip address for Zookeeper node"
                                 port:
                                   type: integer
+                                  description: "TCP port which used to connect to Zookeeper node"
                                   minimum: 0
                                   maximum: 65535
                           session_timeout_ms:
                             type: integer
+                            description: "session timeout during connect to Zookeeper"
                           operation_timeout_ms:
                             type: integer
+                            description: "one operation timeout during Zookeeper transactions"
                           root:
                             type: string
+                            description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                           identity:
                             type: string
+                            description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                       settings:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.settings`
+                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       files:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                          override top-level `chi.spec.configuration.files`
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       templates:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                          override top-level `chi.spec.configuration.templates`
+                        # nullable: true
                         properties:
                           hostTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                           podTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           dataVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           logVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           serviceTemplate:
                             type: string
+                            description: "optional, fully ignores for cluster-level"
                           clusterServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           shardServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           replicaServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                          volumeClaimTemplate:
+                            type: string
+                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                       layout:
                         type: object
-                        nullable: true
+                        description: |
+                          describe current cluster layout, how much shards in cluster, how much replica in shard
+                          allows override settings on each shard and replica separatelly
+                        # nullable: true
                         properties:
-                          # DEPRECATED - to be removed soon
                           type:
                             type: string
+                            description: "DEPRECATED - to be removed soon"
                           shardsCount:
                             type: integer
+                            description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                           replicasCount:
                             type: integer
+                            description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                           shards:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
                                 definitionType:
                                   type: string
+                                  description: "DEPRECATED - to be removed soon"
                                 weight:
                                   type: integer
+                                  description: |
+                                    optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                 # Need to be StringBool
                                 internalReplication:
                                   type: string
+                                  description: |
+                                    optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                    allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                   enum:
                                     # List StringBoolXXX constants from model
                                     - ""
@@ -1287,193 +1823,319 @@ spec:
                                     - "enabled"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                    override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                    override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
                                     hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 replicasCount:
                                   type: integer
+                                  description: |
+                                    optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                    shard contains 1 replica by default
+                                    override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                   minimum: 1
                                 replicas:
                                   type: array
-                                  nullable: true
+                                  description: |
+                                    optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           replicas:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                    override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  # nullable: true
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                    override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
-                                    hostTeampate:
+                                    hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 shardsCount:
                                   type: integer
+                                  description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                   minimum: 1
                                 shards:
                                   type: array
-                                  nullable: true
+                                  description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             templates:
               type: object
-              nullable: true
+              description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+              # nullable: true
               properties:
                 hostTemplates:
                   type: array
-                  nullable: true
+                  description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                  # nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
                     properties:
                       name:
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                         type: string
                       portDistribution:
                         type: array
-                        nullable: true
+                        description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -1481,6 +2143,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                               enum:
                                 # List PortDistributionXXX constants
                                 - ""
@@ -1492,31 +2155,52 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                             minLength: 1
                             # See namePartReplicaMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           tcpPort:
                             type: integer
+                            description: |
+                              optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
                           httpPort:
                             type: integer
+                            description: |
+                              optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/http/
                             minimum: 1
                             maximum: 65535
-                          interserverHttpPort:
+                          interserverHTTPPort:
                             type: integer
+                            description: |
+                              optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                              More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                             minimum: 1
                             maximum: 65535
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
@@ -1536,7 +2220,10 @@ spec:
                                 type: string
                 podTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                    More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1544,30 +2231,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                       generateName:
                         type: string
+                        description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       zone:
                         type: object
+                        description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         #required:
                         #  - values
                         properties:
                           key:
                             type: string
+                            description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                           values:
                             type: array
-                            nullable: true
+                            description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                            # nullable: true
                             items:
                               type: string
                       distribution:
-                        # DEPRECATED
                         type: string
+                        description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         enum:
                           - ""
                           - "Unspecified"
                           - "OnePerHost"
                       podDistribution:
                         type: array
-                        nullable: true
+                        description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -1575,6 +2268,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "you can define multiple affinity policy types"
                               enum:
                                 # List PodDistributionXXX constants
                                 - ""
@@ -1595,6 +2289,7 @@ spec:
                                 - "CircularReplication"
                             scope:
                               type: string
+                              description: "scope for apply each podDistribution"
                               enum:
                                 # list PodDistributionScopeXXX constants
                                 - ""
@@ -1606,15 +2301,26 @@ spec:
                                 - "Namespace"
                             number:
                               type: integer
+                              description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                               minimum: 0
                               maximum: 65535
                       spec:
                         # TODO specify PodSpec
                         type: object
-                        nullable: true
+                        description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
+                      metadata:
+                        type: object
+                        description: |
+                          allows pass standard object's metadata from template to Pod
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 volumeClaimTemplates:
                   type: array
-                  nullable: true
+                  description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1622,23 +2328,39 @@ spec:
                     #  - spec
                     properties:
                       name:
+                        description: |
+                          template name, could use to link inside
+                          top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                          cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                         type: string
                       reclaimPolicy:
                         type: string
+                        description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                         enum:
                           - ""
                           - "Retain"
                           - "Delete"
                       metadata:
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to PVC
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
-                        # TODO specify PersistentVolumeClaimSpec
                         type: object
-                        nullable: true
+                        description: |
+                          allows define all aspects of `PVC` resource
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 serviceTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1647,19 +2369,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: |
+                          template name, could use to link inside
+                          chi-level `chi.spec.defaults.templates.serviceTemplate`
+                          cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                       generateName:
                         type: string
+                        description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       metadata:
                         # TODO specify ObjectMeta
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to Service
+                          Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
                         # TODO specify ServiceSpec
                         type: object
-                        nullable: true
+                        description: |
+                          describe behavior of generated Service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
             useTemplates:
               type: array
-              nullable: true
+              description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+              # nullable: true
               items:
                 type: object
                 #required:
@@ -1667,10 +2406,13 @@ spec:
                 properties:
                   name:
                     type: string
+                    description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                   namespace:
                     type: string
+                    description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                   useType:
                     type: string
+                    description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                     enum:
                       # List useTypeXXX constants from model
                       - ""
@@ -1699,65 +2441,102 @@ spec:
   validation:
     openAPIV3Schema:
       type: object
-      # x-kubernetes-preserve-unknown-fields: true
+      description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+      x-kubernetes-preserve-unknown-fields: true
       properties:
         status:
           type: object
           x-kubernetes-preserve-unknown-fields: true
         spec:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: |
+            allows define some of settings for `clickhouse-operator` itself,
+            More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+            look to etc-clickhouse-operator* ConfigMaps if you need more control
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             watchNamespaces:
               type: array
+              description: "List of namespaces where clickhouse-operator watches for events."
               items:
                 type: string
             chCommonConfigsPath:
               type: string
+              description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
             chHostConfigsPath:
               type: string
+              description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
             chUsersConfigsPath:
               type: string
+              description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
             chiTemplatesPath:
               type: string
+              description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
             statefulSetUpdateTimeout:
               type: integer
+              description: "How many seconds to wait for created/updated StatefulSet to be Ready"
             statefulSetUpdatePollPeriod:
               type: integer
+              description: "How many seconds to wait between checks for created/updated StatefulSet status"
             onStatefulSetCreateFailureAction:
               type: string
+              description: |
+                What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                Possible options:
+                1. abort - do nothing, just break the process and wait for admin.
+                2. delete - delete newly created problematic StatefulSet.
+                3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
             onStatefulSetUpdateFailureAction:
               type: string
+              description: |
+                What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                Possible options:
+                1. abort - do nothing, just break the process and wait for admin.
+                2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
             chConfigUserDefaultProfile:
               type: string
+              description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
             chConfigUserDefaultQuota:
               type: string
+              description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
             chConfigUserDefaultNetworksIP:
               type: array
+              description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
               items:
                 type: string
             chConfigUserDefaultPassword:
+              description: "ClickHouse server configuration `<password>...</password>` for any <user>"
               type: string
             chConfigNetworksHostRegexpTemplate:
+              description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
               type: string
             chUsername:
               type: string
+              description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
             chPassword:
               type: string
+              description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
             chCredentialsSecretNamespace:
               type: string
+              description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
             chCredentialsSecretName:
               type: string
+              description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
             chPort:
               type: integer
               minimum: 1
               maximum: 65535
+              description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
             logtostderr:
               type: string
+              description: "boolean, allows logs to stderr"
             alsologtostderr:
               type: string
+              description: "booleanm allows logs to stderr and files both"
             v:
               type: string
+              description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
             stderrthreshold:
               type: string
             vmodule:
@@ -1766,6 +2545,7 @@ spec:
               type: string
             reconcileThreadsNumber:
               type: integer
+              description: "how much goroutines will use to reconcile in parallel, 10 by default"
               minimum: 1
               maximum: 65535
             reconcileWaitExclude:
@@ -1774,10 +2554,14 @@ spec:
               type: string
             excludeFromPropagationLabels:
               type: array
+              description: |
+                When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                exclude labels from the following list
               items:
                 type: string
             appendScopeLabels:
               type: string
+              description: "Whether to append *Scope* labels to StatefulSet and Pod"
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -1803,6 +2587,16 @@ spec:
                 - "disabled"
                 - "Enabled"
                 - "enabled"
+                - "LabelShardScopeIndex"
+                - "LabelReplicaScopeIndex"
+                - "LabelCHIScopeIndex"
+                - "LabelCHIScopeCycleSize"
+                - "LabelCHIScopeCycleIndex"
+                - "LabelCHIScopeCycleOffset"
+                - "LabelClusterScopeIndex"
+                - "LabelClusterScopeCycleSize"
+                - "LabelClusterScopeCycleIndex"
+                - "LabelClusterScopeCycleOffset"
 ---
 # Possible Template Parameters:
 #
@@ -1815,6 +2609,8 @@ kind: ServiceAccount
 metadata:
   name: clickhouse-operator
   namespace: $OPERATOR_NAMESPACE
+spec:
+  additionalPrinterColumns: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1933,6 +2729,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+spec:
+  additionalPrinterColumns: []
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name
@@ -1948,6 +2753,8 @@ subjects:
   - kind: ServiceAccount
     name: clickhouse-operator
     namespace: $OPERATOR_NAMESPACE
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2119,6 +2926,8 @@ data:
     #  LabelClusterScopeCycleIndex
     #  LabelClusterScopeCycleOffset
     appendScopeLabels: "no"
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2134,6 +2943,8 @@ metadata:
   labels:
     app: clickhouse-operator
 data:
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2188,6 +2999,8 @@ data:
             <flush_interval_milliseconds>7500</flush_interval_milliseconds>
         </part_log>
     </yandex>
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2285,6 +3098,8 @@ data:
                   storage: 2Gi
   readme: |
     Templates in this folder are packaged with an operator and available via 'useTemplate'
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2342,6 +3157,8 @@ data:
             </default>
         </profiles>
     </yandex>
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2466,6 +3283,7 @@ spec:
               mountPath: /etc/clickhouse-operator/templates.d
             - name: etc-clickhouse-operator-usersd-folder
               mountPath: /etc/clickhouse-operator/users.d
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2489,3 +3307,4 @@ spec:
       name: clickhouse-operator-metrics
   selector:
     app: clickhouse-operator
+  additionalPrinterColumns: []

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,216 +11,82 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -248,422 +113,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -690,156 +388,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,216 +849,82 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -1083,422 +951,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -1525,156 +1226,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,119 +1687,125 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: namespaces
+          type: string
+          description: Watch namespaces
+          priority: 0 # show in standard view
+          jsonPath: .status
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            watchNamespaces:
-              type: array
-              items:
-                type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
-                type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
-                type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
+              properties:
+                watchNamespaces:
+                  type: array
+                  items:
+                    type: string
+                chCommonConfigsPath:
+                  type: string
+                chHostConfigsPath:
+                  type: string
+                chUsersConfigsPath:
+                  type: string
+                chiTemplatesPath:
+                  type: string
+                statefulSetUpdateTimeout:
+                  type: integer
+                statefulSetUpdatePollPeriod:
+                  type: integer
+                onStatefulSetCreateFailureAction:
+                  type: string
+                onStatefulSetUpdateFailureAction:
+                  type: string
+                chConfigUserDefaultProfile:
+                  type: string
+                chConfigUserDefaultQuota:
+                  type: string
+                chConfigUserDefaultNetworksIP:
+                  type: array
+                  items:
+                    type: string
+                chConfigUserDefaultPassword:
+                  type: string
+                chConfigNetworksHostRegexpTemplate:
+                  type: string
+                chUsername:
+                  type: string
+                chPassword:
+                  type: string
+                chCredentialsSecretNamespace:
+                  type: string
+                chCredentialsSecretName:
+                  type: string
+                chPort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                logtostderr:
+                  type: string
+                alsologtostderr:
+                  type: string
+                v:
+                  type: string
+                stderrthreshold:
+                  type: string
+                vmodule:
+                  type: string
+                log_backtrace_at:
+                  type: string
+                reconcileThreadsNumber:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                reconcileWaitExclude:
+                  type: string
+                reconcileWaitInclude:
+                  type: string
+                excludeFromPropagationLabels:
+                  type: array
+                  items:
+                    type: string
+                appendScopeLabels:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
 ---
 # Possible Template Parameters:
 #

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -73,21 +73,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -115,12 +139,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -148,89 +174,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -258,41 +311,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -300,36 +376,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -337,17 +456,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -355,75 +479,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -451,193 +621,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -645,6 +941,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -656,31 +953,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -701,7 +1019,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -709,30 +1030,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -740,6 +1067,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -760,6 +1088,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -771,15 +1100,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -787,23 +1128,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -812,19 +1169,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -832,10 +1206,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -916,21 +1293,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -958,12 +1359,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -991,89 +1394,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -1101,41 +1531,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -1143,36 +1596,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1180,17 +1676,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -1198,75 +1699,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -1294,193 +1841,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1488,6 +2161,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -1499,31 +2173,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -1544,7 +2239,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1552,30 +2250,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1583,6 +2287,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -1603,6 +2308,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -1614,15 +2320,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1630,23 +2348,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1655,19 +2389,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1675,10 +2426,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -1707,70 +2461,105 @@ spec:
           description: Watch namespaces
           priority: 0 # show in standard view
           jsonPath: .status
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
-              # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                allows define some of settings for `clickhouse-operator` itself,
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+                look to etc-clickhouse-operator* ConfigMaps if you need more control
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 watchNamespaces:
                   type: array
+                  description: "List of namespaces where clickhouse-operator watches for events."
                   items:
                     type: string
                 chCommonConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
                 chHostConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
                 chUsersConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
                 chiTemplatesPath:
                   type: string
+                  description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
                 statefulSetUpdateTimeout:
                   type: integer
+                  description: "How many seconds to wait for created/updated StatefulSet to be Ready"
                 statefulSetUpdatePollPeriod:
                   type: integer
+                  description: "How many seconds to wait between checks for created/updated StatefulSet status"
                 onStatefulSetCreateFailureAction:
                   type: string
+                  description: |
+                    What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. delete - delete newly created problematic StatefulSet.
+                    3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 onStatefulSetUpdateFailureAction:
                   type: string
+                  description: |
+                    What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                    3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 chConfigUserDefaultProfile:
                   type: string
+                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
                 chConfigUserDefaultQuota:
                   type: string
+                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
                 chConfigUserDefaultNetworksIP:
                   type: array
+                  description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
                   items:
                     type: string
                 chConfigUserDefaultPassword:
+                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
                   type: string
                 chConfigNetworksHostRegexpTemplate:
+                  description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
                   type: string
                 chUsername:
                   type: string
+                  description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chPassword:
                   type: string
+                  description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chCredentialsSecretNamespace:
                   type: string
+                  description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chCredentialsSecretName:
                   type: string
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chPort:
                   type: integer
                   minimum: 1
                   maximum: 65535
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 logtostderr:
                   type: string
+                  description: "boolean, allows logs to stderr"
                 alsologtostderr:
                   type: string
+                  description: "booleanm allows logs to stderr and files both"
                 v:
                   type: string
+                  description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
                 stderrthreshold:
                   type: string
                 vmodule:
@@ -1779,6 +2568,7 @@ spec:
                   type: string
                 reconcileThreadsNumber:
                   type: integer
+                  description: "how much goroutines will use to reconcile in parallel, 10 by default"
                   minimum: 1
                   maximum: 65535
                 reconcileWaitExclude:
@@ -1787,10 +2577,14 @@ spec:
                   type: string
                 excludeFromPropagationLabels:
                   type: array
+                  description: |
+                    When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                    exclude labels from the following list
                   items:
                     type: string
                 appendScopeLabels:
                   type: string
+                  description: "Whether to append *Scope* labels to StatefulSet and Pod"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -1816,6 +2610,16 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                    - "LabelShardScopeIndex"
+                    - "LabelReplicaScopeIndex"
+                    - "LabelCHIScopeIndex"
+                    - "LabelCHIScopeCycleSize"
+                    - "LabelCHIScopeCycleIndex"
+                    - "LabelCHIScopeCycleOffset"
+                    - "LabelClusterScopeIndex"
+                    - "LabelClusterScopeCycleSize"
+                    - "LabelClusterScopeCycleIndex"
+                    - "LabelClusterScopeCycleOffset"
 ---
 # Possible Template Parameters:
 #
@@ -1946,6 +2750,13 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name

--- a/deploy/operator/clickhouse-operator-install-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-v1beta1.yaml
@@ -1,0 +1,2481 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clickhouseinstallations.clickhouse.altinity.com
+spec:
+  group: clickhouse.altinity.com
+  scope: Namespaced
+  names:
+    kind: ClickHouseInstallation
+    singular: clickhouseinstallation
+    plural: clickhouseinstallations
+    shortNames:
+      - chi
+  version: v1
+  additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      JSONPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      JSONPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      JSONPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      JSONPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      JSONPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      JSONPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      JSONPath: .status.endpoint
+  validation:
+    openAPIV3Schema:
+      type: object
+      # x-kubernetes-preserve-unknown-fields: true
+      properties:
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+        spec:
+          type: object
+          # x-kubernetes-preserve-unknown-fields: true
+          properties:
+            taskID:
+              type: string
+            # Need to be StringBool
+            stop:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            # Need to be StringBool
+            troubleshoot:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            namespaceDomainPattern:
+              type: string
+            templating:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+            reconciling:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+                configMapPropagationTimeout:
+                  type: integer
+                  minimum: 0
+                  maximum: 3600
+                cleanup:
+                  type: object
+                  nullable: true
+                  properties:
+                    unknownObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                    reconcileFailedObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+            defaults:
+              type: object
+              nullable: true
+              properties:
+                # Need to be StringBool
+                replicasUseFQDN:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                distributedDDL:
+                  type: object
+                  nullable: true
+                  properties:
+                    profile:
+                      type: string
+                templates:
+                  type: object
+                  nullable: true
+                  properties:
+                    hostTemplate:
+                      type: string
+                    podTemplate:
+                      type: string
+                    dataVolumeClaimTemplate:
+                      type: string
+                    logVolumeClaimTemplate:
+                      type: string
+                    serviceTemplate:
+                      type: string
+                    clusterServiceTemplate:
+                      type: string
+                    shardServiceTemplate:
+                      type: string
+                    replicaServiceTemplate:
+                      type: string
+            configuration:
+              type: object
+              nullable: true
+              properties:
+                zookeeper:
+                  type: object
+                  nullable: true
+                  properties:
+                    nodes:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - host
+                        properties:
+                          host:
+                            type: string
+                          port:
+                            type: integer
+                            minimum: 0
+                            maximum: 65535
+                    session_timeout_ms:
+                      type: integer
+                    operation_timeout_ms:
+                      type: integer
+                    root:
+                      type: string
+                    identity:
+                      type: string
+                users:
+                  type: object
+                  nullable: true
+                profiles:
+                  type: object
+                  nullable: true
+                quotas:
+                  type: object
+                  nullable: true
+                settings:
+                  type: object
+                  nullable: true
+                files:
+                  type: object
+                  nullable: true
+                clusters:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                        # See namePartClusterMaxLen const
+                        maxLength: 15
+                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                      zookeeper:
+                        type: object
+                        nullable: true
+                        properties:
+                          nodes:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - host
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          session_timeout_ms:
+                            type: integer
+                          operation_timeout_ms:
+                            type: integer
+                          root:
+                            type: string
+                          identity:
+                            type: string
+                      settings:
+                        type: object
+                        nullable: true
+                      files:
+                        type: object
+                        nullable: true
+                      templates:
+                        type: object
+                        nullable: true
+                        properties:
+                          hostTemplate:
+                            type: string
+                          podTemplate:
+                            type: string
+                          dataVolumeClaimTemplate:
+                            type: string
+                          logVolumeClaimTemplate:
+                            type: string
+                          serviceTemplate:
+                            type: string
+                          clusterServiceTemplate:
+                            type: string
+                          shardServiceTemplate:
+                            type: string
+                          replicaServiceTemplate:
+                            type: string
+                      layout:
+                        type: object
+                        nullable: true
+                        properties:
+                          # DEPRECATED - to be removed soon
+                          type:
+                            type: string
+                          shardsCount:
+                            type: integer
+                          replicasCount:
+                            type: integer
+                          shards:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                # DEPRECATED - to be removed soon
+                                definitionType:
+                                  type: string
+                                weight:
+                                  type: integer
+                                # Need to be StringBool
+                                internalReplication:
+                                  type: string
+                                  enum:
+                                    # List StringBoolXXX constants from model
+                                    - ""
+                                    - "0"
+                                    - "1"
+                                    - "False"
+                                    - "false"
+                                    - "True"
+                                    - "true"
+                                    - "No"
+                                    - "no"
+                                    - "Yes"
+                                    - "yes"
+                                    - "Off"
+                                    - "off"
+                                    - "On"
+                                    - "on"
+                                    - "Disable"
+                                    - "disable"
+                                    - "Enable"
+                                    - "enable"
+                                    - "Disabled"
+                                    - "disabled"
+                                    - "Enabled"
+                                    - "enabled"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTemplate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                replicasCount:
+                                  type: integer
+                                  minimum: 1
+                                replicas:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+                          replicas:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTeampate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                shardsCount:
+                                  type: integer
+                                  minimum: 1
+                                shards:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+            templates:
+              type: object
+              nullable: true
+              properties:
+                hostTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      portDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PortDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClusterScopeIndex"
+                      spec:
+                        # Host
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            minLength: 1
+                            # See namePartReplicaMaxLen const
+                            maxLength: 15
+                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                          tcpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          httpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          interserverHttpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          settings:
+                            type: object
+                            nullable: true
+                          files:
+                            type: object
+                            nullable: true
+                          templates:
+                            type: object
+                            nullable: true
+                            properties:
+                              hostTemplate:
+                                type: string
+                              podTemplate:
+                                type: string
+                              dataVolumeClaimTemplate:
+                                type: string
+                              logVolumeClaimTemplate:
+                                type: string
+                              serviceTemplate:
+                                type: string
+                              clusterServiceTemplate:
+                                type: string
+                              shardServiceTemplate:
+                                type: string
+                              replicaServiceTemplate:
+                                type: string
+                podTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      zone:
+                        type: object
+                        #required:
+                        #  - values
+                        properties:
+                          key:
+                            type: string
+                          values:
+                            type: array
+                            nullable: true
+                            items:
+                              type: string
+                      distribution:
+                        # DEPRECATED
+                        type: string
+                        enum:
+                          - ""
+                          - "Unspecified"
+                          - "OnePerHost"
+                      podDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PodDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClickHouseAntiAffinity"
+                                - "ShardAntiAffinity"
+                                - "ReplicaAntiAffinity"
+                                - "AnotherNamespaceAntiAffinity"
+                                - "AnotherClickHouseInstallationAntiAffinity"
+                                - "AnotherClusterAntiAffinity"
+                                - "MaxNumberPerNode"
+                                - "NamespaceAffinity"
+                                - "ClickHouseInstallationAffinity"
+                                - "ClusterAffinity"
+                                - "ShardAffinity"
+                                - "ReplicaAffinity"
+                                - "PreviousTailAffinity"
+                                - "CircularReplication"
+                            scope:
+                              type: string
+                              enum:
+                                # list PodDistributionScopeXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "Shard"
+                                - "Replica"
+                                - "Cluster"
+                                - "ClickHouseInstallation"
+                                - "Namespace"
+                            number:
+                              type: integer
+                              minimum: 0
+                              maximum: 65535
+                      spec:
+                        # TODO specify PodSpec
+                        type: object
+                        nullable: true
+                volumeClaimTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      reclaimPolicy:
+                        type: string
+                        enum:
+                          - ""
+                          - "Retain"
+                          - "Delete"
+                      metadata:
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify PersistentVolumeClaimSpec
+                        type: object
+                        nullable: true
+                serviceTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      metadata:
+                        # TODO specify ObjectMeta
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify ServiceSpec
+                        type: object
+                        nullable: true
+            useTemplates:
+              type: array
+              nullable: true
+              items:
+                type: object
+                #required:
+                #  - name
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  useType:
+                    type: string
+                    enum:
+                      # List useTypeXXX constants from model
+                      - ""
+                      - "merge"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clickhouseinstallationtemplates.clickhouse.altinity.com
+spec:
+  group: clickhouse.altinity.com
+  scope: Namespaced
+  names:
+    kind: ClickHouseInstallationTemplate
+    singular: clickhouseinstallationtemplate
+    plural: clickhouseinstallationtemplates
+    shortNames:
+      - chit
+  version: v1
+  additionalPrinterColumns:
+    - name: version
+      type: string
+      description: Operator version
+      priority: 1 # show in wide view
+      JSONPath: .status.version
+    - name: clusters
+      type: integer
+      description: Clusters count
+      priority: 0 # show in standard view
+      JSONPath: .status.clusters
+    - name: shards
+      type: integer
+      description: Shards count
+      priority: 1 # show in wide view
+      JSONPath: .status.shards
+    - name: hosts
+      type: integer
+      description: Hosts count
+      priority: 0 # show in standard view
+      JSONPath: .status.hosts
+    - name: taskID
+      type: string
+      description: TaskID
+      priority: 1 # show in wide view
+      JSONPath: .status.taskID
+    - name: status
+      type: string
+      description: CHI status
+      priority: 0 # show in standard view
+      JSONPath: .status.status
+    - name: updated
+      type: integer
+      description: Updated hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.updated
+    - name: added
+      type: integer
+      description: Added hosts count
+      priority: 1 # show in wide view
+      JSONPath: .status.added
+    - name: deleted
+      type: integer
+      description: Hosts deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.deleted
+    - name: delete
+      type: integer
+      description: Hosts to be deleted count
+      priority: 1 # show in wide view
+      JSONPath: .status.delete
+    - name: endpoint
+      type: string
+      description: Client access endpoint
+      priority: 1 # show in wide view
+      JSONPath: .status.endpoint
+  validation:
+    openAPIV3Schema:
+      type: object
+      # x-kubernetes-preserve-unknown-fields: true
+      properties:
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+        spec:
+          type: object
+          # x-kubernetes-preserve-unknown-fields: true
+          properties:
+            taskID:
+              type: string
+            # Need to be StringBool
+            stop:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            # Need to be StringBool
+            troubleshoot:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+            namespaceDomainPattern:
+              type: string
+            templating:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+            reconciling:
+              type: object
+              nullable: true
+              properties:
+                policy:
+                  type: string
+                configMapPropagationTimeout:
+                  type: integer
+                  minimum: 0
+                  maximum: 3600
+                cleanup:
+                  type: object
+                  nullable: true
+                  properties:
+                    unknownObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                    reconcileFailedObjects:
+                      type: object
+                      nullable: true
+                      properties:
+                        statefulSet:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        pvc:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        configMap:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+                        service:
+                          type: string
+                          enum:
+                            # List ObjectsCleanupXXX constants from model
+                            - "Retain"
+                            - "Delete"
+            defaults:
+              type: object
+              nullable: true
+              properties:
+                # Need to be StringBool
+                replicasUseFQDN:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                distributedDDL:
+                  type: object
+                  nullable: true
+                  properties:
+                    profile:
+                      type: string
+                templates:
+                  type: object
+                  nullable: true
+                  properties:
+                    hostTemplate:
+                      type: string
+                    podTemplate:
+                      type: string
+                    dataVolumeClaimTemplate:
+                      type: string
+                    logVolumeClaimTemplate:
+                      type: string
+                    serviceTemplate:
+                      type: string
+                    clusterServiceTemplate:
+                      type: string
+                    shardServiceTemplate:
+                      type: string
+                    replicaServiceTemplate:
+                      type: string
+            configuration:
+              type: object
+              nullable: true
+              properties:
+                zookeeper:
+                  type: object
+                  nullable: true
+                  properties:
+                    nodes:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - host
+                        properties:
+                          host:
+                            type: string
+                          port:
+                            type: integer
+                            minimum: 0
+                            maximum: 65535
+                    session_timeout_ms:
+                      type: integer
+                    operation_timeout_ms:
+                      type: integer
+                    root:
+                      type: string
+                    identity:
+                      type: string
+                users:
+                  type: object
+                  nullable: true
+                profiles:
+                  type: object
+                  nullable: true
+                quotas:
+                  type: object
+                  nullable: true
+                settings:
+                  type: object
+                  nullable: true
+                files:
+                  type: object
+                  nullable: true
+                clusters:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                        # See namePartClusterMaxLen const
+                        maxLength: 15
+                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                      zookeeper:
+                        type: object
+                        nullable: true
+                        properties:
+                          nodes:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - host
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          session_timeout_ms:
+                            type: integer
+                          operation_timeout_ms:
+                            type: integer
+                          root:
+                            type: string
+                          identity:
+                            type: string
+                      settings:
+                        type: object
+                        nullable: true
+                      files:
+                        type: object
+                        nullable: true
+                      templates:
+                        type: object
+                        nullable: true
+                        properties:
+                          hostTemplate:
+                            type: string
+                          podTemplate:
+                            type: string
+                          dataVolumeClaimTemplate:
+                            type: string
+                          logVolumeClaimTemplate:
+                            type: string
+                          serviceTemplate:
+                            type: string
+                          clusterServiceTemplate:
+                            type: string
+                          shardServiceTemplate:
+                            type: string
+                          replicaServiceTemplate:
+                            type: string
+                      layout:
+                        type: object
+                        nullable: true
+                        properties:
+                          # DEPRECATED - to be removed soon
+                          type:
+                            type: string
+                          shardsCount:
+                            type: integer
+                          replicasCount:
+                            type: integer
+                          shards:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                # DEPRECATED - to be removed soon
+                                definitionType:
+                                  type: string
+                                weight:
+                                  type: integer
+                                # Need to be StringBool
+                                internalReplication:
+                                  type: string
+                                  enum:
+                                    # List StringBoolXXX constants from model
+                                    - ""
+                                    - "0"
+                                    - "1"
+                                    - "False"
+                                    - "false"
+                                    - "True"
+                                    - "true"
+                                    - "No"
+                                    - "no"
+                                    - "Yes"
+                                    - "yes"
+                                    - "Off"
+                                    - "off"
+                                    - "On"
+                                    - "on"
+                                    - "Disable"
+                                    - "disable"
+                                    - "Enable"
+                                    - "enable"
+                                    - "Disabled"
+                                    - "disabled"
+                                    - "Enabled"
+                                    - "enabled"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTemplate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                replicasCount:
+                                  type: integer
+                                  minimum: 1
+                                replicas:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+                          replicas:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  minLength: 1
+                                  # See namePartShardMaxLen const
+                                  maxLength: 15
+                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                settings:
+                                  type: object
+                                  nullable: true
+                                files:
+                                  type: object
+                                  nullable: true
+                                templates:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    hostTeampate:
+                                      type: string
+                                    podTemplate:
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      type: string
+                                    logVolumeClaimTemplate:
+                                      type: string
+                                    serviceTemplate:
+                                      type: string
+                                    clusterServiceTemplate:
+                                      type: string
+                                    shardServiceTemplate:
+                                      type: string
+                                    replicaServiceTemplate:
+                                      type: string
+                                shardsCount:
+                                  type: integer
+                                  minimum: 1
+                                shards:
+                                  type: array
+                                  nullable: true
+                                  items:
+                                    # Host
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                        minLength: 1
+                                        # See namePartReplicaMaxLen const
+                                        maxLength: 15
+                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                      tcpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      httpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      interserverHttpPort:
+                                        type: integer
+                                        minimum: 1
+                                        maximum: 65535
+                                      settings:
+                                        type: object
+                                        nullable: true
+                                      files:
+                                        type: object
+                                        nullable: true
+                                      templates:
+                                        type: object
+                                        nullable: true
+                                        properties:
+                                          hostTemplate:
+                                            type: string
+                                          podTemplate:
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            type: string
+                                          logVolumeClaimTemplate:
+                                            type: string
+                                          serviceTemplate:
+                                            type: string
+                                          clusterServiceTemplate:
+                                            type: string
+                                          shardServiceTemplate:
+                                            type: string
+                                          replicaServiceTemplate:
+                                            type: string
+            templates:
+              type: object
+              nullable: true
+              properties:
+                hostTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      portDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PortDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClusterScopeIndex"
+                      spec:
+                        # Host
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            minLength: 1
+                            # See namePartReplicaMaxLen const
+                            maxLength: 15
+                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                          tcpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          httpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          interserverHttpPort:
+                            type: integer
+                            minimum: 1
+                            maximum: 65535
+                          settings:
+                            type: object
+                            nullable: true
+                          files:
+                            type: object
+                            nullable: true
+                          templates:
+                            type: object
+                            nullable: true
+                            properties:
+                              hostTemplate:
+                                type: string
+                              podTemplate:
+                                type: string
+                              dataVolumeClaimTemplate:
+                                type: string
+                              logVolumeClaimTemplate:
+                                type: string
+                              serviceTemplate:
+                                type: string
+                              clusterServiceTemplate:
+                                type: string
+                              shardServiceTemplate:
+                                type: string
+                              replicaServiceTemplate:
+                                type: string
+                podTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      zone:
+                        type: object
+                        #required:
+                        #  - values
+                        properties:
+                          key:
+                            type: string
+                          values:
+                            type: array
+                            nullable: true
+                            items:
+                              type: string
+                      distribution:
+                        # DEPRECATED
+                        type: string
+                        enum:
+                          - ""
+                          - "Unspecified"
+                          - "OnePerHost"
+                      podDistribution:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          #required:
+                          #  - type
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                # List PodDistributionXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "ClickHouseAntiAffinity"
+                                - "ShardAntiAffinity"
+                                - "ReplicaAntiAffinity"
+                                - "AnotherNamespaceAntiAffinity"
+                                - "AnotherClickHouseInstallationAntiAffinity"
+                                - "AnotherClusterAntiAffinity"
+                                - "MaxNumberPerNode"
+                                - "NamespaceAffinity"
+                                - "ClickHouseInstallationAffinity"
+                                - "ClusterAffinity"
+                                - "ShardAffinity"
+                                - "ReplicaAffinity"
+                                - "PreviousTailAffinity"
+                                - "CircularReplication"
+                            scope:
+                              type: string
+                              enum:
+                                # list PodDistributionScopeXXX constants
+                                - ""
+                                - "Unspecified"
+                                - "Shard"
+                                - "Replica"
+                                - "Cluster"
+                                - "ClickHouseInstallation"
+                                - "Namespace"
+                            number:
+                              type: integer
+                              minimum: 0
+                              maximum: 65535
+                      spec:
+                        # TODO specify PodSpec
+                        type: object
+                        nullable: true
+                volumeClaimTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      reclaimPolicy:
+                        type: string
+                        enum:
+                          - ""
+                          - "Retain"
+                          - "Delete"
+                      metadata:
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify PersistentVolumeClaimSpec
+                        type: object
+                        nullable: true
+                serviceTemplates:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    #required:
+                    #  - name
+                    #  - spec
+                    properties:
+                      name:
+                        type: string
+                      generateName:
+                        type: string
+                      metadata:
+                        # TODO specify ObjectMeta
+                        type: object
+                        nullable: true
+                      spec:
+                        # TODO specify ServiceSpec
+                        type: object
+                        nullable: true
+            useTemplates:
+              type: array
+              nullable: true
+              items:
+                type: object
+                #required:
+                #  - name
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  useType:
+                    type: string
+                    enum:
+                      # List useTypeXXX constants from model
+                      - ""
+                      - "merge"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clickhouseoperatorconfigurations.clickhouse.altinity.com
+spec:
+  group: clickhouse.altinity.com
+  scope: Namespaced
+  names:
+    kind: ClickHouseOperatorConfiguration
+    singular: clickhouseoperatorconfiguration
+    plural: clickhouseoperatorconfigurations
+    shortNames:
+      - chopconf
+  version: v1
+  additionalPrinterColumns:
+    - name: namespaces
+      type: string
+      description: Watch namespaces
+      priority: 0 # show in standard view
+      JSONPath: .status
+  validation:
+    openAPIV3Schema:
+      type: object
+      # x-kubernetes-preserve-unknown-fields: true
+      properties:
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+        spec:
+          type: object
+          # x-kubernetes-preserve-unknown-fields: true
+          properties:
+            watchNamespaces:
+              type: array
+              items:
+                type: string
+            chCommonConfigsPath:
+              type: string
+            chHostConfigsPath:
+              type: string
+            chUsersConfigsPath:
+              type: string
+            chiTemplatesPath:
+              type: string
+            statefulSetUpdateTimeout:
+              type: integer
+            statefulSetUpdatePollPeriod:
+              type: integer
+            onStatefulSetCreateFailureAction:
+              type: string
+            onStatefulSetUpdateFailureAction:
+              type: string
+            chConfigUserDefaultProfile:
+              type: string
+            chConfigUserDefaultQuota:
+              type: string
+            chConfigUserDefaultNetworksIP:
+              type: array
+              items:
+                type: string
+            chConfigUserDefaultPassword:
+              type: string
+            chConfigNetworksHostRegexpTemplate:
+              type: string
+            chUsername:
+              type: string
+            chPassword:
+              type: string
+            chCredentialsSecretNamespace:
+              type: string
+            chCredentialsSecretName:
+              type: string
+            chPort:
+              type: integer
+              minimum: 1
+              maximum: 65535
+            logtostderr:
+              type: string
+            alsologtostderr:
+              type: string
+            v:
+              type: string
+            stderrthreshold:
+              type: string
+            vmodule:
+              type: string
+            log_backtrace_at:
+              type: string
+            reconcileThreadsNumber:
+              type: integer
+              minimum: 1
+              maximum: 65535
+            reconcileWaitExclude:
+              type: string
+            reconcileWaitInclude:
+              type: string
+            excludeFromPropagationLabels:
+              type: array
+              items:
+                type: string
+            appendScopeLabels:
+              type: string
+              enum:
+                # List StringBoolXXX constants from model
+                - ""
+                - "0"
+                - "1"
+                - "False"
+                - "false"
+                - "True"
+                - "true"
+                - "No"
+                - "no"
+                - "Yes"
+                - "yes"
+                - "Off"
+                - "off"
+                - "On"
+                - "on"
+                - "Disable"
+                - "disable"
+                - "Enable"
+                - "enable"
+                - "Disabled"
+                - "disabled"
+                - "Enabled"
+                - "enabled"
+---
+# Possible Template Parameters:
+#
+# kube-system
+#
+# Setup ServiceAccount
+# ServiceAccount would be created in kubectl-specified namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clickhouse-operator
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clickhouse-operator-kube-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - pods
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resourceNames:
+      - clickhouse-operator
+    resources:
+      - deployments
+    verbs:
+      - get
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations
+      - clickhouseinstallationtemplates
+      - clickhouseoperatorconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
+# ClusterRoleBinding is namespace-less and must have unique name
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clickhouse-operator-kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clickhouse-operator-kube-system
+subjects:
+  - kind: ServiceAccount
+    name: clickhouse-operator
+    namespace: kube-system
+---
+# Possible Template Parameters:
+#
+# kube-system
+# altinity/clickhouse-operator:0.16.0
+# etc-clickhouse-operator-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-files
+  namespace: kube-system
+  labels:
+    app: clickhouse-operator
+data:
+  config.yaml: |
+    ################################################
+    ##
+    ## Watch Namespaces Section
+    ##
+    ################################################
+
+    # List of namespaces where clickhouse-operator watches for events.
+    # Concurrently running operators should watch on different namespaces
+    #watchNamespaces:
+    #  - dev
+    #  - test
+    #  - info
+    #  - onemore
+
+    ################################################
+    ##
+    ## Additional Configuration Files Section
+    ##
+    ################################################
+
+    # Path to folder where ClickHouse configuration files common for all instances within CHI are located.
+    chCommonConfigsPath: config.d
+
+    # Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located.
+    chHostConfigsPath: conf.d
+
+    # Path to folder where ClickHouse configuration files with users settings are located.
+    # Files are common for all instances within CHI
+    chUsersConfigsPath: users.d
+
+    # Path to folder where ClickHouseInstallation .yaml manifests are located.
+    # Manifests are applied in sorted alpha-numeric order
+    chiTemplatesPath: templates.d
+
+    ################################################
+    ##
+    ## Cluster Create/Update/Delete Objects Section
+    ##
+    ################################################
+
+    # How many seconds to wait for created/updated StatefulSet to be Ready
+    statefulSetUpdateTimeout: 300
+
+    # How many seconds to wait between checks for created/updated StatefulSet status
+    statefulSetUpdatePollPeriod: 5
+
+    # What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+    # Possible options:
+    # 1. abort - do nothing, just break the process and wait for admin
+    # 2. delete - delete newly created problematic StatefulSet
+    # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+    onStatefulSetCreateFailureAction: ignore
+
+    # What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+    # Possible options:
+    # 1. abort - do nothing, just break the process and wait for admin
+    # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
+    # Pod would be recreated by StatefulSet based on rollback-ed configuration
+    # 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet
+    onStatefulSetUpdateFailureAction: rollback
+
+    ################################################
+    ##
+    ## ClickHouse Settings Section
+    ##
+    ################################################
+
+    # Default values for ClickHouse user configuration
+    # 1. user/profile - string
+    # 2. user/quota - string
+    # 3. user/networks/ip - multiple strings
+    # 4. user/password - string
+    chConfigUserDefaultProfile: default
+    chConfigUserDefaultQuota: default
+    chConfigUserDefaultNetworksIP:
+      - "::1"
+      - "127.0.0.1"
+    chConfigUserDefaultPassword: "default"
+
+    # Default host_regexp to limit network connectivity from outside
+    chConfigNetworksHostRegexpTemplate: "(chi-{chi}-[^.]+\\d+-\\d+|clickhouse\\-{chi})\\.{namespace}\\.svc\\.cluster\\.local$"
+
+    ################################################
+    ##
+    ## Access to ClickHouse instances
+    ##
+    ################################################
+
+    # ClickHouse credentials (username, password and port) to be used by operator to connect to ClickHouse instances
+    # for:
+    # 1. Metrics requests
+    # 2. Schema maintenance
+    # 3. DROP DNS CACHE
+    # User with such credentials can be specified in additional ClickHouse .xml config files,
+    # located in `chUsersConfigsPath` folder
+    chUsername: clickhouse_operator
+    chPassword: clickhouse_operator_password
+
+    # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
+    # Can be used instead of explicitly specified username and password
+    chCredentialsSecretNamespace: ""
+    chCredentialsSecretName: ""
+
+    # Port where to connect to ClickHouse instances to
+    chPort: 8123
+
+    ################################################
+    ##
+    ## Log parameters
+    ##
+    ################################################
+
+    logtostderr: "true"
+    alsologtostderr: "false"
+    v: "1"
+    stderrthreshold: ""
+    vmodule: ""
+    log_backtrace_at: ""
+
+    ################################################
+    ##
+    ## Runtime parameters
+    ##
+    ################################################
+
+    # Max number of concurrent reconciles in progress
+    reconcileThreadsNumber: 10
+    reconcileWaitExclude: false
+    reconcileWaitInclude: false
+
+    ################################################
+    ##
+    ## Labels management parameters
+    ##
+    ################################################
+
+    # When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+    # exclude labels from the following list:
+    #excludeFromPropagationLabels:
+    #  - "labelA"
+    #  - "labelB"
+
+    # Whether to append *Scope* labels to StatefulSet and Pod.
+    # Full list of available *scope* labels check in labeler.go
+    #  LabelShardScopeIndex
+    #  LabelReplicaScopeIndex
+    #  LabelCHIScopeIndex
+    #  LabelCHIScopeCycleSize
+    #  LabelCHIScopeCycleIndex
+    #  LabelCHIScopeCycleOffset
+    #  LabelClusterScopeIndex
+    #  LabelClusterScopeCycleSize
+    #  LabelClusterScopeCycleIndex
+    #  LabelClusterScopeCycleOffset
+    appendScopeLabels: "no"
+---
+# Possible Template Parameters:
+#
+# kube-system
+# altinity/clickhouse-operator:0.16.0
+# etc-clickhouse-operator-confd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-confd-files
+  namespace: kube-system
+  labels:
+    app: clickhouse-operator
+data:
+---
+# Possible Template Parameters:
+#
+# kube-system
+# altinity/clickhouse-operator:0.16.0
+# etc-clickhouse-operator-configd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-configd-files
+  namespace: kube-system
+  labels:
+    app: clickhouse-operator
+data:
+  01-clickhouse-01-listen.xml: |
+    <yandex>
+        <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
+        <listen_host>::</listen_host>
+        <listen_host>0.0.0.0</listen_host>
+        <listen_try>1</listen_try>
+    </yandex>
+  01-clickhouse-02-logger.xml: |
+    <yandex>
+        <logger>
+            <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
+            <level>debug</level>
+            <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+            <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+            <size>1000M</size>
+            <count>10</count>
+            <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->
+            <console>1</console>
+        </logger>
+    </yandex>
+  01-clickhouse-03-query_log.xml: |
+    <yandex>
+        <query_log replace="1">
+            <database>system</database>
+            <table>query_log</table>
+            <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        </query_log>
+        <query_thread_log remove="1"/>
+    </yandex>
+  01-clickhouse-04-part_log.xml: |
+    <yandex>
+        <part_log replace="1">
+            <database>system</database>
+            <table>part_log</table>
+            <engine>Engine = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day</engine>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        </part_log>
+    </yandex>
+---
+# Possible Template Parameters:
+#
+# kube-system
+# altinity/clickhouse-operator:0.16.0
+# etc-clickhouse-operator-templatesd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-templatesd-files
+  namespace: kube-system
+  labels:
+    app: clickhouse-operator
+data:
+  001-templates.json.example: |
+    {
+      "apiVersion": "clickhouse.altinity.com/v1",
+      "kind": "ClickHouseInstallationTemplate",
+      "metadata": {
+        "name": "01-default-volumeclaimtemplate"
+      },
+      "spec": {
+        "templates": {
+          "volumeClaimTemplates": [
+            {
+              "name": "chi-default-volume-claim-template",
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "2Gi"
+                  }
+                }
+              }
+            }
+          ],
+          "podTemplates": [
+            {
+              "name": "chi-default-oneperhost-pod-template",
+              "distribution": "OnePerHost",
+              "spec": {
+                "containers" : [
+                  {
+                    "name": "clickhouse",
+                    "image": "yandex/clickhouse-server:19.3.7",
+                    "ports": [
+                      {
+                        "name": "http",
+                        "containerPort": 8123
+                      },
+                      {
+                        "name": "client",
+                        "containerPort": 9000
+                      },
+                      {
+                        "name": "interserver",
+                        "containerPort": 9009
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  default-pod-template.yaml.example: |
+    apiVersion: "clickhouse.altinity.com/v1"
+    kind: "ClickHouseInstallationTemplate"
+    metadata:
+      name: "default-oneperhost-pod-template"
+    spec:
+      templates:
+        podTemplates:
+          - name: default-oneperhost-pod-template
+            distribution: "OnePerHost"
+  default-storage-template.yaml.example: |
+    apiVersion: "clickhouse.altinity.com/v1"
+    kind: "ClickHouseInstallationTemplate"
+    metadata:
+      name: "default-storage-template-2Gi"
+    spec:
+      templates:
+        volumeClaimTemplates:
+          - name: default-storage-template-2Gi
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+  readme: |
+    Templates in this folder are packaged with an operator and available via 'useTemplate'
+---
+# Possible Template Parameters:
+#
+# kube-system
+# altinity/clickhouse-operator:0.16.0
+# etc-clickhouse-operator-usersd-files
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-clickhouse-operator-usersd-files
+  namespace: kube-system
+  labels:
+    app: clickhouse-operator
+data:
+  01-clickhouse-user.xml: |
+    <yandex>
+        <users>
+            <clickhouse_operator>
+                <networks>
+                    <ip>127.0.0.1</ip>
+                    <ip>0.0.0.0/0</ip>
+                    <ip>::/0</ip>
+                </networks>
+                <password_sha256_hex>716b36073a90c6fe1d445ac1af85f4777c5b7a155cea359961826a030513e448</password_sha256_hex>
+                <profile>clickhouse_operator</profile>
+                <quota>default</quota>
+            </clickhouse_operator>
+        </users>
+        <profiles>
+            <clickhouse_operator>
+                <log_queries>0</log_queries>
+                <skip_unavailable_shards>1</skip_unavailable_shards>
+                <http_connection_timeout>10</http_connection_timeout>
+            </clickhouse_operator>
+        </profiles>
+    </yandex>
+  02-clickhouse-default-profile.xml: |
+    <yandex>
+      <profiles>
+        <default>
+          <log_queries>1</log_queries>
+          <connect_timeout_with_failover_ms>1000</connect_timeout_with_failover_ms>
+          <distributed_aggregation_memory_efficient>1</distributed_aggregation_memory_efficient>
+          <parallel_view_processing>1</parallel_view_processing>
+        </default>
+      </profiles>
+    </yandex>
+  03-database-ordinary.xml: |
+    <!--  Remove it for ClickHouse versions before 20.4 -->
+    <yandex>
+        <profiles>
+            <default>
+                <default_database_engine>Ordinary</default_database_engine>
+            </default>
+        </profiles>
+    </yandex>
+---
+# Possible Template Parameters:
+#
+# kube-system
+# altinity/clickhouse-operator:0.16.0
+# altinity/metrics-exporter:0.16.0
+#
+# Setup Deployment for clickhouse-operator
+# Deployment would be created in kubectl-specified namespace
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: clickhouse-operator
+  namespace: kube-system
+  labels:
+    app: clickhouse-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse-operator
+  template:
+    metadata:
+      labels:
+        app: clickhouse-operator
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/scrape: 'true'
+    spec:
+      serviceAccountName: clickhouse-operator
+      volumes:
+        - name: etc-clickhouse-operator-folder
+          configMap:
+            name: etc-clickhouse-operator-files
+        - name: etc-clickhouse-operator-confd-folder
+          configMap:
+            name: etc-clickhouse-operator-confd-files
+        - name: etc-clickhouse-operator-configd-folder
+          configMap:
+            name: etc-clickhouse-operator-configd-files
+        - name: etc-clickhouse-operator-templatesd-folder
+          configMap:
+            name: etc-clickhouse-operator-templatesd-files
+        - name: etc-clickhouse-operator-usersd-folder
+          configMap:
+            name: etc-clickhouse-operator-usersd-files
+      containers:
+        - name: clickhouse-operator
+          image: altinity/clickhouse-operator:0.16.0
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: etc-clickhouse-operator-folder
+              mountPath: /etc/clickhouse-operator
+            - name: etc-clickhouse-operator-confd-folder
+              mountPath: /etc/clickhouse-operator/conf.d
+            - name: etc-clickhouse-operator-configd-folder
+              mountPath: /etc/clickhouse-operator/config.d
+            - name: etc-clickhouse-operator-templatesd-folder
+              mountPath: /etc/clickhouse-operator/templates.d
+            - name: etc-clickhouse-operator-usersd-folder
+              mountPath: /etc/clickhouse-operator/users.d
+          env:
+            # Pod-specific
+            # spec.nodeName: ip-172-20-52-62.ec2.internal
+            - name: OPERATOR_POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # metadata.name: clickhouse-operator-6f87589dbb-ftcsf
+            - name: OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # metadata.namespace: kube-system
+            - name: OPERATOR_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # status.podIP: 100.96.3.2
+            - name: OPERATOR_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # spec.serviceAccount: clickhouse-operator
+            # spec.serviceAccountName: clickhouse-operator
+            - name: OPERATOR_POD_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            # Container-specific
+            - name: OPERATOR_CONTAINER_CPU_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: requests.cpu
+            - name: OPERATOR_CONTAINER_CPU_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: limits.cpu
+            - name: OPERATOR_CONTAINER_MEM_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: requests.memory
+            - name: OPERATOR_CONTAINER_MEM_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: clickhouse-operator
+                  resource: limits.memory
+        - name: metrics-exporter
+          image: altinity/metrics-exporter:0.16.0
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: etc-clickhouse-operator-folder
+              mountPath: /etc/clickhouse-operator
+            - name: etc-clickhouse-operator-confd-folder
+              mountPath: /etc/clickhouse-operator/conf.d
+            - name: etc-clickhouse-operator-configd-folder
+              mountPath: /etc/clickhouse-operator/config.d
+            - name: etc-clickhouse-operator-templatesd-folder
+              mountPath: /etc/clickhouse-operator/templates.d
+            - name: etc-clickhouse-operator-usersd-folder
+              mountPath: /etc/clickhouse-operator/users.d
+---
+# Possible Template Parameters:
+#
+# kube-system
+#
+# Setup ClusterIP Service to provide monitoring metrics for Prometheus
+# Service would be created in kubectl-specified namespace
+# In order to get access outside of k8s it should be exposed as:
+# kubectl --namespace prometheus port-forward service/prometheus 9090
+# and point browser to localhost:9090
+kind: Service
+apiVersion: v1
+metadata:
+  name: clickhouse-operator-metrics
+  namespace: kube-system
+  labels:
+    app: clickhouse-operator
+spec:
+  ports:
+    - port: 8888
+      name: clickhouse-operator-metrics
+  selector:
+    app: clickhouse-operator

--- a/deploy/operator/clickhouse-operator-install-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-v1beta1.yaml
@@ -70,21 +70,41 @@ spec:
       JSONPath: .status.endpoint
   validation:
     openAPIV3Schema:
+      description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
       type: object
-      # x-kubernetes-preserve-unknown-fields: true
+      required:
+        - spec
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         status:
           type: object
+          description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
           x-kubernetes-preserve-unknown-fields: true
         spec:
           type: object
           # x-kubernetes-preserve-unknown-fields: true
+          description: |
+            Specification of the desired behavior of one or more ClickHouse clusters
+            More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
           properties:
             taskID:
               type: string
+              description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
             # Need to be StringBool
             stop:
               type: string
+              description: |
+                Allow stop all ClickHouse clusters described in current chi.
+                Stop mechanism works as follows:
+                 - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                 - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -112,12 +132,14 @@ spec:
                 - "enabled"
             restart:
               type: string
+              description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
               enum:
                 - ""
                 - "RollingUpdate"
             # Need to be StringBool
             troubleshoot:
               type: string
+              description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -145,89 +167,116 @@ spec:
                 - "enabled"
             namespaceDomainPattern:
               type: string
+              description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
             templating:
               type: object
-              nullable: true
+              # nullable: true
+              description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
               properties:
                 policy:
                   type: string
+                  description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                  enum:
+                    - "auto"
+                    - "manual"
             reconciling:
               type: object
-              nullable: true
+              description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+              # nullable: true
               properties:
                 policy:
                   type: string
                 configMapPropagationTimeout:
                   type: integer
+                  description: |
+                    timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                    see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                   minimum: 0
                   maximum: 3600
                 cleanup:
                   type: object
-                  nullable: true
+                  description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                  # nullable: true
                   properties:
                     unknownObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for unknown StatefulSet, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for unknown PVC, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for unknown ConfigMap, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for unknown Service, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                     reconcileFailedObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for failed PVC reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for failed Service reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
             defaults:
               type: object
-              nullable: true
+              description: |
+                define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+              # nullable: true
               properties:
                 # Need to be StringBool
                 replicasUseFQDN:
                   type: string
+                  description: |
+                    define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                    "yes" by default
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -255,41 +304,64 @@ spec:
                     - "enabled"
                 distributedDDL:
                   type: object
-                  nullable: true
+                  description: |
+                    allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                    More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                  # nullable: true
                   properties:
                     profile:
                       type: string
+                      description: "Settings from this profile will be used to execute DDL queries"
                 templates:
                   type: object
-                  nullable: true
+                  description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                  # nullable: true
                   properties:
                     hostTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                     podTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     dataVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     logVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     serviceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                     clusterServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                     shardServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                     replicaServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                    volumeClaimTemplate:
+                      type: string
+                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             configuration:
               type: object
-              nullable: true
+              description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+              # nullable: true
               properties:
                 zookeeper:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                    `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                    currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                    More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                  # nullable: true
                   properties:
                     nodes:
                       type: array
-                      nullable: true
+                      description: "describe every available zookeeper cluster node for interaction"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -297,36 +369,79 @@ spec:
                         properties:
                           host:
                             type: string
+                            description: "dns name or ip address for Zookeeper node"
                           port:
                             type: integer
+                            description: "TCP port which used to connect to Zookeeper node"
                             minimum: 0
                             maximum: 65535
                     session_timeout_ms:
                       type: integer
+                      description: "session timeout during connect to Zookeeper"
                     operation_timeout_ms:
                       type: integer
+                      description: "one operation timeout during Zookeeper transactions"
                     root:
                       type: string
+                      description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                     identity:
                       type: string
+                      description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                 users:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure password hashed, authorization restrictions, database level security row filters etc.
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 profiles:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of settings profile
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 quotas:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of resource quotas
+                    More details: https://clickhouse.tech/docs/en/operations/quotas/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 settings:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 files:
                   type: object
-                  nullable: true
+                  description: |
+                    allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                    every key in this object is the file name
+                    every value in this object is the file content
+                    you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                    each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                    More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 clusters:
                   type: array
-                  nullable: true
+                  description: |
+                    describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                    every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                    all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                    Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                    If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -334,17 +449,22 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                         minLength: 1
                         # See namePartClusterMaxLen const
                         maxLength: 15
                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                       zookeeper:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.zookeeper` settings
+                        # nullable: true
                         properties:
                           nodes:
                             type: array
-                            nullable: true
+                            description: "describe every available zookeeper cluster node for interaction"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -352,75 +472,120 @@ spec:
                               properties:
                                 host:
                                   type: string
+                                  description: "dns name or ip address for Zookeeper node"
                                 port:
                                   type: integer
+                                  description: "TCP port which used to connect to Zookeeper node"
                                   minimum: 0
                                   maximum: 65535
                           session_timeout_ms:
                             type: integer
+                            description: "session timeout during connect to Zookeeper"
                           operation_timeout_ms:
                             type: integer
+                            description: "one operation timeout during Zookeeper transactions"
                           root:
                             type: string
+                            description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                           identity:
                             type: string
+                            description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                       settings:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.settings`
+                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       files:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                          override top-level `chi.spec.configuration.files`
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       templates:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                          override top-level `chi.spec.configuration.templates`
+                        # nullable: true
                         properties:
                           hostTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                           podTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           dataVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           logVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           serviceTemplate:
                             type: string
+                            description: "optional, fully ignores for cluster-level"
                           clusterServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           shardServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           replicaServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                          volumeClaimTemplate:
+                            type: string
+                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                       layout:
                         type: object
-                        nullable: true
+                        description: |
+                          describe current cluster layout, how much shards in cluster, how much replica in shard
+                          allows override settings on each shard and replica separatelly
+                        # nullable: true
                         properties:
-                          # DEPRECATED - to be removed soon
                           type:
                             type: string
+                            description: "DEPRECATED - to be removed soon"
                           shardsCount:
                             type: integer
+                            description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                           replicasCount:
                             type: integer
+                            description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                           shards:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
                                 definitionType:
                                   type: string
+                                  description: "DEPRECATED - to be removed soon"
                                 weight:
                                   type: integer
+                                  description: |
+                                    optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                 # Need to be StringBool
                                 internalReplication:
                                   type: string
+                                  description: |
+                                    optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                    allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                   enum:
                                     # List StringBoolXXX constants from model
                                     - ""
@@ -448,193 +613,319 @@ spec:
                                     - "enabled"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                    override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                    override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
                                     hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 replicasCount:
                                   type: integer
+                                  description: |
+                                    optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                    shard contains 1 replica by default
+                                    override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                   minimum: 1
                                 replicas:
                                   type: array
-                                  nullable: true
+                                  description: |
+                                    optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           replicas:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                    override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  # nullable: true
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                    override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
-                                    hostTeampate:
+                                    hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 shardsCount:
                                   type: integer
+                                  description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                   minimum: 1
                                 shards:
                                   type: array
-                                  nullable: true
+                                  description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             templates:
               type: object
-              nullable: true
+              description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+              # nullable: true
               properties:
                 hostTemplates:
                   type: array
-                  nullable: true
+                  description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                  # nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
                     properties:
                       name:
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                         type: string
                       portDistribution:
                         type: array
-                        nullable: true
+                        description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -642,6 +933,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                               enum:
                                 # List PortDistributionXXX constants
                                 - ""
@@ -653,31 +945,52 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                             minLength: 1
                             # See namePartReplicaMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           tcpPort:
                             type: integer
+                            description: |
+                              optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
                           httpPort:
                             type: integer
+                            description: |
+                              optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/http/
                             minimum: 1
                             maximum: 65535
-                          interserverHttpPort:
+                          interserverHTTPPort:
                             type: integer
+                            description: |
+                              optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                              More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                             minimum: 1
                             maximum: 65535
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
@@ -697,7 +1010,10 @@ spec:
                                 type: string
                 podTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                    More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -705,30 +1021,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                       generateName:
                         type: string
+                        description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       zone:
                         type: object
+                        description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         #required:
                         #  - values
                         properties:
                           key:
                             type: string
+                            description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                           values:
                             type: array
-                            nullable: true
+                            description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                            # nullable: true
                             items:
                               type: string
                       distribution:
-                        # DEPRECATED
                         type: string
+                        description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         enum:
                           - ""
                           - "Unspecified"
                           - "OnePerHost"
                       podDistribution:
                         type: array
-                        nullable: true
+                        description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -736,6 +1058,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "you can define multiple affinity policy types"
                               enum:
                                 # List PodDistributionXXX constants
                                 - ""
@@ -756,6 +1079,7 @@ spec:
                                 - "CircularReplication"
                             scope:
                               type: string
+                              description: "scope for apply each podDistribution"
                               enum:
                                 # list PodDistributionScopeXXX constants
                                 - ""
@@ -767,15 +1091,26 @@ spec:
                                 - "Namespace"
                             number:
                               type: integer
+                              description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                               minimum: 0
                               maximum: 65535
                       spec:
                         # TODO specify PodSpec
                         type: object
-                        nullable: true
+                        description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
+                      metadata:
+                        type: object
+                        description: |
+                          allows pass standard object's metadata from template to Pod
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 volumeClaimTemplates:
                   type: array
-                  nullable: true
+                  description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -783,23 +1118,39 @@ spec:
                     #  - spec
                     properties:
                       name:
+                        description: |
+                          template name, could use to link inside
+                          top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                          cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                         type: string
                       reclaimPolicy:
                         type: string
+                        description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                         enum:
                           - ""
                           - "Retain"
                           - "Delete"
                       metadata:
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to PVC
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
-                        # TODO specify PersistentVolumeClaimSpec
                         type: object
-                        nullable: true
+                        description: |
+                          allows define all aspects of `PVC` resource
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 serviceTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -808,19 +1159,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: |
+                          template name, could use to link inside
+                          chi-level `chi.spec.defaults.templates.serviceTemplate`
+                          cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                       generateName:
                         type: string
+                        description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       metadata:
                         # TODO specify ObjectMeta
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to Service
+                          Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
                         # TODO specify ServiceSpec
                         type: object
-                        nullable: true
+                        description: |
+                          describe behavior of generated Service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
             useTemplates:
               type: array
-              nullable: true
+              description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+              # nullable: true
               items:
                 type: object
                 #required:
@@ -828,10 +1196,13 @@ spec:
                 properties:
                   name:
                     type: string
+                    description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                   namespace:
                     type: string
+                    description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                   useType:
                     type: string
+                    description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                     enum:
                       # List useTypeXXX constants from model
                       - ""
@@ -909,21 +1280,41 @@ spec:
       JSONPath: .status.endpoint
   validation:
     openAPIV3Schema:
+      description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
       type: object
-      # x-kubernetes-preserve-unknown-fields: true
+      required:
+        - spec
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         status:
           type: object
+          description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
           x-kubernetes-preserve-unknown-fields: true
         spec:
           type: object
           # x-kubernetes-preserve-unknown-fields: true
+          description: |
+            Specification of the desired behavior of one or more ClickHouse clusters
+            More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
           properties:
             taskID:
               type: string
+              description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
             # Need to be StringBool
             stop:
               type: string
+              description: |
+                Allow stop all ClickHouse clusters described in current chi.
+                Stop mechanism works as follows:
+                 - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                 - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -951,12 +1342,14 @@ spec:
                 - "enabled"
             restart:
               type: string
+              description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
               enum:
                 - ""
                 - "RollingUpdate"
             # Need to be StringBool
             troubleshoot:
               type: string
+              description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -984,89 +1377,116 @@ spec:
                 - "enabled"
             namespaceDomainPattern:
               type: string
+              description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
             templating:
               type: object
-              nullable: true
+              # nullable: true
+              description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
               properties:
                 policy:
                   type: string
+                  description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                  enum:
+                    - "auto"
+                    - "manual"
             reconciling:
               type: object
-              nullable: true
+              description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+              # nullable: true
               properties:
                 policy:
                   type: string
                 configMapPropagationTimeout:
                   type: integer
+                  description: |
+                    timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                    see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                   minimum: 0
                   maximum: 3600
                 cleanup:
                   type: object
-                  nullable: true
+                  description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                  # nullable: true
                   properties:
                     unknownObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for unknown StatefulSet, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for unknown PVC, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for unknown ConfigMap, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for unknown Service, Delete by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                     reconcileFailedObjects:
                       type: object
-                      nullable: true
+                      description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                      # nullable: true
                       properties:
                         statefulSet:
                           type: string
+                          description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         pvc:
                           type: string
+                          description: "behavior policy for failed PVC reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         configMap:
                           type: string
+                          description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
                         service:
                           type: string
+                          description: "behavior policy for failed Service reconciling, Retain by default"
                           enum:
                             # List ObjectsCleanupXXX constants from model
                             - "Retain"
                             - "Delete"
             defaults:
               type: object
-              nullable: true
+              description: |
+                define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+              # nullable: true
               properties:
                 # Need to be StringBool
                 replicasUseFQDN:
                   type: string
+                  description: |
+                    define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                    "yes" by default
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -1094,41 +1514,64 @@ spec:
                     - "enabled"
                 distributedDDL:
                   type: object
-                  nullable: true
+                  description: |
+                    allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                    More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                  # nullable: true
                   properties:
                     profile:
                       type: string
+                      description: "Settings from this profile will be used to execute DDL queries"
                 templates:
                   type: object
-                  nullable: true
+                  description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                  # nullable: true
                   properties:
                     hostTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                     podTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     dataVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     logVolumeClaimTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                     serviceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                     clusterServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                     shardServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                     replicaServiceTemplate:
                       type: string
+                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                    volumeClaimTemplate:
+                      type: string
+                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             configuration:
               type: object
-              nullable: true
+              description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+              # nullable: true
               properties:
                 zookeeper:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                    `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                    currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                    More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                  # nullable: true
                   properties:
                     nodes:
                       type: array
-                      nullable: true
+                      description: "describe every available zookeeper cluster node for interaction"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1136,36 +1579,79 @@ spec:
                         properties:
                           host:
                             type: string
+                            description: "dns name or ip address for Zookeeper node"
                           port:
                             type: integer
+                            description: "TCP port which used to connect to Zookeeper node"
                             minimum: 0
                             maximum: 65535
                     session_timeout_ms:
                       type: integer
+                      description: "session timeout during connect to Zookeeper"
                     operation_timeout_ms:
                       type: integer
+                      description: "one operation timeout during Zookeeper transactions"
                     root:
                       type: string
+                      description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                     identity:
                       type: string
+                      description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                 users:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure password hashed, authorization restrictions, database level security row filters etc.
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 profiles:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of settings profile
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 quotas:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                    you can configure any aspect of resource quotas
+                    More details: https://clickhouse.tech/docs/en/operations/quotas/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 settings:
                   type: object
-                  nullable: true
+                  description: |
+                    allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                    Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 files:
                   type: object
-                  nullable: true
+                  description: |
+                    allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                    every key in this object is the file name
+                    every value in this object is the file content
+                    you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                    each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                    More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                  # nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
                 clusters:
                   type: array
-                  nullable: true
+                  description: |
+                    describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                    every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                    all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                    Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                    If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1173,17 +1659,22 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                         minLength: 1
                         # See namePartClusterMaxLen const
                         maxLength: 15
                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                       zookeeper:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.zookeeper` settings
+                        # nullable: true
                         properties:
                           nodes:
                             type: array
-                            nullable: true
+                            description: "describe every available zookeeper cluster node for interaction"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1191,75 +1682,120 @@ spec:
                               properties:
                                 host:
                                   type: string
+                                  description: "dns name or ip address for Zookeeper node"
                                 port:
                                   type: integer
+                                  description: "TCP port which used to connect to Zookeeper node"
                                   minimum: 0
                                   maximum: 65535
                           session_timeout_ms:
                             type: integer
+                            description: "session timeout during connect to Zookeeper"
                           operation_timeout_ms:
                             type: integer
+                            description: "one operation timeout during Zookeeper transactions"
                           root:
                             type: string
+                            description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                           identity:
                             type: string
+                            description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                       settings:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                          override top-level `chi.spec.configuration.settings`
+                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       files:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                          override top-level `chi.spec.configuration.files`
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       templates:
                         type: object
-                        nullable: true
+                        description: |
+                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                          override top-level `chi.spec.configuration.templates`
+                        # nullable: true
                         properties:
                           hostTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                           podTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           dataVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           logVolumeClaimTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                           serviceTemplate:
                             type: string
+                            description: "optional, fully ignores for cluster-level"
                           clusterServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           shardServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                           replicaServiceTemplate:
                             type: string
+                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                          volumeClaimTemplate:
+                            type: string
+                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                       layout:
                         type: object
-                        nullable: true
+                        description: |
+                          describe current cluster layout, how much shards in cluster, how much replica in shard
+                          allows override settings on each shard and replica separatelly
+                        # nullable: true
                         properties:
-                          # DEPRECATED - to be removed soon
                           type:
                             type: string
+                            description: "DEPRECATED - to be removed soon"
                           shardsCount:
                             type: integer
+                            description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                           replicasCount:
                             type: integer
+                            description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                           shards:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
                                 definitionType:
                                   type: string
+                                  description: "DEPRECATED - to be removed soon"
                                 weight:
                                   type: integer
+                                  description: |
+                                    optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                 # Need to be StringBool
                                 internalReplication:
                                   type: string
+                                  description: |
+                                    optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                    allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                    will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                    More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                   enum:
                                     # List StringBoolXXX constants from model
                                     - ""
@@ -1287,193 +1823,319 @@ spec:
                                     - "enabled"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                    override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                    override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
                                     hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for shard-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 replicasCount:
                                   type: integer
+                                  description: |
+                                    optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                    shard contains 1 replica by default
+                                    override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                   minimum: 1
                                 replicas:
                                   type: array
-                                  nullable: true
+                                  description: |
+                                    optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        # nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for replica-level"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           replicas:
                             type: array
-                            nullable: true
+                            description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                            # nullable: true
                             items:
                               type: object
                               properties:
                                 name:
                                   type: string
+                                  description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                   minLength: 1
                                   # See namePartShardMaxLen const
                                   maxLength: 15
                                   pattern: "^[a-zA-Z0-9-]{0,15}$"
                                 settings:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                    override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                    More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                  # nullable: true
+                                  x-kubernetes-preserve-unknown-fields: true
                                 files:
                                   type: object
-                                  nullable: true
+                                  # nullable: true
+                                  description: |
+                                    optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                    override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                  x-kubernetes-preserve-unknown-fields: true
                                 templates:
                                   type: object
-                                  nullable: true
+                                  description: |
+                                    optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                    override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                  # nullable: true
                                   properties:
-                                    hostTeampate:
+                                    hostTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                     podTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                     dataVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     logVolumeClaimTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                     serviceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     clusterServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     shardServiceTemplate:
                                       type: string
+                                      description: "optional, fully ignores for replica-level"
                                     replicaServiceTemplate:
                                       type: string
+                                      description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                    volumeClaimTemplate:
+                                      type: string
+                                      description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                 shardsCount:
                                   type: integer
+                                  description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                   minimum: 1
                                 shards:
                                   type: array
-                                  nullable: true
+                                  description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                  # nullable: true
                                   items:
                                     # Host
                                     type: object
                                     properties:
                                       name:
                                         type: string
+                                        description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                         minLength: 1
                                         # See namePartReplicaMaxLen const
                                         maxLength: 15
                                         pattern: "^[a-zA-Z0-9-]{0,15}$"
                                       tcpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                          allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
                                       httpPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                          allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
-                                      interserverHttpPort:
+                                      interserverHTTPPort:
                                         type: integer
+                                        description: |
+                                          optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                          allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                         minimum: 1
                                         maximum: 65535
                                       settings:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                          override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                          More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       files:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                          override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                        # nullable: true
+                                        x-kubernetes-preserve-unknown-fields: true
                                       templates:
                                         type: object
-                                        nullable: true
+                                        description: |
+                                          optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                          override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                        # nullable: true
                                         properties:
                                           hostTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                           podTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           dataVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           logVolumeClaimTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                           serviceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           clusterServiceTemplate:
                                             type: string
+                                            description: "optional, fully ignores for shard-level"
                                           shardServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                           replicaServiceTemplate:
                                             type: string
+                                            description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                          volumeClaimTemplate:
+                                            type: string
+                                            description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
             templates:
               type: object
-              nullable: true
+              description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+              # nullable: true
               properties:
                 hostTemplates:
                   type: array
-                  nullable: true
+                  description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                  # nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
                     properties:
                       name:
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                         type: string
                       portDistribution:
                         type: array
-                        nullable: true
+                        description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -1481,6 +2143,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                               enum:
                                 # List PortDistributionXXX constants
                                 - ""
@@ -1492,31 +2155,52 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                             minLength: 1
                             # See namePartReplicaMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           tcpPort:
                             type: integer
+                            description: |
+                              optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
                           httpPort:
                             type: integer
+                            description: |
+                              optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                              More info: https://clickhouse.tech/docs/en/interfaces/http/
                             minimum: 1
                             maximum: 65535
-                          interserverHttpPort:
+                          interserverHTTPPort:
                             type: integer
+                            description: |
+                              optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                              More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                             minimum: 1
                             maximum: 65535
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
@@ -1536,7 +2220,10 @@ spec:
                                 type: string
                 podTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                    More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1544,30 +2231,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                       generateName:
                         type: string
+                        description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       zone:
                         type: object
+                        description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         #required:
                         #  - values
                         properties:
                           key:
                             type: string
+                            description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                           values:
                             type: array
-                            nullable: true
+                            description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                            # nullable: true
                             items:
                               type: string
                       distribution:
-                        # DEPRECATED
                         type: string
+                        description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                         enum:
                           - ""
                           - "Unspecified"
                           - "OnePerHost"
                       podDistribution:
                         type: array
-                        nullable: true
+                        description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                        # nullable: true
                         items:
                           type: object
                           #required:
@@ -1575,6 +2268,7 @@ spec:
                           properties:
                             type:
                               type: string
+                              description: "you can define multiple affinity policy types"
                               enum:
                                 # List PodDistributionXXX constants
                                 - ""
@@ -1595,6 +2289,7 @@ spec:
                                 - "CircularReplication"
                             scope:
                               type: string
+                              description: "scope for apply each podDistribution"
                               enum:
                                 # list PodDistributionScopeXXX constants
                                 - ""
@@ -1606,15 +2301,26 @@ spec:
                                 - "Namespace"
                             number:
                               type: integer
+                              description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                               minimum: 0
                               maximum: 65535
                       spec:
                         # TODO specify PodSpec
                         type: object
-                        nullable: true
+                        description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
+                      metadata:
+                        type: object
+                        description: |
+                          allows pass standard object's metadata from template to Pod
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 volumeClaimTemplates:
                   type: array
-                  nullable: true
+                  description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1622,23 +2328,39 @@ spec:
                     #  - spec
                     properties:
                       name:
+                        description: |
+                          template name, could use to link inside
+                          top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                          cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                         type: string
                       reclaimPolicy:
                         type: string
+                        description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                         enum:
                           - ""
                           - "Retain"
                           - "Delete"
                       metadata:
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to PVC
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
-                        # TODO specify PersistentVolumeClaimSpec
                         type: object
-                        nullable: true
+                        description: |
+                          allows define all aspects of `PVC` resource
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                 serviceTemplates:
                   type: array
-                  nullable: true
+                  description: |
+                    allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1647,19 +2369,36 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: |
+                          template name, could use to link inside
+                          chi-level `chi.spec.defaults.templates.serviceTemplate`
+                          cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                          shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                          replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                       generateName:
                         type: string
+                        description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                       metadata:
                         # TODO specify ObjectMeta
                         type: object
-                        nullable: true
+                        description: |
+                          allows pass standard object's metadata from template to Service
+                          Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
                       spec:
                         # TODO specify ServiceSpec
                         type: object
-                        nullable: true
+                        description: |
+                          describe behavior of generated Service
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        # nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
             useTemplates:
               type: array
-              nullable: true
+              description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+              # nullable: true
               items:
                 type: object
                 #required:
@@ -1667,10 +2406,13 @@ spec:
                 properties:
                   name:
                     type: string
+                    description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                   namespace:
                     type: string
+                    description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                   useType:
                     type: string
+                    description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                     enum:
                       # List useTypeXXX constants from model
                       - ""
@@ -1699,65 +2441,102 @@ spec:
   validation:
     openAPIV3Schema:
       type: object
-      # x-kubernetes-preserve-unknown-fields: true
+      description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+      x-kubernetes-preserve-unknown-fields: true
       properties:
         status:
           type: object
           x-kubernetes-preserve-unknown-fields: true
         spec:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: |
+            allows define some of settings for `clickhouse-operator` itself,
+            More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+            look to etc-clickhouse-operator* ConfigMaps if you need more control
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             watchNamespaces:
               type: array
+              description: "List of namespaces where clickhouse-operator watches for events."
               items:
                 type: string
             chCommonConfigsPath:
               type: string
+              description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
             chHostConfigsPath:
               type: string
+              description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
             chUsersConfigsPath:
               type: string
+              description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
             chiTemplatesPath:
               type: string
+              description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
             statefulSetUpdateTimeout:
               type: integer
+              description: "How many seconds to wait for created/updated StatefulSet to be Ready"
             statefulSetUpdatePollPeriod:
               type: integer
+              description: "How many seconds to wait between checks for created/updated StatefulSet status"
             onStatefulSetCreateFailureAction:
               type: string
+              description: |
+                What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                Possible options:
+                1. abort - do nothing, just break the process and wait for admin.
+                2. delete - delete newly created problematic StatefulSet.
+                3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
             onStatefulSetUpdateFailureAction:
               type: string
+              description: |
+                What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                Possible options:
+                1. abort - do nothing, just break the process and wait for admin.
+                2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
             chConfigUserDefaultProfile:
               type: string
+              description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
             chConfigUserDefaultQuota:
               type: string
+              description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
             chConfigUserDefaultNetworksIP:
               type: array
+              description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
               items:
                 type: string
             chConfigUserDefaultPassword:
+              description: "ClickHouse server configuration `<password>...</password>` for any <user>"
               type: string
             chConfigNetworksHostRegexpTemplate:
+              description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
               type: string
             chUsername:
               type: string
+              description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
             chPassword:
               type: string
+              description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
             chCredentialsSecretNamespace:
               type: string
+              description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
             chCredentialsSecretName:
               type: string
+              description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
             chPort:
               type: integer
               minimum: 1
               maximum: 65535
+              description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
             logtostderr:
               type: string
+              description: "boolean, allows logs to stderr"
             alsologtostderr:
               type: string
+              description: "booleanm allows logs to stderr and files both"
             v:
               type: string
+              description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
             stderrthreshold:
               type: string
             vmodule:
@@ -1766,6 +2545,7 @@ spec:
               type: string
             reconcileThreadsNumber:
               type: integer
+              description: "how much goroutines will use to reconcile in parallel, 10 by default"
               minimum: 1
               maximum: 65535
             reconcileWaitExclude:
@@ -1774,10 +2554,14 @@ spec:
               type: string
             excludeFromPropagationLabels:
               type: array
+              description: |
+                When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                exclude labels from the following list
               items:
                 type: string
             appendScopeLabels:
               type: string
+              description: "Whether to append *Scope* labels to StatefulSet and Pod"
               enum:
                 # List StringBoolXXX constants from model
                 - ""
@@ -1803,6 +2587,16 @@ spec:
                 - "disabled"
                 - "Enabled"
                 - "enabled"
+                - "LabelShardScopeIndex"
+                - "LabelReplicaScopeIndex"
+                - "LabelCHIScopeIndex"
+                - "LabelCHIScopeCycleSize"
+                - "LabelCHIScopeCycleIndex"
+                - "LabelCHIScopeCycleOffset"
+                - "LabelClusterScopeIndex"
+                - "LabelClusterScopeCycleSize"
+                - "LabelClusterScopeCycleIndex"
+                - "LabelClusterScopeCycleOffset"
 ---
 # Possible Template Parameters:
 #
@@ -1815,6 +2609,8 @@ kind: ServiceAccount
 metadata:
   name: clickhouse-operator
   namespace: kube-system
+spec:
+  additionalPrinterColumns: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1933,6 +2729,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+spec:
+  additionalPrinterColumns: []
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name
@@ -1948,6 +2753,8 @@ subjects:
   - kind: ServiceAccount
     name: clickhouse-operator
     namespace: kube-system
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2119,6 +2926,8 @@ data:
     #  LabelClusterScopeCycleIndex
     #  LabelClusterScopeCycleOffset
     appendScopeLabels: "no"
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2134,6 +2943,8 @@ metadata:
   labels:
     app: clickhouse-operator
 data:
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2188,6 +2999,8 @@ data:
             <flush_interval_milliseconds>7500</flush_interval_milliseconds>
         </part_log>
     </yandex>
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2285,6 +3098,8 @@ data:
                   storage: 2Gi
   readme: |
     Templates in this folder are packaged with an operator and available via 'useTemplate'
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2342,6 +3157,8 @@ data:
             </default>
         </profiles>
     </yandex>
+spec:
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2466,6 +3283,7 @@ spec:
               mountPath: /etc/clickhouse-operator/templates.d
             - name: etc-clickhouse-operator-usersd-folder
               mountPath: /etc/clickhouse-operator/users.d
+  additionalPrinterColumns: []
 ---
 # Possible Template Parameters:
 #
@@ -2489,3 +3307,4 @@ spec:
       name: clickhouse-operator-metrics
   selector:
     app: clickhouse-operator
+  additionalPrinterColumns: []

--- a/deploy/operator/clickhouse-operator-install.yaml
+++ b/deploy/operator/clickhouse-operator-install.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallation
@@ -12,216 +11,82 @@ spec:
     plural: clickhouseinstallations
     shortNames:
       - chi
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -248,422 +113,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -690,156 +388,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseInstallationTemplate
@@ -847,216 +849,82 @@ spec:
     plural: clickhouseinstallationtemplates
     shortNames:
       - chit
-  additionalPrinterColumns:
-    - name: version
-      type: string
-      description: Operator version
-      priority: 1 # show in wide view
-      JSONPath: .status.version
-    - name: clusters
-      type: integer
-      description: Clusters count
-      priority: 0 # show in standard view
-      JSONPath: .status.clusters
-    - name: shards
-      type: integer
-      description: Shards count
-      priority: 1 # show in wide view
-      JSONPath: .status.shards
-    - name: hosts
-      type: integer
-      description: Hosts count
-      priority: 0 # show in standard view
-      JSONPath: .status.hosts
-    - name: taskID
-      type: string
-      description: TaskID
-      priority: 1 # show in wide view
-      JSONPath: .status.taskID
-    - name: status
-      type: string
-      description: CHI status
-      priority: 0 # show in standard view
-      JSONPath: .status.status
-    - name: updated
-      type: integer
-      description: Updated hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.updated
-    - name: added
-      type: integer
-      description: Added hosts count
-      priority: 1 # show in wide view
-      JSONPath: .status.added
-    - name: deleted
-      type: integer
-      description: Hosts deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.deleted
-    - name: delete
-      type: integer
-      description: Hosts to be deleted count
-      priority: 1 # show in wide view
-      JSONPath: .status.delete
-    - name: endpoint
-      type: string
-      description: Client access endpoint
-      priority: 1 # show in wide view
-      JSONPath: .status.endpoint
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: version
+          type: string
+          description: Operator version
+          priority: 1 # show in wide view
+          jsonPath: .status.version
+        - name: clusters
+          type: integer
+          description: Clusters count
+          priority: 0 # show in standard view
+          jsonPath: .status.clusters
+        - name: shards
+          type: integer
+          description: Shards count
+          priority: 1 # show in wide view
+          jsonPath: .status.shards
+        - name: hosts
+          type: integer
+          description: Hosts count
+          priority: 0 # show in standard view
+          jsonPath: .status.hosts
+        - name: taskID
+          type: string
+          description: TaskID
+          priority: 1 # show in wide view
+          jsonPath: .status.taskID
+        - name: status
+          type: string
+          description: CHI status
+          priority: 0 # show in standard view
+          jsonPath: .status.status
+        - name: updated
+          type: integer
+          description: Updated hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.updated
+        - name: added
+          type: integer
+          description: Added hosts count
+          priority: 1 # show in wide view
+          jsonPath: .status.added
+        - name: deleted
+          type: integer
+          description: Hosts deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.deleted
+        - name: delete
+          type: integer
+          description: Hosts to be deleted count
+          priority: 1 # show in wide view
+          jsonPath: .status.delete
+        - name: endpoint
+          type: string
+          description: Client access endpoint
+          priority: 1 # show in wide view
+          jsonPath: .status.endpoint
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            taskID:
-              type: string
-            # Need to be StringBool
-            stop:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            # Need to be StringBool
-            troubleshoot:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
-            namespaceDomainPattern:
-              type: string
-            templating:
+            status:
               type: object
-              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
               properties:
-                policy:
+                taskID:
                   type: string
-            reconciling:
-              type: object
-              nullable: true
-              properties:
-                policy:
-                  type: string
-                configMapPropagationTimeout:
-                  type: integer
-                  minimum: 0
-                  maximum: 3600
-                cleanup:
-                  type: object
-                  nullable: true
-                  properties:
-                    unknownObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                    reconcileFailedObjects:
-                      type: object
-                      nullable: true
-                      properties:
-                        statefulSet:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        pvc:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        configMap:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-                        service:
-                          type: string
-                          enum:
-                            # List ObjectsCleanupXXX constants from model
-                            - "Retain"
-                            - "Delete"
-            defaults:
-              type: object
-              nullable: true
-              properties:
                 # Need to be StringBool
-                replicasUseFQDN:
+                stop:
                   type: string
                   enum:
                     # List StringBoolXXX constants from model
@@ -1083,422 +951,255 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
-                distributedDDL:
+                # Need to be StringBool
+                troubleshoot:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                namespaceDomainPattern:
+                  type: string
+                templating:
                   type: object
                   nullable: true
                   properties:
-                    profile:
+                    policy:
                       type: string
-                templates:
+                reconciling:
                   type: object
                   nullable: true
                   properties:
-                    hostTemplate:
+                    policy:
                       type: string
-                    podTemplate:
-                      type: string
-                    dataVolumeClaimTemplate:
-                      type: string
-                    logVolumeClaimTemplate:
-                      type: string
-                    serviceTemplate:
-                      type: string
-                    clusterServiceTemplate:
-                      type: string
-                    shardServiceTemplate:
-                      type: string
-                    replicaServiceTemplate:
-                      type: string
-            configuration:
-              type: object
-              nullable: true
-              properties:
-                zookeeper:
+                    configMapPropagationTimeout:
+                      type: integer
+                      minimum: 0
+                      maximum: 3600
+                    cleanup:
+                      type: object
+                      nullable: true
+                      properties:
+                        unknownObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                        reconcileFailedObjects:
+                          type: object
+                          nullable: true
+                          properties:
+                            statefulSet:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            pvc:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            configMap:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                            service:
+                              type: string
+                              enum:
+                                # List ObjectsCleanupXXX constants from model
+                                - "Retain"
+                                - "Delete"
+                defaults:
                   type: object
                   nullable: true
                   properties:
-                    nodes:
+                    # Need to be StringBool
+                    replicasUseFQDN:
+                      type: string
+                      enum:
+                        # List StringBoolXXX constants from model
+                        - ""
+                        - "0"
+                        - "1"
+                        - "False"
+                        - "false"
+                        - "True"
+                        - "true"
+                        - "No"
+                        - "no"
+                        - "Yes"
+                        - "yes"
+                        - "Off"
+                        - "off"
+                        - "On"
+                        - "on"
+                        - "Disable"
+                        - "disable"
+                        - "Enable"
+                        - "enable"
+                        - "Disabled"
+                        - "disabled"
+                        - "Enabled"
+                        - "enabled"
+                    distributedDDL:
+                      type: object
+                      nullable: true
+                      properties:
+                        profile:
+                          type: string
+                    templates:
+                      type: object
+                      nullable: true
+                      properties:
+                        hostTemplate:
+                          type: string
+                        podTemplate:
+                          type: string
+                        dataVolumeClaimTemplate:
+                          type: string
+                        logVolumeClaimTemplate:
+                          type: string
+                        serviceTemplate:
+                          type: string
+                        clusterServiceTemplate:
+                          type: string
+                        shardServiceTemplate:
+                          type: string
+                        replicaServiceTemplate:
+                          type: string
+                configuration:
+                  type: object
+                  nullable: true
+                  properties:
+                    zookeeper:
+                      type: object
+                      nullable: true
+                      properties:
+                        nodes:
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            #required:
+                            #  - host
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                type: integer
+                                minimum: 0
+                                maximum: 65535
+                        session_timeout_ms:
+                          type: integer
+                        operation_timeout_ms:
+                          type: integer
+                        root:
+                          type: string
+                        identity:
+                          type: string
+                    users:
+                      type: object
+                      nullable: true
+                    profiles:
+                      type: object
+                      nullable: true
+                    quotas:
+                      type: object
+                      nullable: true
+                    settings:
+                      type: object
+                      nullable: true
+                    files:
+                      type: object
+                      nullable: true
+                    clusters:
                       type: array
                       nullable: true
                       items:
                         type: object
                         #required:
-                        #  - host
-                        properties:
-                          host:
-                            type: string
-                          port:
-                            type: integer
-                            minimum: 0
-                            maximum: 65535
-                    session_timeout_ms:
-                      type: integer
-                    operation_timeout_ms:
-                      type: integer
-                    root:
-                      type: string
-                    identity:
-                      type: string
-                users:
-                  type: object
-                  nullable: true
-                profiles:
-                  type: object
-                  nullable: true
-                quotas:
-                  type: object
-                  nullable: true
-                settings:
-                  type: object
-                  nullable: true
-                files:
-                  type: object
-                  nullable: true
-                clusters:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                        # See namePartClusterMaxLen const
-                        maxLength: 15
-                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                      zookeeper:
-                        type: object
-                        nullable: true
-                        properties:
-                          nodes:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              #required:
-                              #  - host
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  type: integer
-                                  minimum: 0
-                                  maximum: 65535
-                          session_timeout_ms:
-                            type: integer
-                          operation_timeout_ms:
-                            type: integer
-                          root:
-                            type: string
-                          identity:
-                            type: string
-                      settings:
-                        type: object
-                        nullable: true
-                      files:
-                        type: object
-                        nullable: true
-                      templates:
-                        type: object
-                        nullable: true
-                        properties:
-                          hostTemplate:
-                            type: string
-                          podTemplate:
-                            type: string
-                          dataVolumeClaimTemplate:
-                            type: string
-                          logVolumeClaimTemplate:
-                            type: string
-                          serviceTemplate:
-                            type: string
-                          clusterServiceTemplate:
-                            type: string
-                          shardServiceTemplate:
-                            type: string
-                          replicaServiceTemplate:
-                            type: string
-                      layout:
-                        type: object
-                        nullable: true
-                        properties:
-                          # DEPRECATED - to be removed soon
-                          type:
-                            type: string
-                          shardsCount:
-                            type: integer
-                          replicasCount:
-                            type: integer
-                          shards:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                # DEPRECATED - to be removed soon
-                                definitionType:
-                                  type: string
-                                weight:
-                                  type: integer
-                                # Need to be StringBool
-                                internalReplication:
-                                  type: string
-                                  enum:
-                                    # List StringBoolXXX constants from model
-                                    - ""
-                                    - "0"
-                                    - "1"
-                                    - "False"
-                                    - "false"
-                                    - "True"
-                                    - "true"
-                                    - "No"
-                                    - "no"
-                                    - "Yes"
-                                    - "yes"
-                                    - "Off"
-                                    - "off"
-                                    - "On"
-                                    - "on"
-                                    - "Disable"
-                                    - "disable"
-                                    - "Enable"
-                                    - "enable"
-                                    - "Disabled"
-                                    - "disabled"
-                                    - "Enabled"
-                                    - "enabled"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTemplate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                replicasCount:
-                                  type: integer
-                                  minimum: 1
-                                replicas:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-                          replicas:
-                            type: array
-                            nullable: true
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                  # See namePartShardMaxLen const
-                                  maxLength: 15
-                                  pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                settings:
-                                  type: object
-                                  nullable: true
-                                files:
-                                  type: object
-                                  nullable: true
-                                templates:
-                                  type: object
-                                  nullable: true
-                                  properties:
-                                    hostTeampate:
-                                      type: string
-                                    podTemplate:
-                                      type: string
-                                    dataVolumeClaimTemplate:
-                                      type: string
-                                    logVolumeClaimTemplate:
-                                      type: string
-                                    serviceTemplate:
-                                      type: string
-                                    clusterServiceTemplate:
-                                      type: string
-                                    shardServiceTemplate:
-                                      type: string
-                                    replicaServiceTemplate:
-                                      type: string
-                                shardsCount:
-                                  type: integer
-                                  minimum: 1
-                                shards:
-                                  type: array
-                                  nullable: true
-                                  items:
-                                    # Host
-                                    type: object
-                                    properties:
-                                      name:
-                                        type: string
-                                        minLength: 1
-                                        # See namePartReplicaMaxLen const
-                                        maxLength: 15
-                                        pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                      tcpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      httpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      interserverHttpPort:
-                                        type: integer
-                                        minimum: 1
-                                        maximum: 65535
-                                      settings:
-                                        type: object
-                                        nullable: true
-                                      files:
-                                        type: object
-                                        nullable: true
-                                      templates:
-                                        type: object
-                                        nullable: true
-                                        properties:
-                                          hostTemplate:
-                                            type: string
-                                          podTemplate:
-                                            type: string
-                                          dataVolumeClaimTemplate:
-                                            type: string
-                                          logVolumeClaimTemplate:
-                                            type: string
-                                          serviceTemplate:
-                                            type: string
-                                          clusterServiceTemplate:
-                                            type: string
-                                          shardServiceTemplate:
-                                            type: string
-                                          replicaServiceTemplate:
-                                            type: string
-            templates:
-              type: object
-              nullable: true
-              properties:
-                hostTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      portDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PortDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClusterScopeIndex"
-                      spec:
-                        # Host
-                        type: object
+                        #  - name
                         properties:
                           name:
                             type: string
                             minLength: 1
-                            # See namePartReplicaMaxLen const
+                            # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
-                          tcpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          httpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
-                          interserverHttpPort:
-                            type: integer
-                            minimum: 1
-                            maximum: 65535
+                          zookeeper:
+                            type: object
+                            nullable: true
+                            properties:
+                              nodes:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  #required:
+                                  #  - host
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      type: integer
+                                      minimum: 0
+                                      maximum: 65535
+                              session_timeout_ms:
+                                type: integer
+                              operation_timeout_ms:
+                                type: integer
+                              root:
+                                type: string
+                              identity:
+                                type: string
                           settings:
                             type: object
                             nullable: true
@@ -1525,156 +1226,460 @@ spec:
                                 type: string
                               replicaServiceTemplate:
                                 type: string
-
-                podTemplates:
-                  type: array
+                          layout:
+                            type: object
+                            nullable: true
+                            properties:
+                              # DEPRECATED - to be removed soon
+                              type:
+                                type: string
+                              shardsCount:
+                                type: integer
+                              replicasCount:
+                                type: integer
+                              shards:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    # DEPRECATED - to be removed soon
+                                    definitionType:
+                                      type: string
+                                    weight:
+                                      type: integer
+                                    # Need to be StringBool
+                                    internalReplication:
+                                      type: string
+                                      enum:
+                                        # List StringBoolXXX constants from model
+                                        - ""
+                                        - "0"
+                                        - "1"
+                                        - "False"
+                                        - "false"
+                                        - "True"
+                                        - "true"
+                                        - "No"
+                                        - "no"
+                                        - "Yes"
+                                        - "yes"
+                                        - "Off"
+                                        - "off"
+                                        - "On"
+                                        - "on"
+                                        - "Disable"
+                                        - "disable"
+                                        - "Enable"
+                                        - "enable"
+                                        - "Disabled"
+                                        - "disabled"
+                                        - "Enabled"
+                                        - "enabled"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTemplate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    replicasCount:
+                                      type: integer
+                                      minimum: 1
+                                    replicas:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                              replicas:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                      # See namePartShardMaxLen const
+                                      maxLength: 15
+                                      pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                    settings:
+                                      type: object
+                                      nullable: true
+                                    files:
+                                      type: object
+                                      nullable: true
+                                    templates:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        hostTeampate:
+                                          type: string
+                                        podTemplate:
+                                          type: string
+                                        dataVolumeClaimTemplate:
+                                          type: string
+                                        logVolumeClaimTemplate:
+                                          type: string
+                                        serviceTemplate:
+                                          type: string
+                                        clusterServiceTemplate:
+                                          type: string
+                                        shardServiceTemplate:
+                                          type: string
+                                        replicaServiceTemplate:
+                                          type: string
+                                    shardsCount:
+                                      type: integer
+                                      minimum: 1
+                                    shards:
+                                      type: array
+                                      nullable: true
+                                      items:
+                                        # Host
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                            minLength: 1
+                                            # See namePartReplicaMaxLen const
+                                            maxLength: 15
+                                            pattern: "^[a-zA-Z0-9-]{0,15}$"
+                                          tcpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          httpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          interserverHttpPort:
+                                            type: integer
+                                            minimum: 1
+                                            maximum: 65535
+                                          settings:
+                                            type: object
+                                            nullable: true
+                                          files:
+                                            type: object
+                                            nullable: true
+                                          templates:
+                                            type: object
+                                            nullable: true
+                                            properties:
+                                              hostTemplate:
+                                                type: string
+                                              podTemplate:
+                                                type: string
+                                              dataVolumeClaimTemplate:
+                                                type: string
+                                              logVolumeClaimTemplate:
+                                                type: string
+                                              serviceTemplate:
+                                                type: string
+                                              clusterServiceTemplate:
+                                                type: string
+                                              shardServiceTemplate:
+                                                type: string
+                                              replicaServiceTemplate:
+                                                type: string
+                templates:
+                  type: object
                   nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      zone:
+                  properties:
+                    hostTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
                         #required:
-                        #  - values
+                        #  - name
                         properties:
-                          key:
+                          name:
                             type: string
-                          values:
+                          portDistribution:
                             type: array
                             nullable: true
                             items:
-                              type: string
-                      distribution:
-                        # DEPRECATED
-                        type: string
-                        enum:
-                          - ""
-                          - "Unspecified"
-                          - "OnePerHost"
-                      podDistribution:
-                        type: array
-                        nullable: true
-                        items:
-                          type: object
-                          #required:
-                          #  - type
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                # List PodDistributionXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "ClickHouseAntiAffinity"
-                                - "ShardAntiAffinity"
-                                - "ReplicaAntiAffinity"
-                                - "AnotherNamespaceAntiAffinity"
-                                - "AnotherClickHouseInstallationAntiAffinity"
-                                - "AnotherClusterAntiAffinity"
-                                - "MaxNumberPerNode"
-                                - "NamespaceAffinity"
-                                - "ClickHouseInstallationAffinity"
-                                - "ClusterAffinity"
-                                - "ShardAffinity"
-                                - "ReplicaAffinity"
-                                - "PreviousTailAffinity"
-                                - "CircularReplication"
-                            scope:
-                              type: string
-                              enum:
-                                # list PodDistributionScopeXXX constants
-                                - ""
-                                - "Unspecified"
-                                - "Shard"
-                                - "Replica"
-                                - "Cluster"
-                                - "ClickHouseInstallation"
-                                - "Namespace"
-                            number:
-                              type: integer
-                              minimum: 0
-                              maximum: 65535
-                      spec:
-                        # TODO specify PodSpec
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PortDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClusterScopeIndex"
+                          spec:
+                            # Host
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                                # See namePartReplicaMaxLen const
+                                maxLength: 15
+                                pattern: "^[a-zA-Z0-9-]{0,15}$"
+                              tcpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              httpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              interserverHttpPort:
+                                type: integer
+                                minimum: 1
+                                maximum: 65535
+                              settings:
+                                type: object
+                                nullable: true
+                              files:
+                                type: object
+                                nullable: true
+                              templates:
+                                type: object
+                                nullable: true
+                                properties:
+                                  hostTemplate:
+                                    type: string
+                                  podTemplate:
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    type: string
+                                  logVolumeClaimTemplate:
+                                    type: string
+                                  serviceTemplate:
+                                    type: string
+                                  clusterServiceTemplate:
+                                    type: string
+                                  shardServiceTemplate:
+                                    type: string
+                                  replicaServiceTemplate:
+                                    type: string
+
+                    podTemplates:
+                      type: array
+                      nullable: true
+                      items:
                         type: object
-                        nullable: true
-                volumeClaimTemplates:
+                        #required:
+                        #  - name
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          zone:
+                            type: object
+                            #required:
+                            #  - values
+                            properties:
+                              key:
+                                type: string
+                              values:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                          distribution:
+                            # DEPRECATED
+                            type: string
+                            enum:
+                              - ""
+                              - "Unspecified"
+                              - "OnePerHost"
+                          podDistribution:
+                            type: array
+                            nullable: true
+                            items:
+                              type: object
+                              #required:
+                              #  - type
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    # List PodDistributionXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "ClickHouseAntiAffinity"
+                                    - "ShardAntiAffinity"
+                                    - "ReplicaAntiAffinity"
+                                    - "AnotherNamespaceAntiAffinity"
+                                    - "AnotherClickHouseInstallationAntiAffinity"
+                                    - "AnotherClusterAntiAffinity"
+                                    - "MaxNumberPerNode"
+                                    - "NamespaceAffinity"
+                                    - "ClickHouseInstallationAffinity"
+                                    - "ClusterAffinity"
+                                    - "ShardAffinity"
+                                    - "ReplicaAffinity"
+                                    - "PreviousTailAffinity"
+                                    - "CircularReplication"
+                                scope:
+                                  type: string
+                                  enum:
+                                    # list PodDistributionScopeXXX constants
+                                    - ""
+                                    - "Unspecified"
+                                    - "Shard"
+                                    - "Replica"
+                                    - "Cluster"
+                                    - "ClickHouseInstallation"
+                                    - "Namespace"
+                                number:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 65535
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            nullable: true
+                    volumeClaimTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          reclaimPolicy:
+                            type: string
+                            enum:
+                              - ""
+                              - "Retain"
+                              - "Delete"
+                          metadata:
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify PersistentVolumeClaimSpec
+                            type: object
+                            nullable: true
+                    serviceTemplates:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        #required:
+                        #  - name
+                        #  - spec
+                        properties:
+                          name:
+                            type: string
+                          generateName:
+                            type: string
+                          metadata:
+                            # TODO specify ObjectMeta
+                            type: object
+                            nullable: true
+                          spec:
+                            # TODO specify ServiceSpec
+                            type: object
+                            nullable: true
+                useTemplates:
                   type: array
                   nullable: true
                   items:
                     type: object
                     #required:
                     #  - name
-                    #  - spec
                     properties:
                       name:
                         type: string
-                      reclaimPolicy:
+                      namespace:
+                        type: string
+                      useType:
                         type: string
                         enum:
+                          # List useTypeXXX constants from model
                           - ""
-                          - "Retain"
-                          - "Delete"
-                      metadata:
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify PersistentVolumeClaimSpec
-                        type: object
-                        nullable: true
-                serviceTemplates:
-                  type: array
-                  nullable: true
-                  items:
-                    type: object
-                    #required:
-                    #  - name
-                    #  - spec
-                    properties:
-                      name:
-                        type: string
-                      generateName:
-                        type: string
-                      metadata:
-                        # TODO specify ObjectMeta
-                        type: object
-                        nullable: true
-                      spec:
-                        # TODO specify ServiceSpec
-                        type: object
-                        nullable: true
-            useTemplates:
-              type: array
-              nullable: true
-              items:
-                type: object
-                #required:
-                #  - name
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  useType:
-                    type: string
-                    enum:
-                      # List useTypeXXX constants from model
-                      - ""
-                      - "merge"
+                          - "merge"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
 spec:
   group: clickhouse.altinity.com
-  version: v1
   scope: Namespaced
   names:
     kind: ClickHouseOperatorConfiguration
@@ -1682,119 +1687,125 @@ spec:
     plural: clickhouseoperatorconfigurations
     shortNames:
       - chopconf
-  additionalPrinterColumns:
-    - name: namespaces
-      type: string
-      description: Watch namespaces
-      priority: 0 # show in standard view
-      JSONPath: .status
-  # TODO return to this feature later
-  # Pruning unknown fields. FEATURE STATE: Kubernetes v1.15
-  # Probably full specification may be needed
-  #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: namespaces
+          type: string
+          description: Watch namespaces
+          priority: 0 # show in standard view
+          jsonPath: .status
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          # x-kubernetes-preserve-unknown-fields: true
           properties:
-            watchNamespaces:
-              type: array
-              items:
-                type: string
-            chCommonConfigsPath:
-              type: string
-            chHostConfigsPath:
-              type: string
-            chUsersConfigsPath:
-              type: string
-            chiTemplatesPath:
-              type: string
-            statefulSetUpdateTimeout:
-              type: integer
-            statefulSetUpdatePollPeriod:
-              type: integer
-            onStatefulSetCreateFailureAction:
-              type: string
-            onStatefulSetUpdateFailureAction:
-              type: string
-            chConfigUserDefaultProfile:
-              type: string
-            chConfigUserDefaultQuota:
-              type: string
-            chConfigUserDefaultNetworksIP:
-              type: array
-              items:
-                type: string
-            chConfigUserDefaultPassword:
-              type: string
-            chConfigNetworksHostRegexpTemplate:
-              type: string
-            chUsername:
-              type: string
-            chPassword:
-              type: string
-            chCredentialsSecretNamespace:
-              type: string
-            chCredentialsSecretName:
-              type: string
-            chPort:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            logtostderr:
-              type: string
-            alsologtostderr:
-              type: string
-            v:
-              type: string
-            stderrthreshold:
-              type: string
-            vmodule:
-              type: string
-            log_backtrace_at:
-              type: string
-            reconcileThreadsNumber:
-              type: integer
-              minimum: 1
-              maximum: 65535
-            reconcileWaitExclude:
-              type: string
-            reconcileWaitInclude:
-              type: string
-            excludeFromPropagationLabels:
-              type: array
-              items:
-                type: string
-            appendScopeLabels:
-              type: string
-              enum:
-                # List StringBoolXXX constants from model
-                - ""
-                - "0"
-                - "1"
-                - "False"
-                - "false"
-                - "True"
-                - "true"
-                - "No"
-                - "no"
-                - "Yes"
-                - "yes"
-                - "Off"
-                - "off"
-                - "On"
-                - "on"
-                - "Disable"
-                - "disable"
-                - "Enable"
-                - "enable"
-                - "Disabled"
-                - "disabled"
-                - "Enabled"
-                - "enabled"
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              # x-kubernetes-preserve-unknown-fields: true
+              properties:
+                watchNamespaces:
+                  type: array
+                  items:
+                    type: string
+                chCommonConfigsPath:
+                  type: string
+                chHostConfigsPath:
+                  type: string
+                chUsersConfigsPath:
+                  type: string
+                chiTemplatesPath:
+                  type: string
+                statefulSetUpdateTimeout:
+                  type: integer
+                statefulSetUpdatePollPeriod:
+                  type: integer
+                onStatefulSetCreateFailureAction:
+                  type: string
+                onStatefulSetUpdateFailureAction:
+                  type: string
+                chConfigUserDefaultProfile:
+                  type: string
+                chConfigUserDefaultQuota:
+                  type: string
+                chConfigUserDefaultNetworksIP:
+                  type: array
+                  items:
+                    type: string
+                chConfigUserDefaultPassword:
+                  type: string
+                chConfigNetworksHostRegexpTemplate:
+                  type: string
+                chUsername:
+                  type: string
+                chPassword:
+                  type: string
+                chCredentialsSecretNamespace:
+                  type: string
+                chCredentialsSecretName:
+                  type: string
+                chPort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                logtostderr:
+                  type: string
+                alsologtostderr:
+                  type: string
+                v:
+                  type: string
+                stderrthreshold:
+                  type: string
+                vmodule:
+                  type: string
+                log_backtrace_at:
+                  type: string
+                reconcileThreadsNumber:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                reconcileWaitExclude:
+                  type: string
+                reconcileWaitInclude:
+                  type: string
+                excludeFromPropagationLabels:
+                  type: array
+                  items:
+                    type: string
+                appendScopeLabels:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
 ---
 # Possible Template Parameters:
 #

--- a/deploy/operator/clickhouse-operator-install.yaml
+++ b/deploy/operator/clickhouse-operator-install.yaml
@@ -73,21 +73,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -115,12 +139,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -148,89 +174,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -258,41 +311,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -300,36 +376,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -337,17 +456,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -355,75 +479,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -451,193 +621,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -645,6 +941,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -656,31 +953,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -701,7 +1019,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -709,30 +1030,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -740,6 +1067,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -760,6 +1088,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -771,15 +1100,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -787,23 +1128,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -812,19 +1169,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -832,10 +1206,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -916,21 +1293,45 @@ spec:
           jsonPath: .status.endpoint
       schema:
         openAPIV3Schema:
+          description: "define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`"
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          required:
+            - spec
           properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
             status:
               type: object
+              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                Specification of the desired behavior of one or more ClickHouse clusters
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md"
               properties:
                 taskID:
                   type: string
+                  description: "Allow define custom taskID for named update and watch status of this update execution in .status.taskIDs field, by default every update of chi manifest will generate random taskID"
                 # Need to be StringBool
                 stop:
                   type: string
+                  description: |
+                    Allow stop all ClickHouse clusters described in current chi.
+                    Stop mechanism works as follows:
+                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
+                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -958,12 +1359,14 @@ spec:
                     - "enabled"
                 restart:
                   type: string
+                  description: "restart policy for StatefulSets. When value `RollingUpdate` it allow graceful restart one by one instead of restart all StatefulSet simultaneously"
                   enum:
                     - ""
                     - "RollingUpdate"
                 # Need to be StringBool
                 troubleshoot:
                   type: string
+                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -991,89 +1394,116 @@ spec:
                     - "enabled"
                 namespaceDomainPattern:
                   type: string
+                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
                 templating:
                   type: object
-                  nullable: true
+                  # nullable: true
+                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
                   properties:
                     policy:
                       type: string
+                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      enum:
+                        - "auto"
+                        - "manual"
                 reconciling:
                   type: object
-                  nullable: true
+                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  # nullable: true
                   properties:
                     policy:
                       type: string
                     configMapPropagationTimeout:
                       type: integer
+                      description: |
+                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
+                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      nullable: true
+                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for unknown StatefulSet, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for unknown PVC, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for unknown ConfigMap, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for unknown Service, Delete by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                         reconcileFailedObjects:
                           type: object
-                          nullable: true
+                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          # nullable: true
                           properties:
                             statefulSet:
                               type: string
+                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
+                              description: "behavior policy for failed PVC reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             configMap:
                               type: string
+                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                             service:
                               type: string
+                              description: "behavior policy for failed Service reconciling, Retain by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
                                 - "Retain"
                                 - "Delete"
                 defaults:
                   type: object
-                  nullable: true
+                  description: |
+                    define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level
+                    More info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults
+                  # nullable: true
                   properties:
                     # Need to be StringBool
                     replicasUseFQDN:
                       type: string
+                      description: |
+                        define should replicas be specified by FQDN in `<host></host>`, then "no" then will use short hostname and clickhouse-server will use kubernetes default suffixes for properly DNS lookup
+                        "yes" by default
                       enum:
                         # List StringBoolXXX constants from model
                         - ""
@@ -1101,41 +1531,64 @@ spec:
                         - "enabled"
                     distributedDDL:
                       type: object
-                      nullable: true
+                      description: |
+                        allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings
+                        More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl
+                      # nullable: true
                       properties:
                         profile:
                           type: string
+                          description: "Settings from this profile will be used to execute DDL queries"
                     templates:
                       type: object
-                      nullable: true
+                      description: "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource"
+                      # nullable: true
                       properties:
                         hostTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
                         podTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         dataVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         logVolumeClaimTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
                         clusterServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         shardServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
                         replicaServiceTemplate:
                           type: string
+                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                        volumeClaimTemplate:
+                          type: string
+                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 configuration:
                   type: object
-                  nullable: true
+                  description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                  # nullable: true
                   properties:
                     zookeeper:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                        `clickhouse-operator` itself doesn't manage Zookeeper, please install Zookeeper separatelly look examples on https://github.com/Altinity/clickhouse-operator/tree/master/deploy/zookeeper/
+                        currently, zookeeper (or clickhouse-keeper replacement) used for *ReplicatedMergeTree table engines and for `distributed_ddl`
+                        More details: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+                      # nullable: true
                       properties:
                         nodes:
                           type: array
-                          nullable: true
+                          description: "describe every available zookeeper cluster node for interaction"
+                          # nullable: true
                           items:
                             type: object
                             #required:
@@ -1143,36 +1596,79 @@ spec:
                             properties:
                               host:
                                 type: string
+                                description: "dns name or ip address for Zookeeper node"
                               port:
                                 type: integer
+                                description: "TCP port which used to connect to Zookeeper node"
                                 minimum: 0
                                 maximum: 65535
                         session_timeout_ms:
                           type: integer
+                          description: "session timeout during connect to Zookeeper"
                         operation_timeout_ms:
                           type: integer
+                          description: "one operation timeout during Zookeeper transactions"
                         root:
                           type: string
+                          description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                         identity:
                           type: string
+                          description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                     users:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure password hashed, authorization restrictions, database level security row filters etc.
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     profiles:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><profiles>..</profiles></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of settings profile
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationprofiles
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure <yandex><quotas>..</quotas></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`
+                        you can configure any aspect of resource quotas
+                        More details: https://clickhouse.tech/docs/en/operations/quotas/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationquotas
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
-                      nullable: true
+                      description: |
+                        allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                        Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     files:
                       type: object
-                      nullable: true
+                      description: |
+                        allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                        every key in this object is the file name
+                        every value in this object is the file content
+                        you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
+                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
-                      nullable: true
+                      description: |
+                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
+                        all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
+                        Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
+                        If `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1180,17 +1676,22 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                           zookeeper:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure <yandex><zookeeper>..</zookeeper></yandex> section in each `Pod` only in current ClickHouse cluster, during generate `ConfigMap` which will mounted in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.zookeeper` settings
+                            # nullable: true
                             properties:
                               nodes:
                                 type: array
-                                nullable: true
+                                description: "describe every available zookeeper cluster node for interaction"
+                                # nullable: true
                                 items:
                                   type: object
                                   #required:
@@ -1198,75 +1699,121 @@ spec:
                                   properties:
                                     host:
                                       type: string
+                                      description: "dns name or ip address for Zookeeper node"
                                     port:
                                       type: integer
+                                      description: "TCP port which used to connect to Zookeeper node"
                                       minimum: 0
                                       maximum: 65535
                               session_timeout_ms:
                                 type: integer
+                                description: "session timeout during connect to Zookeeper"
                               operation_timeout_ms:
                                 type: integer
+                                description: "one operation timeout during Zookeeper transactions"
                               root:
                                 type: string
+                                description: "optional root znode path inside zookeeper to store ClickHouse related data (replication queue or distributed DDL)"
                               identity:
                                 type: string
+                                description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
                           settings:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                              override top-level `chi.spec.configuration.settings`
+                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           files:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                              override top-level `chi.spec.configuration.files`
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           templates:
                             type: object
-                            nullable: true
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
+                            # nullable: true
                             properties:
                               hostTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one cluster"
                               podTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               dataVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               logVolumeClaimTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one cluster"
                               serviceTemplate:
                                 type: string
+                                description: "optional, fully ignores for cluster-level"
                               clusterServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               shardServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
                               replicaServiceTemplate:
                                 type: string
+                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters` only for one cluster"
+                              volumeClaimTemplate:
+                                type: string
+                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                           layout:
                             type: object
-                            nullable: true
+                            description: |
+                              describe current cluster layout, how much shards in cluster, how much replica in shard
+                              allows override settings on each shard and replica separatelly
+                            # nullable: true
                             properties:
-                              # DEPRECATED - to be removed soon
                               type:
                                 type: string
+                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
+                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
+                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
-                                    # DEPRECATED - to be removed soon
+
                                     definitionType:
                                       type: string
+                                      description: "DEPRECATED - to be removed soon"
                                     weight:
                                       type: integer
+                                      description: |
+                                        optional, 1 by default, allows setup shard <weight> setting which will use during insert into tables with `Distributed` engine,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                     # Need to be StringBool
                                     internalReplication:
                                       type: string
+                                      description: |
+                                        optional, `true` by default when `chi.spec.configuration.clusters[].layout.ReplicaCount` > 1 and 0 otherwise
+                                        allows setup <internal_replication> setting which will use during insert into tables with `Distributed` engine for insert only in one live replica and other replicas will download inserted data during replication,
+                                        will apply in <remote_servers> inside ConfigMap which will mount in /etc/clickhouse-server/config.d/chop-generated-remote_servers.xml
+                                        More details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
                                       enum:
                                         # List StringBoolXXX constants from model
                                         - ""
@@ -1294,193 +1841,319 @@ spec:
                                         - "enabled"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
+                                        override top-level `chi.spec.configuration.settings` and cluster-level `chi.spec.configuration.clusters.settings`
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one shard during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected shard
+                                        override top-level `chi.spec.configuration.templates` and cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
                                         hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for shard-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     replicasCount:
                                       type: integer
+                                      description: |
+                                        optional, how much replicas in selected shard for selected ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                        shard contains 1 replica by default
+                                        override cluster-level `chi.spec.configuration.clusters.layout.replicasCount`
                                       minimum: 1
                                     replicas:
                                       type: array
-                                      nullable: true
+                                      description: |
+                                        optional, allows override behavior for selected replicas from cluster-level `chi.spec.configuration.clusters` and shard-level `chi.spec.configuration.clusters.layout.shards`
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected replica, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected replica, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected replica, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and shard-level `chi.spec.configuration.clusters.layout.shards.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            # nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files`, cluster-level `chi.spec.configuration.clusters.files` and shard-level `chi.spec.configuration.clusters.layout.shards.files`
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates` and shard-level `chi.spec.configuration.clusters.layout.shards.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for replica-level"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                               replicas:
                                 type: array
-                                nullable: true
+                                description: "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do"
+                                # nullable: true
                                 items:
                                   type: object
                                   properties:
                                     name:
                                       type: string
+                                      description: "optional, by default replica name is generated, but you can override it and setup custom name"
                                       minLength: 1
                                       # See namePartShardMaxLen const
                                       maxLength: 15
                                       pattern: "^[a-zA-Z0-9-]{0,15}$"
                                     settings:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                        override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present
+                                        More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                      # nullable: true
+                                      x-kubernetes-preserve-unknown-fields: true
                                     files:
                                       type: object
-                                      nullable: true
+                                      # nullable: true
+                                      description: |
+                                        optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                        override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                      x-kubernetes-preserve-unknown-fields: true
                                     templates:
                                       type: object
-                                      nullable: true
+                                      description: |
+                                        optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                        override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`
+                                      # nullable: true
                                       properties:
-                                        hostTeampate:
+                                        hostTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one replica"
                                         podTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one replica"
                                         dataVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         logVolumeClaimTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                         serviceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         clusterServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         shardServiceTemplate:
                                           type: string
+                                          description: "optional, fully ignores for replica-level"
                                         replicaServiceTemplate:
                                           type: string
+                                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one replica"
+                                        volumeClaimTemplate:
+                                          type: string
+                                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                                     shardsCount:
                                       type: integer
+                                      description: "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`"
                                       minimum: 1
                                     shards:
                                       type: array
-                                      nullable: true
+                                      description: "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents"
+                                      # nullable: true
                                       items:
                                         # Host
                                         type: object
                                         properties:
                                           name:
                                             type: string
+                                            description: "optional, by default shard name is generated, but you can override it and setup custom name"
                                             minLength: 1
                                             # See namePartReplicaMaxLen const
                                             maxLength: 15
                                             pattern: "^[a-zA-Z0-9-]{0,15}$"
                                           tcpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `tcp` for selected shard, override `chi.spec.templates.hostTemplates.spec.tcpPort`
+                                              allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
                                           httpPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `http` for selected shard, override `chi.spec.templates.hostTemplates.spec.httpPort`
+                                              allows connect to `clickhouse-server` via HTTP protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
-                                          interserverHttpPort:
+                                          interserverHTTPPort:
                                             type: integer
+                                            description: |
+                                              optional, setup `Pod.spec.containers.ports` with name `interserver` for selected shard, override `chi.spec.templates.hostTemplates.spec.interserverHTTPPort`
+                                              allows connect between replicas inside same shard during fetch replicated data parts HTTP protocol
                                             minimum: 1
                                             maximum: 65535
                                           settings:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                              override top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`
+                                              More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           files:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                              override top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents
+                                            # nullable: true
+                                            x-kubernetes-preserve-unknown-fields: true
                                           templates:
                                             type: object
-                                            nullable: true
+                                            description: |
+                                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica
+                                              override top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`
+                                            # nullable: true
                                             properties:
                                               hostTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure each `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod` only for one shard"
                                               podTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               dataVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               logVolumeClaimTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters` only for one shard"
                                               serviceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               clusterServiceTemplate:
                                                 type: string
+                                                description: "optional, fully ignores for shard-level"
                                               shardServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
                                               replicaServiceTemplate:
                                                 type: string
+                                                description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside clickhouse cluster described in `chi.spec.configuration.clusters` only for one shard"
+                                              volumeClaimTemplate:
+                                                type: string
+                                                description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
                 templates:
                   type: object
-                  nullable: true
+                  description: "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it"
+                  # nullable: true
                   properties:
                     hostTemplates:
                       type: array
-                      nullable: true
+                      description: "hostTemplate will use during apply to generate `clickhose-server` config files"
+                      # nullable: true
                       items:
                         type: object
                         #required:
                         #  - name
                         properties:
                           name:
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`"
                             type: string
                           portDistribution:
                             type: array
-                            nullable: true
+                            description: "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1488,6 +2161,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network"
                                   enum:
                                     # List PortDistributionXXX constants
                                     - ""
@@ -1499,31 +2173,52 @@ spec:
                             properties:
                               name:
                                 type: string
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
                                 pattern: "^[a-zA-Z0-9-]{0,15}$"
                               tcpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `tcp_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=tcp]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
                               httpPort:
                                 type: integer
+                                description: |
+                                  optional, setup `http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=http]`
+                                  More info: https://clickhouse.tech/docs/en/interfaces/http/
                                 minimum: 1
                                 maximum: 65535
-                              interserverHttpPort:
+                              interserverHTTPPort:
                                 type: integer
+                                description: |
+                                  optional, setup `interserver_http_port` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified, should have equal value with `chi.spec.templates.podTemplates.spec.containers.ports[name=interserver]`
+                                  More info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#interserver-http-port
                                 minimum: 1
                                 maximum: 65535
                               settings:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`
+                                  More details: https://clickhouse.tech/docs/en/operations/settings/settings/
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               files:
                                 type: object
-                                nullable: true
+                                description: |
+                                  optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
+                                # nullable: true
+                                x-kubernetes-preserve-unknown-fields: true
                               templates:
                                 type: object
-                                nullable: true
+                                description: "be carefull, this part of CRD allows override template inside template, don't use it if you don't understand what you do"
+                                # nullable: true
                                 properties:
                                   hostTemplate:
                                     type: string
@@ -1544,7 +2239,10 @@ spec:
 
                     podTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone
+                        More information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1552,30 +2250,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           zone:
                             type: object
+                            description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             #required:
                             #  - values
                             properties:
                               key:
                                 type: string
+                                description: "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
                               values:
                                 type: array
-                                nullable: true
+                                description: "optional, if defined, allows select kubernetes nodes by label with `value` in `values`"
+                                # nullable: true
                                 items:
                                   type: string
                           distribution:
-                            # DEPRECATED
                             type: string
+                            description: "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
                             enum:
                               - ""
                               - "Unspecified"
                               - "OnePerHost"
                           podDistribution:
                             type: array
-                            nullable: true
+                            description: "define ClickHouse Pod distibution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster"
+                            # nullable: true
                             items:
                               type: object
                               #required:
@@ -1583,6 +2287,7 @@ spec:
                               properties:
                                 type:
                                   type: string
+                                  description: "you can define multiple affinity policy types"
                                   enum:
                                     # List PodDistributionXXX constants
                                     - ""
@@ -1603,6 +2308,7 @@ spec:
                                     - "CircularReplication"
                                 scope:
                                   type: string
+                                  description: "scope for apply each podDistribution"
                                   enum:
                                     # list PodDistributionScopeXXX constants
                                     - ""
@@ -1614,15 +2320,27 @@ spec:
                                     - "Namespace"
                                 number:
                                   type: integer
+                                  description: "define, how much ClickHouse Pods could be inside selected scope with selected distribution type"
                                   minimum: 0
                                   maximum: 65535
                           spec:
                             # TODO specify PodSpec
                             type: object
-                            nullable: true
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            type: object
+                            description: |
+                              allows pass standard object's metadata from template to Pod
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+
                     volumeClaimTemplates:
                       type: array
-                      nullable: true
+                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1630,23 +2348,39 @@ spec:
                         #  - spec
                         properties:
                           name:
+                            description: |
+                              template name, could use to link inside
+                              top-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,
+                              cluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`
                             type: string
                           reclaimPolicy:
                             type: string
+                            description: "define behavior of `PVC` deletion policy during delete `Pod`, `Delete` by default, when `Retain` then `PVC` still alive even `Pod` will deleted"
                             enum:
                               - ""
                               - "Retain"
                               - "Delete"
                           metadata:
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to PVC
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
-                            # TODO specify PersistentVolumeClaimSpec
                             type: object
-                            nullable: true
+                            description: |
+                              allows define all aspects of `PVC` resource
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     serviceTemplates:
                       type: array
-                      nullable: true
+                      description: |
+                        allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level
+                      # nullable: true
                       items:
                         type: object
                         #required:
@@ -1655,19 +2389,36 @@ spec:
                         properties:
                           name:
                             type: string
+                            description: |
+                              template name, could use to link inside
+                              chi-level `chi.spec.defaults.templates.serviceTemplate`
+                              cluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`
+                              shard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`
+                              replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
+                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
-                            nullable: true
+                            description: |
+                              allows pass standard object's metadata from template to Service
+                              Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             # TODO specify ServiceSpec
                             type: object
-                            nullable: true
+                            description: |
+                              describe behavior of generated Service
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  nullable: true
+                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  # nullable: true
                   items:
                     type: object
                     #required:
@@ -1675,10 +2426,13 @@ spec:
                     properties:
                       name:
                         type: string
+                        description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
                       useType:
                         type: string
+                        description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"
                         enum:
                           # List useTypeXXX constants from model
                           - ""
@@ -1707,70 +2461,105 @@ spec:
           description: Watch namespaces
           priority: 0 # show in standard view
           jsonPath: .status
-      subresources:
-        status: {}
       schema:
         openAPIV3Schema:
           type: object
-          # x-kubernetes-preserve-unknown-fields: true
+          description: "allows customize `clickhouse-operator` settings, need restart clickhouse-operator pod after adding, more details https://github.com/Altinity/clickhouse-operator/blob/master/docs/operator_configuration.md"
+          x-kubernetes-preserve-unknown-fields: true
           properties:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
-              # x-kubernetes-preserve-unknown-fields: true
+              description: |
+                allows define some of settings for `clickhouse-operator` itself,
+                More info: https://github.com/Altinity/clickhouse-operator/blob/master/config/config.yaml
+                look to etc-clickhouse-operator* ConfigMaps if you need more control
+              x-kubernetes-preserve-unknown-fields: true
               properties:
                 watchNamespaces:
                   type: array
+                  description: "List of namespaces where clickhouse-operator watches for events."
                   items:
                     type: string
                 chCommonConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files common for all instances within CHI are located. Default - config.d"
                 chHostConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files unique for each instance (host) within CHI are located. Default - conf.d"
                 chUsersConfigsPath:
                   type: string
+                  description: "Path to folder where ClickHouse configuration files with users settings are located. Files are common for all instances within CHI"
                 chiTemplatesPath:
                   type: string
+                  description: "Path to folder where ClickHouseInstallation .yaml manifests are located."
                 statefulSetUpdateTimeout:
                   type: integer
+                  description: "How many seconds to wait for created/updated StatefulSet to be Ready"
                 statefulSetUpdatePollPeriod:
                   type: integer
+                  description: "How many seconds to wait between checks for created/updated StatefulSet status"
                 onStatefulSetCreateFailureAction:
                   type: string
+                  description: |
+                    What to do in case created StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. delete - delete newly created problematic StatefulSet.
+                    3. ignore (default) - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 onStatefulSetUpdateFailureAction:
                   type: string
+                  description: |
+                    What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds
+                    Possible options:
+                    1. abort - do nothing, just break the process and wait for admin.
+                    2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
+                    3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
                 chConfigUserDefaultProfile:
                   type: string
+                  description: "ClickHouse server configuration `<profile>...</profile>` for any <user>"
                 chConfigUserDefaultQuota:
                   type: string
+                  description: "ClickHouse server configuration `<quota>...</quota>` for any <user>"
                 chConfigUserDefaultNetworksIP:
                   type: array
+                  description: "ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>"
                   items:
                     type: string
                 chConfigUserDefaultPassword:
+                  description: "ClickHouse server configuration `<password>...</password>` for any <user>"
                   type: string
                 chConfigNetworksHostRegexpTemplate:
+                  description: "ClickHouse server configuration `<host_regexp>...</host_regexp>` for any <user>"
                   type: string
                 chUsername:
                   type: string
+                  description: "ClickHouse username to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chPassword:
                   type: string
+                  description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
                 chCredentialsSecretNamespace:
                   type: string
+                  description: "Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chCredentialsSecretName:
                   type: string
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 chPort:
                   type: integer
                   minimum: 1
                   maximum: 65535
+                  description: "Name of k8s Secret with username and password to be used by operator to connect to ClickHouse instances"
                 logtostderr:
                   type: string
+                  description: "boolean, allows logs to stderr"
                 alsologtostderr:
                   type: string
+                  description: "booleanm allows logs to stderr and files both"
                 v:
                   type: string
+                  description: "verbosity level of clickhouse-operator log, default - 1 max - 9"
                 stderrthreshold:
                   type: string
                 vmodule:
@@ -1779,6 +2568,7 @@ spec:
                   type: string
                 reconcileThreadsNumber:
                   type: integer
+                  description: "how much goroutines will use to reconcile in parallel, 10 by default"
                   minimum: 1
                   maximum: 65535
                 reconcileWaitExclude:
@@ -1787,10 +2577,14 @@ spec:
                   type: string
                 excludeFromPropagationLabels:
                   type: array
+                  description: |
+                    When propagating labels from the chi's `metadata.labels` section to child objects' `metadata.labels`,
+                    exclude labels from the following list
                   items:
                     type: string
                 appendScopeLabels:
                   type: string
+                  description: "Whether to append *Scope* labels to StatefulSet and Pod"
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -1816,6 +2610,16 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                    - "LabelShardScopeIndex"
+                    - "LabelReplicaScopeIndex"
+                    - "LabelCHIScopeIndex"
+                    - "LabelCHIScopeCycleSize"
+                    - "LabelCHIScopeCycleIndex"
+                    - "LabelCHIScopeCycleOffset"
+                    - "LabelClusterScopeIndex"
+                    - "LabelClusterScopeCycleSize"
+                    - "LabelClusterScopeCycleIndex"
+                    - "LabelClusterScopeCycleOffset"
 ---
 # Possible Template Parameters:
 #
@@ -1946,6 +2750,13 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
 ---
 # Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
 # ClusterRoleBinding is namespace-less and must have unique name

--- a/docs/chi-examples/01-simple-layout-04-shards-and-replicas-customization.yaml
+++ b/docs/chi-examples/01-simple-layout-04-shards-and-replicas-customization.yaml
@@ -1,0 +1,56 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseInstallation"
+metadata:
+  name: "simple-04"
+spec:
+  configuration:
+    settings:
+      http_server_default_response: "from_top_level"
+    files:
+      # need unique file names
+      conf.d/test_file_confd.xml: "<yandex><http_server_default_response>from_top_level from files</http_server_default_response></yandex>"
+      config.d/test_file_configd.xml: "<yandex><http_server_default_response>from_top_level from files</http_server_default_response></yandex>"
+      users.d/test_file_usersd.xml: "<yandex><users><custom_user><password>from_top_level_from_files</password></custom_user></users></yandex>"
+    clusters:
+      - name: "replicas"
+        # will override on layout.shards level
+        settings:
+          http_server_default_response: "from_cluster"
+        files:
+          conf.d/test_file_cluster_confd.xml: "<yandex><http_server_default_response>from_cluster from files</http_server_default_response></yandex>"
+          config.d/test_file_cluster_configd.xml: "<yandex><http_server_default_response>from_cluster from files</http_server_default_response></yandex>"
+          users.d/test_file_cluster_usersd.xml: "<yandex><users><custom_user><password>from_cluster_from_files</password></custom_user></users></yandex>"
+          users.d/test_file_cluster_usersd2.xml: "<yandex><users><custom_user><password>from_cluster_from_files</password></custom_user></users></yandex>"
+        layout:
+          shardsCount: 1
+          replicasCount: 1
+          shards:
+            # will override on layout.shards.replicas level
+            - settings:
+                http_server_default_response: "from_shard"
+              files:
+                conf.d/test_file_shard_confd.xml: "<yandex><http_server_default_response>from_shard from files</http_server_default_response></yandex>"
+                config.d/test_file_shard_configd.xml: "<yandex><http_server_default_response>from_shard from files</http_server_default_response></yandex>"
+                users.d/test_file_shard_usersd.xml: "<yandex><users><custom_user><password>from_shard_from_files</password></custom_user></users></yandex>"
+                users.d/test_file_shard_usersd2.xml: "<yandex><users><custom_user><password>from_shard_from_files2</password></custom_user></users></yandex>"
+              replicas:
+                # will mount into /etc/clickhouse-server/conf.d
+                - settings:
+                    http_server_default_response: "from_replica_inside_shard"
+                  files:
+                    config.d/test_file_shard_replica_configd.xml: "<yandex><http_server_default_response>from_replica_inside_shard from files</http_server_default_response></yandex>"
+          replicas:
+            # will completely ignore, cause layout.shards exists
+            - settings:
+                users/custom_user/password: "from_replica"
+              files:
+                conf.d/test_file_replica_confd.xml: "<yandex><http_server_default_response>from_replica from files</http_server_default_response></yandex>"
+                config.d/test_file_replica_configd.xml: "<yandex><http_server_default_response>from_replica from files</http_server_default_response></yandex>"
+                users.d/test_file_replica_usersd.xml: "<yandex><users><custom_user><password>from_replica_from_files</password></custom_user></users></yandex>"
+                users.d/test_file_replica_usersd2.xml: "<yandex><users><custom_user><password>from_replica_from_files2</password></custom_user></users></yandex>"
+              shards:
+                - settings:
+                    users/custom_user/password: "from_shard_inside_replica"
+                  files:
+                    config.d/test_file_replica_shard.xml: "<yandex><http_server_default_response>from_shard_inside_replica from files</http_server_default_response></yandex>"
+

--- a/docs/chi-examples/05-settings-05-files-nested.yaml
+++ b/docs/chi-examples/05-settings-05-files-nested.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   configuration:
     files:
+      /wrong/prefix/file.txt: |
+        !!! WILL TOTALLY IGNORED and not render in ConfigMap !!!
+      conf.d/subfolder/file_in_subfolder.txt: |
+        !!! SUBFOLDER WILL INGORED, file will placed into conf.d !!!
       simple_1.file: |
         <yandex>
           <!-- simple_1.file goes to COMMON -->

--- a/docs/custom_resource_explained.md
+++ b/docs/custom_resource_explained.md
@@ -62,7 +62,7 @@ clickhouse-installation-max   23h
 `.spec.configuration.zookeeper` refers to [&lt;yandex&gt;&lt;zookeeper&gt;&lt;/zookeeper&gt;&lt;/yandex&gt;][server-settings_zookeeper] config section
 
 ## .spec.configuration.profiles
-`.spec.configuration.profiles` refers to [&lt;yandex&gt;&lt;profiles&gt;&lt;/profiles&gt;&lt;/yandex&gt;][settings] settings sections.
+`.spec.configuration.profiles` refers to [&lt;yandex&gt;&lt;profiles&gt;&lt;/profiles&gt;&lt;/yandex&gt;][profiles] settings sections.
 ```yaml
     profiles:
       readonly/readonly: 1
@@ -77,8 +77,28 @@ expands into
       </profiles>
 ```
 
+## .spec.configuration.quotas
+`.spec.configuration.quotas` refers to [&lt;yandex&gt;&lt;quotas&gt;&lt;/quotas&gt;&lt;/yandex&gt;][quotas] settings sections.
+```yaml
+    quotas:
+      default/interval/duration: 3600
+      default/interval/queries: 10000
+```
+
+expands into
+```xml
+      <quotas>
+        <default>
+          <interval>
+              <duration>3600</duration>
+              <queries>3600</queries>
+          </interval>
+        </default>
+      </quotas>
+```
+
 ## .spec.configuration.users
-`.spec.configuration.users` refers to [&lt;yandex&gt;&lt;users&gt;&lt;/users&gt;&lt;/yandex&gt;][settings] settings sections.
+`.spec.configuration.users` refers to [&lt;yandex&gt;&lt;users&gt;&lt;/users&gt;&lt;/yandex&gt;][users] settings sections.
 ```yaml
   users:
     test/networks/ip:
@@ -576,10 +596,12 @@ Example - how to place ClickHouse instances on nodes labeled as `clickhouse=allo
 
 [custom-resource]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 [99-clickhouseinstallation-max.yaml]: ./chi-examples/99-clickhouseinstallation-max.yaml
-[server-settings_zookeeper]: https://clickhouse.yandex/docs/en/single/index.html?#server-settings_zookeeper
-[settings]: https://clickhouse.yandex/docs/en/operations/settings/settings/
-[settings]: https://clickhouse.yandex/docs/en/operations/settings/settings/
-[external_dicts_dict]: https://clickhouse.yandex/docs/en/query_language/dicts/external_dicts_dict/
+[server-settings_zookeeper]: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings_zookeeper
+[settings]: https://clickhouse.tech/docs/en/operations/settings/settings/
+[quotas]: https://clickhouse.tech/docs/en/operations/quotas/
+[profiles]: https://clickhouse.tech/docs/en/operations/settings/settings-profiles/
+[users]: https://clickhouse.tech/docs/en/operations/settings/settings-users/
+[external_dicts_dict]: https://clickhouse.tech/docs/en/query_language/dicts/external_dicts_dict/
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [persistentvolumeclaims]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
 [pod-templates]: https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -25,6 +25,12 @@ just run:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/operator/clickhouse-operator-install.yaml
 ```
+## **If you want to install operator on kubernetes version prior `1.17` in `kube-system` namespace**
+
+just run:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/operator/clickhouse-operator-install-v1beta1.yaml
+```
 
 ## **In case you'd like to customize installation parameters**,
 

--- a/tests/configs/test-003-complex-layout.yaml
+++ b/tests/configs/test-003-complex-layout.yaml
@@ -1,7 +1,7 @@
 apiVersion: "clickhouse.altinity.com/v1"
 kind: "ClickHouseInstallation"
 metadata:
-  name: "test-002-complex-layout"
+  name: "test-003-complex-layout"
 spec:
   useTemplates:
     - name: clickhouse-version

--- a/tests/configs/test-005-acm.yaml
+++ b/tests/configs/test-005-acm.yaml
@@ -39,8 +39,11 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/clickhouse
               name: default-gp2
-        - image: altinity/clickhouse-backup:1.0.14
+        - image: altinity/clickhouse-backup:1.0.16
           name: clickhouse-backup
+          command:
+            - clickhouse-backup
+            - server
           ports:
             - containerPort: 7171
               name: backup

--- a/tests/configs/test-018-configmap-1.yaml
+++ b/tests/configs/test-018-configmap-1.yaml
@@ -7,7 +7,7 @@ spec:
     - name: clickhouse-version
   configuration:
     settings:
-      diaplay_name: "old_display_name"
+      display_name: "old_display_name"
       macros/test: "old_test"
     clusters:
     - name: default

--- a/tests/configs/test-018-configmap-2.yaml
+++ b/tests/configs/test-018-configmap-2.yaml
@@ -7,7 +7,7 @@ spec:
     - name: clickhouse-version
   configuration:
     settings:
-      diaplay_name: "new_display_name"
+      display_name: "new_display_name"
       macros/test:  "new_test"
     clusters:
     - name: default

--- a/tests/kubectl.py
+++ b/tests/kubectl.py
@@ -63,10 +63,11 @@ def delete_chi(chi, ns=namespace, wait = True):
 def delete_all_chi(ns=namespace):
     crds = launch("get crds -o=custom-columns=name:.metadata.name", ns=ns).splitlines()
     if "clickhouseinstallations.clickhouse.altinity.com" in crds:
-        chis = get("chi", "", ns=ns)["items"]
-        for chi in chis:
-            # kubectl(f"patch chi {chi} --type=merge -p '\{\"metadata\":\{\"finalizers\": [null]\}\}'", ns = ns)
-            delete_chi(chi["metadata"]["name"], ns)
+        chis = get("chi", "", ns=ns)
+        if "items" in chis:
+            for chi in chis["items"]:
+                # kubectl(f"patch chi {chi} --type=merge -p '\{\"metadata\":\{\"finalizers\": [null]\}\}'", ns = ns)
+                delete_chi(chi["metadata"]["name"], ns)
 
 
 def create_and_check(config, check, ns=namespace, timeout=600):

--- a/tests/kubectl.py
+++ b/tests/kubectl.py
@@ -300,7 +300,7 @@ def get_pod_ports(chi_name, ns=namespace):
 def check_pod_ports(chi_name, ports, ns=namespace):
     pod_ports = get_pod_ports(chi_name, ns)
     with Then(f"Expect pod ports {pod_ports} to match {ports}"):
-        assert pod_ports.sort() == ports.sort()
+        assert set(pod_ports) == set(ports)
 
 
 def check_pod_image(chi_name, image, ns=namespace):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -16,7 +16,7 @@ test_namespace = os.getenv('TEST_NAMESPACE') if 'TEST_NAMESPACE' in os.environ e
 
 # Default value
 operator_version = os.getenv('OPERATOR_VERSION') if 'OPERATOR_VERSION' in os.environ else \
-    open(os.path.join(pathlib.Path(__file__).parent.absolute(), "../release")).read(1024)
+    open(os.path.join(pathlib.Path(__file__).parent.absolute(), "../release")).read(1024).strip(" \r\n\t")
 operator_namespace = os.getenv('OPERATOR_NAMESPACE') if 'OPERATOR_NAMESPACE' in os.environ else \
     'kube-system'
 minio_namespace = os.getenv('MINIO_NAMESPACE') if 'MINIO_NAMESPACE' in os.environ else 'minio'
@@ -37,4 +37,6 @@ prometheus_namespace = "prometheus"
 prometheus_operator_version = "0.43"
 prometheus_scrape_interval = 10
 
+clickhouse_operator_install = os.getenv('CLICKHOUSE_OPERATOR_INSTALL') if 'CLICKHOUSE_OPERATOR_INSTALL' in os.environ else \
+    '../deploy/operator/clickhouse-operator-install-template.yaml'
 minio_version = "latest"

--- a/tests/templates/tpl-clickhouse-backups.yaml
+++ b/tests/templates/tpl-clickhouse-backups.yaml
@@ -31,7 +31,7 @@ spec:
                 - --config-file=/etc/clickhouse-server/config.xml
 
             - name: clickhouse-backup
-              image: altinity/clickhouse-backup:1.0.14
+              image: altinity/clickhouse-backup:1.0.16
               imagePullPolicy: Always
               command:
                 - bash

--- a/tests/test.py
+++ b/tests/test.py
@@ -44,6 +44,7 @@ if main():
             all_tests = [
                 test_operator.test_001,
                 test_operator.test_002,
+                test_operator.test_003,
                 test_operator.test_004,
                 test_operator.test_005,
                 test_operator.test_006,

--- a/tests/test.py
+++ b/tests/test.py
@@ -15,7 +15,7 @@ if main():
 
         with Given(f"clickhouse-operator version {settings.operator_version} is installed"):
             if kubectl.get_count("pod", ns=settings.operator_namespace, label="-l app=clickhouse-operator") == 0:
-                config = util.get_full_path('../deploy/operator/clickhouse-operator-install-template.yaml')
+                config = util.get_full_path(settings.clickhouse_operator_install)
                 kubectl.apply(
                     ns=settings.operator_namespace,
                     config=f"<(cat {config} | "


### PR DESCRIPTION
fixes for test_007 (has error test case passed, clickhouse-operator broken in this part after 0.10.0),
small fixes for test_005 (old version clickhouse-backup image ran clickhouse-backup server automatically)
and test_018
update clickhouse-backup in tests to 1.0.16

fix https://github.com/Altinity/clickhouse-operator/issues/777
fix https://github.com/Altinity/clickhouse-operator/issues/762
close https://github.com/Altinity/clickhouse-operator/pull/773
fix https://github.com/Altinity/clickhouse-operator/issues/774

* [ ] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)
