### PR TITLE
add port to metrics container

### DIFF
--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-with-configmap.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-with-configmap.yaml
@@ -125,3 +125,6 @@ spec:
               mountPath: /etc/clickhouse-operator/templates.d
             - name: etc-clickhouse-operator-usersd-folder
               mountPath: /etc/clickhouse-operator/users.d
+          ports:
+            - containerPort: 8888
+              name: metrics


### PR DESCRIPTION
The deployment of the metrics container is missing the container port. This PR adds this.

Thus allowing to define PodMonitors , since the prometheus operator team is recommending against using meta annotations.