### PR TITLE
Error creating metric metric_BlockReadTime_dm-0: "chi_clickhouse_metr…

### DIFF
--- a/pkg/apis/metrics/prometheus_writer.go
+++ b/pkg/apis/metrics/prometheus_writer.go
@@ -238,5 +238,8 @@ func convertMetricName(in string) string {
 		out = append(out, unicode.ToLower(runes[i]))
 	}*/
 
-	return strings.Replace(in, ".", "_", -1)
+//	return strings.Replace(in, ".", "_", -1)
+	tmp := strings.Replace(in, ".", "_", -1)
+	res := strings.Replace(tmp, "-", "_", -1)
+	return res
 }

--- a/pkg/apis/metrics/prometheus_writer.go
+++ b/pkg/apis/metrics/prometheus_writer.go
@@ -238,8 +238,5 @@ func convertMetricName(in string) string {
 		out = append(out, unicode.ToLower(runes[i]))
 	}*/
 
-//	return strings.Replace(in, ".", "_", -1)
-	tmp := strings.Replace(in, ".", "_", -1)
-	res := strings.Replace(tmp, "-", "_", -1)
-	return res
+	return strings.NewReplacer("-","_",".","_").Replace()
 }


### PR DESCRIPTION
…ic_BlockReadTime_dm-0" is not a valid metric name

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [ ] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [ ] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [ ] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
