### PR TITLE
fix non pointer mistake in metrics-exporter

### DIFF
--- a/pkg/apis/metrics/clickhouse_fetcher.go
+++ b/pkg/apis/metrics/clickhouse_fetcher.go
@@ -171,7 +171,7 @@ func (f *ClickHouseFetcher) getClickHouseSystemParts() ([][]string, error) {
 				metricDiskDataBytes, metricMemoryPrimaryKeyBytesAllocated string
 			if err := rows.Scan(
 				&database, &table, &active, &partitions, &parts, &bytes, &uncompressed, &_rows,
-				&metricDiskDataBytes, metricMemoryPrimaryKeyBytesAllocated,
+				&metricDiskDataBytes, &metricMemoryPrimaryKeyBytesAllocated,
 			); err == nil {
 				*data = append(*data, []string{
 					database, table, active, partitions, parts, bytes, uncompressed, _rows,


### PR DESCRIPTION
Signed-off-by: Anthony Dubuissez <a.dubuissez@bricks-co.com>

Fixing the metrics-exporter report of the system.parts fetch that would never return any data due to a missing pointer.

I put the master branch for this pr as I didnt find the next-release branch, only 0.18.0.


## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x ] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [ x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [ x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)

