### PR TITLE
Fix typo in Readme for Copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Operator creates, configures and manages ClickHouse clusters running on Kubernet
  
 ## License
 
-Copyright (c) 2019-2219, Altinity Ltd and/or its affiliates. All rights reserved.
+Copyright (c) 2019-2022, Altinity Ltd and/or its affiliates. All rights reserved.
 
 Altinity Operator for ClickHouse is licensed under the Apache License 2.0.
 


### PR DESCRIPTION
Really basic typo fix. Could be mistaken though. Maybe you've managed to actually copyright all the way to 2219 ;)