### PR TITLE
update versions and improve clickhouse-keeper manifests 

### DIFF
--- a/config/templates.d/001-templates.json.example
+++ b/config/templates.d/001-templates.json.example
@@ -29,7 +29,7 @@
             "containers" : [
               {
                 "name": "clickhouse",
-                "image": "yandex/clickhouse-server:21.3",
+                "image": "clickhouse/clickhouse-server:22.3",
                 "ports": [
                   {
                     "name": "http",

--- a/deploy/builder/templates-config/templates.d/001-templates.json.example
+++ b/deploy/builder/templates-config/templates.d/001-templates.json.example
@@ -29,7 +29,7 @@
             "containers" : [
               {
                 "name": "clickhouse",
-                "image": "yandex/clickhouse-server:21.3",
+                "image": "clickhouse/clickhouse-server:22.3",
                 "ports": [
                   {
                     "name": "http",

--- a/deploy/clickhouse-keeper/clickhouse-keeper-1-node-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-1-node-256M-for-test-only.yaml
@@ -39,13 +39,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  # DNS would be like keeper-0.clickhouse-keepers.namespace.svc
+  # DNS would be like clickhouse-keeper-0.clickhouse-keepers.namespace.svc
   name: clickhouse-keepers
   labels:
     app: clickhouse-keeper
 spec:
   ports:
-    - port: 9234
+    - port: 9444
       name: raft
   clusterIP: None
   selector:
@@ -80,9 +80,10 @@ data:
         <keeper_server incl="keeper_server">
             <path>/var/lib/clickhouse-keeper</path>
             <tcp_port>2181</tcp_port>
+            <four_letter_word_white_list>*</four_letter_word_white_list>
             <coordination_settings>
                 <!-- <raft_logs_level>trace</raft_logs_level> -->
-                <raft_logs_level>debug</raft_logs_level>
+                <raft_logs_level>information</raft_logs_level>
             </coordination_settings>
         </keeper_server>
     </yandex>
@@ -134,7 +135,7 @@ spec:
                 path: keeper_config.xml
       containers:
         - name: clickhouse-keeper
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           image: "clickhouse/clickhouse-server:latest"
           resources:
             requests:
@@ -152,7 +153,7 @@ spec:
             - name: SERVERS
               value: "1"
             - name: RAFT_PORT
-              value: "9234"
+              value: "9444"
           command:
             - bash
             - -x
@@ -178,38 +179,20 @@ spec:
                 done
                 echo "</raft_configuration>"
                 echo "</keeper_server></yandex>"
-              } >> /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
+              } > /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
               cat /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml && 
               clickhouse keeper --config-file=/etc/clickhouse-keeper/keeper_config.xml
           readinessProbe:
-            exec:
-              command:
-                - bash
-                - -xc
-                - "OK=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"ruok\" >&3 && timeout 5 cat <&3');
-                   if [[ \"$OK\" == \"imok\" ]];
-                   then
-                      STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_server_state | cut -d \" \" -f 2);
-                      if [[ \"$STATE\" == \"leader\" ]]; then
-                        SYNCED_FOLLOWERS=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_synced_followers | cut -d \" \" -f 2 | cut -d \".\" -f 1);
-                        if [[ $SYNCED_FOLLOWERS == $(( $SERVERS - 1 )) ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      elif [[ \"$STATE\" == \"follower\" ]]; then
-                        PEER_STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_peer_state);
-                        if [[ \"$PEER_STATE\" == \"following - broadcast\" ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      fi;
-                    else
-                      exit 1;
-                    fi"
-            initialDelaySeconds: 15
-            timeoutSeconds: 15
+            tcpSocket:
+              port: 9444
+            timeoutSeconds: 5
+            periodSeconds: 60
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 2181
+            timeoutSeconds: 5
+            periodSeconds: 30
         - name: zookeeper-exporter
           imagePullPolicy: IfNotPresent
           image: dabealu/zookeeper-exporter:latest
@@ -232,6 +215,7 @@ spec:
                 - sh
                 - -c
                 - "OK=$(echo ruok | nc 127.0.0.1 2181); if [[ \"$OK\" == \"imok\" ]]; then exit 0; else exit 1; fi"
+            periodSeconds: 5
           ports:
             - containerPort: 7000
               name: prometheus

--- a/deploy/clickhouse-keeper/clickhouse-keeper-1-node.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-1-node.yaml
@@ -21,13 +21,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  # DNS would be like keeper-0.clickhouse-keepers.namespace.svc
+  # DNS would be like clickhouse-keeper-0.clickhouse-keepers.namespace.svc
   name: clickhouse-keepers
   labels:
     app: clickhouse-keeper
 spec:
   ports:
-    - port: 9234
+    - port: 9444
       name: raft
   clusterIP: None
   selector:
@@ -62,9 +62,10 @@ data:
         <keeper_server incl="keeper_server">
             <path>/var/lib/clickhouse-keeper</path>
             <tcp_port>2181</tcp_port>
+            <four_letter_word_white_list>*</four_letter_word_white_list>
             <coordination_settings>
                 <!-- <raft_logs_level>trace</raft_logs_level> -->
-                <raft_logs_level>debug</raft_logs_level>
+                <raft_logs_level>information</raft_logs_level>
             </coordination_settings>
         </keeper_server>
     </yandex>
@@ -133,7 +134,7 @@ spec:
             - name: SERVERS
               value: "1"
             - name: RAFT_PORT
-              value: "9234"
+              value: "9444"
           command:
             - bash
             - -x
@@ -159,38 +160,20 @@ spec:
                 done
                 echo "</raft_configuration>"
                 echo "</keeper_server></yandex>"
-              } >> /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
+              } > /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
               cat /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml && 
               clickhouse keeper --config-file=/etc/clickhouse-keeper/keeper_config.xml
           readinessProbe:
-            exec:
-              command:
-                - bash
-                - -xc
-                - "OK=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"ruok\" >&3 && timeout 5 cat <&3');
-                   if [[ \"$OK\" == \"imok\" ]];
-                   then
-                      STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_server_state | cut -d \" \" -f 2);
-                      if [[ \"$STATE\" == \"leader\" ]]; then
-                        SYNCED_FOLLOWERS=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_synced_followers | cut -d \" \" -f 2 | cut -d \".\" -f 1);
-                        if [[ $SYNCED_FOLLOWERS == $(( $SERVERS - 1 )) ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      elif [[ \"$STATE\" == \"follower\" ]]; then
-                        PEER_STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_peer_state);
-                        if [[ \"$PEER_STATE\" == \"following - broadcast\" ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      fi;
-                    else
-                      exit 1;
-                    fi"
-            initialDelaySeconds: 15
-            timeoutSeconds: 15
+            tcpSocket:
+              port: 9444
+            timeoutSeconds: 5
+            periodSeconds: 60
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 2181
+            timeoutSeconds: 5
+            periodSeconds: 30
         - name: zookeeper-exporter
           imagePullPolicy: IfNotPresent
           image: dabealu/zookeeper-exporter:latest
@@ -213,6 +196,7 @@ spec:
                 - sh
                 - -c
                 - "OK=$(echo ruok | nc 127.0.0.1 2181); if [[ \"$OK\" == \"imok\" ]]; then exit 0; else exit 1; fi"
+            periodSeconds: 5
           ports:
             - containerPort: 7000
               name: prometheus

--- a/deploy/clickhouse-keeper/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
@@ -39,13 +39,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  # DNS would be like keeper-0.clickhouse-keepers.namespace.svc
+  # DNS would be like clickhouse-keeper-0.clickhouse-keepers.namespace.svc
   name: clickhouse-keepers
   labels:
     app: clickhouse-keeper
 spec:
   ports:
-    - port: 9234
+    - port: 9444
       name: raft
   clusterIP: None
   selector:
@@ -80,9 +80,10 @@ data:
         <keeper_server incl="keeper_server">
             <path>/var/lib/clickhouse-keeper</path>
             <tcp_port>2181</tcp_port>
+            <four_letter_word_white_list>*</four_letter_word_white_list>
             <coordination_settings>
                 <!-- <raft_logs_level>trace</raft_logs_level> -->
-                <raft_logs_level>debug</raft_logs_level>
+                <raft_logs_level>information</raft_logs_level>
             </coordination_settings>
         </keeper_server>
     </yandex>
@@ -134,7 +135,7 @@ spec:
                 path: keeper_config.xml
       containers:
         - name: clickhouse-keeper
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           image: "clickhouse/clickhouse-server:latest"
           resources:
             requests:
@@ -152,7 +153,7 @@ spec:
             - name: SERVERS
               value: "3"
             - name: RAFT_PORT
-              value: "9234"
+              value: "9444"
           command:
             - bash
             - -x
@@ -178,38 +179,20 @@ spec:
                 done
                 echo "</raft_configuration>"
                 echo "</keeper_server></yandex>"
-              } >> /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
+              } > /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
               cat /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml && 
               clickhouse keeper --config-file=/etc/clickhouse-keeper/keeper_config.xml
           readinessProbe:
-            exec:
-              command:
-                - bash
-                - -xc
-                - "OK=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"ruok\" >&3 && timeout 5 cat <&3');
-                   if [[ \"$OK\" == \"imok\" ]];
-                   then
-                      STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_server_state | cut -d \" \" -f 2);
-                      if [[ \"$STATE\" == \"leader\" ]]; then
-                        SYNCED_FOLLOWERS=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_synced_followers | cut -d \" \" -f 2 | cut -d \".\" -f 1);
-                        if [[ $SYNCED_FOLLOWERS == $(( $SERVERS - 1 )) ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      elif [[ \"$STATE\" == \"follower\" ]]; then
-                        PEER_STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_peer_state);
-                        if [[ \"$PEER_STATE\" == \"following - broadcast\" ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      fi;
-                    else
-                      exit 1;
-                    fi"
-            initialDelaySeconds: 15
-            timeoutSeconds: 15
+            tcpSocket:
+              port: 9444
+            timeoutSeconds: 5
+            periodSeconds: 60
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 2181
+            timeoutSeconds: 5
+            periodSeconds: 30
         - name: zookeeper-exporter
           imagePullPolicy: IfNotPresent
           image: dabealu/zookeeper-exporter:latest
@@ -232,6 +215,7 @@ spec:
                 - sh
                 - -c
                 - "OK=$(echo ruok | nc 127.0.0.1 2181); if [[ \"$OK\" == \"imok\" ]]; then exit 0; else exit 1; fi"
+            periodSeconds: 5
           ports:
             - containerPort: 7000
               name: prometheus

--- a/deploy/clickhouse-keeper/clickhouse-keeper-3-nodes.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-3-nodes.yaml
@@ -21,13 +21,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  # DNS would be like keeper-0.clickhouse-keepers.namespace.svc
+  # DNS would be like clickhouse-keeper-0.clickhouse-keepers.namespace.svc
   name: clickhouse-keepers
   labels:
     app: clickhouse-keeper
 spec:
   ports:
-    - port: 9234
+    - port: 9444
       name: raft
   clusterIP: None
   selector:
@@ -62,6 +62,7 @@ data:
         <keeper_server incl="keeper_server">
             <path>/var/lib/clickhouse-keeper</path>
             <tcp_port>2181</tcp_port>
+            <four_letter_word_white_list>*</four_letter_word_white_list>
             <coordination_settings>
                 <!-- <raft_logs_level>trace</raft_logs_level> -->
                 <raft_logs_level>debug</raft_logs_level>
@@ -133,7 +134,7 @@ spec:
             - name: SERVERS
               value: "3"
             - name: RAFT_PORT
-              value: "9234"
+              value: "9444"
           command:
             - bash
             - -x
@@ -159,38 +160,20 @@ spec:
                 done
                 echo "</raft_configuration>"
                 echo "</keeper_server></yandex>"
-              } >> /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
+              } > /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml &&
               cat /tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml && 
               clickhouse keeper --config-file=/etc/clickhouse-keeper/keeper_config.xml
           readinessProbe:
-            exec:
-              command:
-                - bash
-                - -xc
-                - "OK=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"ruok\" >&3 && timeout 5 cat <&3');
-                   if [[ \"$OK\" == \"imok\" ]];
-                   then
-                      STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_server_state | cut -d \" \" -f 2);
-                      if [[ \"$STATE\" == \"leader\" ]]; then
-                        SYNCED_FOLLOWERS=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_synced_followers | cut -d \" \" -f 2 | cut -d \".\" -f 1);
-                        if [[ $SYNCED_FOLLOWERS == $(( $SERVERS - 1 )) ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      elif [[ \"$STATE\" == \"follower\" ]]; then
-                        PEER_STATE=$(bash -c 'exec 3<>/dev/tcp/127.0.0.1/2181 && printf \"mntr\" >&3 && timeout 5 cat <&3' | grep zk_peer_state);
-                        if [[ \"$PEER_STATE\" == \"following - broadcast\" ]]; then
-                          exit 0;
-                        else
-                          exit 1;
-                        fi;
-                      fi;
-                    else
-                      exit 1;
-                    fi"
-            initialDelaySeconds: 15
-            timeoutSeconds: 15
+            tcpSocket:
+              port: 9444
+            timeoutSeconds: 5
+            periodSeconds: 60
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 2181
+            timeoutSeconds: 5
+            periodSeconds: 30
         - name: zookeeper-exporter
           imagePullPolicy: IfNotPresent
           image: dabealu/zookeeper-exporter:latest
@@ -213,6 +196,7 @@ spec:
                 - sh
                 - -c
                 - "OK=$(echo ruok | nc 127.0.0.1 2181); if [[ \"$OK\" == \"imok\" ]]; then exit 0; else exit 1; fi"
+            periodSeconds: 5
           ports:
             - containerPort: 7000
               name: prometheus

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -3513,7 +3513,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:21.3",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -3473,7 +3473,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:21.3",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -3506,7 +3506,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:21.3",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",

--- a/deploy/operator/clickhouse-operator-install-template-dev.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-dev.yaml
@@ -3479,7 +3479,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:21.3",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -3473,7 +3473,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:21.3",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -3506,7 +3506,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:21.3",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -3513,7 +3513,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "yandex/clickhouse-server:21.3",
+                    "image": "clickhouse/clickhouse-server:22.3",
                     "ports": [
                       {
                         "name": "http",

--- a/deploy/zookeeper/advanced/05-stateful-set-persistent-volume.yaml
+++ b/deploy/zookeeper/advanced/05-stateful-set-persistent-volume.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.6.3"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "1Gi"

--- a/deploy/zookeeper/advanced/05-stateful-set-volume-emptyDir.yaml
+++ b/deploy/zookeeper/advanced/05-stateful-set-volume-emptyDir.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.6.3"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "1Gi"

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node-1GB-for-tests-only.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node-1GB-for-tests-only.yaml
@@ -82,7 +82,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.7.0"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "128M"

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-1-node.yaml
@@ -94,7 +94,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.7.0"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "512M"

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes-1GB-for-tests-only.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes-1GB-for-tests-only.yaml
@@ -82,7 +82,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.7.0"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "128M"

--- a/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes.yaml
+++ b/deploy/zookeeper/quick-start-persistent-volume/zookeeper-3-nodes.yaml
@@ -92,7 +92,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.7.0"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "512M"

--- a/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-1-node.yaml
+++ b/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-1-node.yaml
@@ -92,7 +92,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.7.0"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "512M"

--- a/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-3-nodes.yaml
+++ b/deploy/zookeeper/quick-start-volume-emptyDir/zookeeper-3-nodes.yaml
@@ -92,7 +92,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: IfNotPresent
-          image: "docker.io/zookeeper:3.6.1"
+          image: "docker.io/zookeeper:3.8.0"
           resources:
             requests:
               memory: "512M"

--- a/docs/chi-examples/02-templates-01-pod-template.yaml
+++ b/docs/chi-examples/02-templates-01-pod-template.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               # Container has explicitly specified resource requests
               resources:
                 requests:

--- a/docs/chi-examples/02-templates-04-host-template-volume-claim-and-pod-resources-limit.yaml
+++ b/docs/chi-examples/02-templates-04-host-template-volume-claim-and-pod-resources-limit.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: clickhouse-data-storage
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/02-templates-06-sidecar.yaml
+++ b/docs/chi-examples/02-templates-06-sidecar.yaml
@@ -39,7 +39,7 @@ spec:
           containers:
             # Main container
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: sidecar-configmap-volume
                   mountPath: /configmap-volume

--- a/docs/chi-examples/02-templates-07-bootstrap-schema.yaml
+++ b/docs/chi-examples/02-templates-07-bootstrap-schema.yaml
@@ -41,7 +41,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: bootstrap-configmap-volume
                   mountPath: /docker-entrypoint-initdb.d

--- a/docs/chi-examples/03-persistent-volume-02-pod-template.yaml
+++ b/docs/chi-examples/03-persistent-volume-02-pod-template.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: data-storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/03-persistent-volume-03-custom-labels-and-annotations.yaml
+++ b/docs/chi-examples/03-persistent-volume-03-custom-labels-and-annotations.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: data-storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/03-persistent-volume-07-multiple-resizable-volumes-1.yaml
+++ b/docs/chi-examples/03-persistent-volume-07-multiple-resizable-volumes-1.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: data-storage-vc-template-1
                   mountPath: /data/clickhouse-01

--- a/docs/chi-examples/03-persistent-volume-07-multiple-resizable-volumes-2.yaml
+++ b/docs/chi-examples/03-persistent-volume-07-multiple-resizable-volumes-2.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: data-storage-vc-template-1
                   mountPath: /data/clickhouse-01

--- a/docs/chi-examples/03-persistent-volume-07-multiple-resizable-volumes-3.yaml
+++ b/docs/chi-examples/03-persistent-volume-07-multiple-resizable-volumes-3.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: data-storage-vc-template-1
                   mountPath: /data/clickhouse-01

--- a/docs/chi-examples/03-persistent-volume-07-security-context.yaml
+++ b/docs/chi-examples/03-persistent-volume-07-security-context.yaml
@@ -42,7 +42,7 @@ spec:
             fsGroup: 101
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.8
+              image: clickhouse/clickhouse-server:22.3
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: data-storage-vc-template-1

--- a/docs/chi-examples/04-replication-zookeeper-03-minimal-AWS-persistent-volume.yaml
+++ b/docs/chi-examples/04-replication-zookeeper-03-minimal-AWS-persistent-volume.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: clickhouse-storage-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/04-replication-zookeeper-04-medium-AWS-persistent-volume.yaml
+++ b/docs/chi-examples/04-replication-zookeeper-04-medium-AWS-persistent-volume.yaml
@@ -25,7 +25,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: clickhouse-storage-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/04-replication-zookeeper-05-simple-PV.yaml
+++ b/docs/chi-examples/04-replication-zookeeper-05-simple-PV.yaml
@@ -34,4 +34,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/06-advanced-layout-01-shards.yaml
+++ b/docs/chi-examples/06-advanced-layout-01-shards.yaml
@@ -10,17 +10,17 @@ spec:
           shards:
             - replicas:
                 - templates:
-                    podTemplate: clickhouse:20.5
+                    podTemplate: clickhouse:22.1
                   httpPort: 8000
                   tcpPort: 8001
                   interserverHTTPPort: 8002
                 - templates:
-                    podTemplate: clickhouse:20.6
+                    podTemplate: clickhouse:22.2
                   httpPort: 9000
                   tcpPort: 9001
                   interserverHTTPPort: 9002
                 - templates:
-                    podTemplate: clickhouse:20.7
+                    podTemplate: clickhouse:22.3
                   httpPort: 10000
                   tcpPort: 10001
                   interserverHTTPPort: 10002
@@ -28,21 +28,21 @@ spec:
   templates:
     podTemplates:
 
-      - name: clickhouse:20.5
+      - name: clickhouse:22.1
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.5
+              image: clickhouse/clickhouse-server:22.1
 
-      - name: clickhouse:20.6
+      - name: clickhouse:22.2
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.6
+              image: clickhouse/clickhouse-server:22.2
 
 
-      - name: clickhouse:20.7
+      - name: clickhouse:22.3
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/06-advanced-layout-02-replicas.yaml
+++ b/docs/chi-examples/06-advanced-layout-02-replicas.yaml
@@ -10,17 +10,17 @@ spec:
           shardsCount: 4
           replicas:
             - templates:
-                podTemplate: clickhouse:20.5
+                podTemplate: clickhouse:22.1
               httpPort: 8000
               tcpPort: 8001
               interserverHTTPPort: 8002
             - templates:
-                podTemplate: clickhouse:20.6
+                podTemplate: clickhouse:22.2
               httpPort: 9000
               tcpPort: 9001
               interserverHTTPPort: 9002
             - templates:
-                podTemplate: clickhouse:20.7
+                podTemplate: clickhouse:22.3
               httpPort: 10000
               tcpPort: 10001
               interserverHTTPPort: 10002
@@ -28,21 +28,21 @@ spec:
   templates:
     podTemplates:
 
-      - name: clickhouse:20.5
+      - name: clickhouse:22.1
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.5
+              image: clickhouse/clickhouse-server:22.1
 
-      - name: clickhouse:20.6
+      - name: clickhouse:22.3
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.6
+              image: clickhouse/clickhouse-server:22.2
 
 
-      - name: clickhouse:20.7
+      - name: clickhouse:22.3
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/06-advanced-layout-03-multiple-clusters.yaml
+++ b/docs/chi-examples/06-advanced-layout-03-multiple-clusters.yaml
@@ -12,12 +12,12 @@ spec:
                 - templates:
                     podTemplate: t1
                 - templates:
-                    podTemplate: t1
+                    podTemplate: t2
             - replicas:
                 - templates:
                     podTemplate: t1
                 - templates:
-                    podTemplate: t1
+                    podTemplate: t2
             - replicas:
                 - templates:
                     podTemplate: t1
@@ -31,33 +31,33 @@ spec:
                 - templates:
                     podTemplate: t1
                 - templates:
-                    podTemplate: t1
+                    podTemplate: t2
                 - templates:
-                    podTemplate: t1
+                    podTemplate: t3
             - replicas:
                 - templates:
                     podTemplate: t1
                 - templates:
-                    podTemplate: t1
+                    podTemplate: t2
                 - templates:
-                    podTemplate: t1
+                    podTemplate: t3
 
   templates:
     podTemplates:
-      - name: clickhouse:20.5
+      - name: t1
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.5
+              image: clickhouse/clickhouse-server:22.1
 
-      - name: clickhouse:20.6
+      - name: t2
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.6
+              image: clickhouse/clickhouse-server:22.2
 
-      - name: clickhouse:20.7
+      - name: t3
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/08-clickhouse-version-update-01-initial-position.yaml
+++ b/docs/chi-examples/08-clickhouse-version-update-01-initial-position.yaml
@@ -7,7 +7,7 @@ spec:
     clusters:
       - name: update
         templates:
-          podTemplate: clickhouse:20.6
+          podTemplate: clickhouse:22.3
         layout:
           shards:
             - replicas:
@@ -17,8 +17,8 @@ spec:
 
   templates:
     podTemplates:
-      - name: clickhouse:20.6
+      - name: clickhouse:22.3
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.6
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/08-clickhouse-version-update-02-apply-update-one.yaml
+++ b/docs/chi-examples/08-clickhouse-version-update-02-apply-update-one.yaml
@@ -7,7 +7,7 @@ spec:
     clusters:
       - name: update
         templates:
-          podTemplate: clickhouse:20.6
+          podTemplate: clickhouse:22.2
         layout:
           shards:
             - replicas:
@@ -15,18 +15,18 @@ spec:
                 - tcpPort: 9000
                 - tcpPort: 9000
                   templates:
-                    podTemplate: clickhouse:20.7
+                    podTemplate: clickhouse:22.3
 
   templates:
     podTemplates:
-      - name: clickhouse:20.6
+      - name: clickhouse:22.2
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.6
+              image: clickhouse/clickhouse-server:22.2
 
-      - name: clickhouse:20.7
+      - name: clickhouse:22.3
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/08-clickhouse-version-update-03-apply-update-all.yaml
+++ b/docs/chi-examples/08-clickhouse-version-update-03-apply-update-all.yaml
@@ -7,7 +7,7 @@ spec:
     clusters:
       - name: update
         templates:
-          podTemplate: clickhouse:20.7
+          podTemplate: clickhouse:22.3
         layout:
           shards:
             - replicas:
@@ -17,8 +17,8 @@ spec:
 
   templates:
     podTemplates:
-      - name: clickhouse:20.7
+      - name: clickhouse:22.3
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/09-rolling-update-emptydir-01-initial-position.yaml
+++ b/docs/chi-examples/09-rolling-update-emptydir-01-initial-position.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: clickhouse-storage
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/09-rolling-update-emptydir-02-apply-update.yaml
+++ b/docs/chi-examples/09-rolling-update-emptydir-02-apply-update.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: clickhouse-storage
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/10-zones-01-simple-01-aws-pods-in-availability-zones.yaml
+++ b/docs/chi-examples/10-zones-01-simple-01-aws-pods-in-availability-zones.yaml
@@ -49,7 +49,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
 
       - name: clickhouse-in-zone-us-east-1b
         zone:
@@ -58,4 +58,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/10-zones-01-simple-02-aws-pod-per-host.yaml
+++ b/docs/chi-examples/10-zones-01-simple-02-aws-pod-per-host.yaml
@@ -40,4 +40,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/10-zones-02-advanced-01-aws-pods-in-availability-zones.yaml
+++ b/docs/chi-examples/10-zones-02-advanced-01-aws-pods-in-availability-zones.yaml
@@ -56,7 +56,7 @@ spec:
                           - "us-east-1a"
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
 
       - name: clickhouse-in-zone-us-east-1b
         spec:
@@ -72,4 +72,4 @@ spec:
                           - "us-east-1b"
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/10-zones-02-advanced-02-aws-pod-per-host.yaml
+++ b/docs/chi-examples/10-zones-02-advanced-02-aws-pod-per-host.yaml
@@ -55,4 +55,4 @@ spec:
                   topologyKey: "kubernetes.io/hostname"
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/10-zones-03-advanced-03-pod-per-host-default-storage-class.yaml
+++ b/docs/chi-examples/10-zones-03-advanced-03-pod-per-host-default-storage-class.yaml
@@ -76,7 +76,7 @@ spec:
                     topologyKey: "kubernetes.io/hostname"
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/10-zones-04-advanced-04-pod-per-host-local-storage.yaml
+++ b/docs/chi-examples/10-zones-04-advanced-04-pod-per-host-local-storage.yaml
@@ -57,7 +57,7 @@ spec:
                 type: DirectoryOrCreate
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: local-path
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/11-local-storage-01-simple-host-path.yaml
+++ b/docs/chi-examples/11-local-storage-01-simple-host-path.yaml
@@ -48,7 +48,7 @@ spec:
                 type: DirectoryOrCreate
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 # Specify reference to volume on local filesystem
                 - name: local-path

--- a/docs/chi-examples/11-local-storage-02-advanced-host-path.yaml
+++ b/docs/chi-examples/11-local-storage-02-advanced-host-path.yaml
@@ -62,7 +62,7 @@ spec:
                 type: DirectoryOrCreate
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 # Specify reference to volume on local filesystem
                 - name: local-path

--- a/docs/chi-examples/12-troubleshooting-01.yaml
+++ b/docs/chi-examples/12-troubleshooting-01.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               command:
                 - "/bin/bash"
                 - "-c"

--- a/docs/chi-examples/13-distribution-02-3x3-circular-replication.yaml
+++ b/docs/chi-examples/13-distribution-02-3x3-circular-replication.yaml
@@ -20,7 +20,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
 ---
 apiVersion: "clickhouse.altinity.com/v1"
 kind: "ClickHouseInstallation"
@@ -44,4 +44,4 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/13-distribution-03-3x3-distribution-detailed.yaml
+++ b/docs/chi-examples/13-distribution-03-3x3-distribution-detailed.yaml
@@ -27,4 +27,4 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/15-hostNetwork-01-simple.yaml
+++ b/docs/chi-examples/15-hostNetwork-01-simple.yaml
@@ -24,4 +24,4 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/15-hostNetwork-02-simple-port-distribution.yaml
+++ b/docs/chi-examples/15-hostNetwork-02-simple-port-distribution.yaml
@@ -34,4 +34,4 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/15-hostNetwork-03-expanded-port-distribution.yaml
+++ b/docs/chi-examples/15-hostNetwork-03-expanded-port-distribution.yaml
@@ -41,4 +41,4 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/15-hostNetwork-04-simple-fixed-replicas.yaml
+++ b/docs/chi-examples/15-hostNetwork-04-simple-fixed-replicas.yaml
@@ -50,4 +50,4 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/15-hostNetwork-05-expanded-fixed-replicas.yaml
+++ b/docs/chi-examples/15-hostNetwork-05-expanded-fixed-replicas.yaml
@@ -51,4 +51,4 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3

--- a/docs/chi-examples/17-monitoring-cluster-01.yaml
+++ b/docs/chi-examples/17-monitoring-cluster-01.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: clickhouse-storage-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/19-pod-generate-name.yaml
+++ b/docs/chi-examples/19-pod-generate-name.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: clickhouse-storage-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/20-protobuf-schema-example.yaml
+++ b/docs/chi-examples/20-protobuf-schema-example.yaml
@@ -37,7 +37,7 @@ spec:
             fsGroup: 101
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:latest
+              image: clickhouse/clickhouse-server:latest
           initContainers:
             - name: copy
               image: alpine:latest

--- a/docs/chi-examples/99-clickhouseinstallation-max.yaml
+++ b/docs/chi-examples/99-clickhouseinstallation-max.yaml
@@ -52,7 +52,7 @@ spec:
       profile: default
     templates:
       hostTemplate: host-template-custom-ports
-      podTemplate: clickhouse-v20.6
+      podTemplate: clickhouse-v22.2
       dataVolumeClaimTemplate: default-volume-claim
       logVolumeClaimTemplate: default-volume-claim
       serviceTemplate: chi-service-template
@@ -132,7 +132,7 @@ spec:
 
       - name: all-counts
         templates:
-          podTemplate: clickhouse-v20.6
+          podTemplate: clickhouse-v22.2
           dataVolumeClaimTemplate: default-volume-claim
           logVolumeClaimTemplate: default-volume-claim
         layout:
@@ -141,7 +141,7 @@ spec:
 
       - name: shards-only
         templates:
-          podTemplate: clickhouse-v20.6
+          podTemplate: clickhouse-v22.2
           dataVolumeClaimTemplate: default-volume-claim
           logVolumeClaimTemplate: default-volume-claim
         layout:
@@ -150,7 +150,7 @@ spec:
 
       - name: replicas-only
         templates:
-          podTemplate: clickhouse-v20.6
+          podTemplate: clickhouse-v22.2
           dataVolumeClaimTemplate: default-volume-claim
           logVolumeClaimTemplate: default-volume-claim
         layout:
@@ -159,7 +159,7 @@ spec:
 
       - name: customized
         templates:
-          podTemplate: clickhouse-v20.6
+          podTemplate: clickhouse-v22.2
           dataVolumeClaimTemplate: default-volume-claim
           logVolumeClaimTemplate: default-volume-claim
         layout:
@@ -169,13 +169,13 @@ spec:
               weight: 1
               internalReplication: Disabled
               templates:
-                podTemplate: clickhouse-v20.6
+                podTemplate: clickhouse-v22.2
                 dataVolumeClaimTemplate: default-volume-claim
                 logVolumeClaimTemplate: default-volume-claim
 
             - name: shard1
               templates:
-                podTemplate: clickhouse-v20.6
+                podTemplate: clickhouse-v22.2
                 dataVolumeClaimTemplate: default-volume-claim
                 logVolumeClaimTemplate: default-volume-claim
               replicas:
@@ -186,7 +186,7 @@ spec:
             - name: shard2
               replicasCount: 3
               templates:
-                podTemplate: clickhouse-v20.6
+                podTemplate: clickhouse-v22.2
                 dataVolumeClaimTemplate: default-volume-claim
                 logVolumeClaimTemplate: default-volume-claim
                 replicaServiceTemplate: replica-service-template
@@ -196,7 +196,7 @@ spec:
                   httpPort: 8123
                   interserverHTTPPort: 9009
                   templates:
-                    podTemplate: clickhouse-v20.7
+                    podTemplate: clickhouse-v22.3
                     dataVolumeClaimTemplate: default-volume-claim
                     logVolumeClaimTemplate: default-volume-claim
                     replicaServiceTemplate: replica-service-template
@@ -347,7 +347,7 @@ spec:
     podTemplates:
       # multiple pod templates makes possible to update version smoothly
       # pod template for ClickHouse v18.16.1
-      - name: clickhouse-v20.7
+      - name: clickhouse-v22.3
         # We may need to label nodes with clickhouse=allow label for this example to run
         # See ./label_nodes.sh for this purpose
         zone:
@@ -426,7 +426,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: default-volume-claim
                   mountPath: /var/lib/clickhouse
@@ -438,13 +438,13 @@ spec:
                   memory: "64Mi"
                   cpu: "100m"
 
-      # pod template for ClickHouse v19.11.3.11
-      - name: clickhouse-v20.6
+      # pod template for ClickHouse v22.2
+      - name: clickhouse-v22.2
         # type PodSpec struct {} from k8s.io/core/v1
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:20.6
+              image: clickhouse/clickhouse-server:22.2
               volumeMounts:
                 - name: default-volume-claim
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/99-clickhouseupgrade-draft.yaml
+++ b/docs/chi-examples/99-clickhouseupgrade-draft.yaml
@@ -1,3 +1,4 @@
+# DRAFT, doesn't works in 2022
 apiVersion: "clickhouse.altinity.com/v1"
 kind: "ClickHouseUpgrade"
 metadata:
@@ -8,7 +9,7 @@ spec:
       zone:
         matchLabels:
           clickhouse.altinity.com/zone: zone1
-      podTemplate: clickhouse-v20.6
+      podTemplate: clickhouse-v21.8
       dataVolumeClaimTemplate: default
       logVolumeClaimTemplate: default
 #     scenario: Default
@@ -56,7 +57,7 @@ spec:
                 matchLabels:
                   clickhouse.altinity.com/zone: zone4
                   clickhouse.altinity.com/kind: ssd
-              podTemplate: clickhouse-v20.6
+              podTemplate: clickhouse-v22.3
 
             replicas:
               - index: 2
@@ -82,12 +83,12 @@ spec:
               storage: 1Gi
     podTemplates:
     # multiple pod templates makes possible to update version smoothly
-    # pod template for ClickHouse v18.16.1
-    - name: clickhouse-v20.6
+    # pod template for ClickHouse v21.8
+    - name: clickhouse-v21.8
     # volumes: are missing
       containers:
       - name: clickhouse
-        image: yandex/clickhouse-server:20.6
+        image: clickhouse/clickhouse-server:21.8
         volumeMounts:
         - name: clickhouse-data-test
           mountPath: /var/lib/clickhouse
@@ -98,12 +99,12 @@ spec:
           limits:
             memory: "64Mi"
             cpu: "100m"
-    # pod template for ClickHouse v20.6
-    - name: clickhouse-v20.6
+    # pod template for ClickHouse v22.3
+    - name: clickhouse-v22.3
     # volumes: are missing
       containers:
       - name: clickhouse
-        image: yandex/clickhouse-server:20.6
+        image: clickhouse/clickhouse-server:22.3
         volumeMounts:
         - name: clickhouse-data-test
           mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/evolution/01-persistent-volume.yaml
+++ b/docs/chi-examples/evolution/01-persistent-volume.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:19.3.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/evolution/02-introduce-replication.yaml
+++ b/docs/chi-examples/evolution/02-introduce-replication.yaml
@@ -22,7 +22,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:19.3.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/evolution/03-introduce-more-shards-and-zones.yaml
+++ b/docs/chi-examples/evolution/03-introduce-more-shards-and-zones.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:19.3.7
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/evolution/04-update-introduce-canary.yaml
+++ b/docs/chi-examples/evolution/04-update-introduce-canary.yaml
@@ -21,7 +21,7 @@ spec:
               replicas:
                 - name: "1"
                   templates:
-                    podTemplate: pod-template-with-volume-19.4
+                    podTemplate: pod-template-with-volume-22.3
 
   templates:
     podTemplates:
@@ -35,12 +35,12 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:19.3.7
+              image: clickhouse/clickhouse-server:21.8
               volumeMounts:
                 - name: storage-vc-template
                   mountPath: /var/lib/clickhouse
 
-      - name: pod-template-with-volume-19.4
+      - name: pod-template-with-volume-22.3
         zone:
           key: "clickhouse"
           values:
@@ -50,7 +50,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:19.4.3.11
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/chi-examples/evolution/05-update-propagate-update.yaml
+++ b/docs/chi-examples/evolution/05-update-propagate-update.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:19.4.3.11
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/config-examples/templates/103-templates.yaml
+++ b/docs/config-examples/templates/103-templates.yaml
@@ -9,7 +9,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:19.3.7
+              image: clickhouse/clickhouse-server:22.3
               ports:
                 - name: http
                   containerPort: 8123

--- a/docs/custom_resource_explained.md
+++ b/docs/custom_resource_explained.md
@@ -561,7 +561,7 @@ with additional sections, such as:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:18.16.1
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: default-volume-claim
                   mountPath: /var/lib/clickhouse

--- a/docs/operator_configuration.md
+++ b/docs/operator_configuration.md
@@ -149,7 +149,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:19.11.8.46
+              image: clickhouse/clickhouse-server:22.3
 ```
 
 Template needs to be deployed to some namespace, and later on used in the installation:

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -268,7 +268,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: data-storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docs/replication_setup.md
+++ b/docs/replication_setup.md
@@ -48,7 +48,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:19.6.2.11
+              image: clickhouse/clickhouse-server:22.3
 ```
 
 

--- a/pkg/model/ch_config_const.go
+++ b/pkg/model/ch_config_const.go
@@ -68,7 +68,7 @@ const (
 
 const (
 	// defaultClickHouseDockerImage specifies default ClickHouse docker image to be used
-	defaultClickHouseDockerImage = "yandex/clickhouse-server:latest"
+	defaultClickHouseDockerImage = "clickhouse/clickhouse-server:latest"
 
 	// defaultBusyBoxDockerImage specifies default BusyBox docker image to be used
 	defaultBusyBoxDockerImage = "busybox"

--- a/tests/e2e/manifests/chi/test-005-acm.yaml
+++ b/tests/e2e/manifests/chi/test-005-acm.yaml
@@ -13,7 +13,7 @@ spec:
           fsGroup: 101
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.3
+          image: clickhouse/clickhouse-server:22.3
           ports:
           - name: http
             containerPort: 8123
@@ -31,15 +31,15 @@ spec:
           - /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
           resources:
             requests:
-              memory: 300Mi
+              memory: 1Gi
               cpu: "1"
             limits:
-              memory: 300Mi
+              memory: 1Gi
               cpu: "1"
           volumeMounts:
             - mountPath: /var/lib/clickhouse
               name: default-gp2
-        - image: altinity/clickhouse-backup:1.3.0
+        - image: altinity/clickhouse-backup:1.3.1
           name: clickhouse-backup
           command:
             - clickhouse-backup
@@ -84,6 +84,7 @@ spec:
         <yandex>
           <https_port>8443</https_port>
           <tcp_port_secure>9440</tcp_port_secure>
+          <max_server_memory_usage_to_ram_ratio>1</max_server_memory_usage_to_ram_ratio>
         </yandex>
       node.csr: |
         **** HIDDEN ****

--- a/tests/e2e/manifests/chi/test-006-ch-upgrade-1.yaml
+++ b/tests/e2e/manifests/chi/test-006-ch-upgrade-1.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.3
+          image: clickhouse/clickhouse-server:21.8
   defaults:
     templates:
       podTemplate: clickhouse-old

--- a/tests/e2e/manifests/chi/test-006-ch-upgrade-2.yaml
+++ b/tests/e2e/manifests/chi/test-006-ch-upgrade-2.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.8
+          image: clickhouse/clickhouse-server:22.3
   defaults:
     templates:
       podTemplate: clickhouse-new

--- a/tests/e2e/manifests/chi/test-006-ch-upgrade-3.yaml
+++ b/tests/e2e/manifests/chi/test-006-ch-upgrade-3.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.3
+          image: clickhouse/clickhouse-server:21.8
   defaults:
     templates:
       podTemplate: clickhouse-new

--- a/tests/e2e/manifests/chi/test-008-operator-restart-2.yaml
+++ b/tests/e2e/manifests/chi/test-008-operator-restart-2.yaml
@@ -62,7 +62,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               ports:
                 - name: http
                   containerPort: 8123

--- a/tests/e2e/manifests/chi/test-009-operator-upgrade-2.yaml
+++ b/tests/e2e/manifests/chi/test-009-operator-upgrade-2.yaml
@@ -62,7 +62,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               ports:
                 - name: http
                   containerPort: 8123

--- a/tests/e2e/manifests/chi/test-015-host-network.yaml
+++ b/tests/e2e/manifests/chi/test-015-host-network.yaml
@@ -41,7 +41,7 @@ spec:
           hostNetwork: true
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
 
 
           # dnsPolicy: ClusterFirstWithHostNet

--- a/tests/e2e/manifests/chi/test-017-multi-version.yaml
+++ b/tests/e2e/manifests/chi/test-017-multi-version.yaml
@@ -5,25 +5,25 @@ metadata:
 spec:
   templates:
     podTemplates:
-    - name: v21.3
+    - name: v22.3
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.3
-    - name: v21.8
+          image: clickhouse/clickhouse-server:21.8
+    - name: v22.8
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.8
+          image: clickhouse/clickhouse-server:22.3
   configuration:
     clusters:
     - name: default
       layout:
         shards:
          - templates:
-             podTemplate: v21.3
+             podTemplate: v22.3
          - templates:
-             podTemplate: v21.8
+             podTemplate: v22.8
     files:
       users.d/remove_database_ordinary.xml: |
         <yandex>

--- a/tests/e2e/manifests/chi/test-020-multi-volume.yaml
+++ b/tests/e2e/manifests/chi/test-020-multi-volume.yaml
@@ -36,7 +36,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-rescale-volume-01.yaml
+++ b/tests/e2e/manifests/chi/test-021-rescale-volume-01.yaml
@@ -25,7 +25,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-rescale-volume-02-enlarge-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-rescale-volume-02-enlarge-disk.yaml
@@ -25,7 +25,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-rescale-volume-03-add-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-rescale-volume-03-add-disk.yaml
@@ -36,7 +36,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-rescale-volume-04-decrease-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-rescale-volume-04-decrease-disk.yaml
@@ -36,7 +36,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-022-broken-image.yaml
+++ b/tests/e2e/manifests/chi/test-022-broken-image.yaml
@@ -12,7 +12,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:20.3.13.127-broken
+          image: clickhouse/clickhouse-server:22.3-broken
   configuration:
     clusters:
     - name: default

--- a/tests/e2e/manifests/chi/test-024-template-annotations.yaml
+++ b/tests/e2e/manifests/chi/test-024-template-annotations.yaml
@@ -14,7 +14,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.8
+          image: clickhouse/clickhouse-server:22.3
     volumeClaimTemplates:
     - name: default-volumeclaim-template
       reclaimPolicy: Delete

--- a/tests/e2e/manifests/chi/test-025-rescaling-2.yaml
+++ b/tests/e2e/manifests/chi/test-025-rescaling-2.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               command:
                 - "/bin/bash"
                 - "-c"

--- a/tests/e2e/manifests/chi/test-025-rescaling.yaml
+++ b/tests/e2e/manifests/chi/test-025-rescaling.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               command:
                 - "/bin/bash"
                 - "-c"

--- a/tests/e2e/manifests/chi/test-026-mixed-replicas.yaml
+++ b/tests/e2e/manifests/chi/test-026-mixed-replicas.yaml
@@ -54,7 +54,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
       - name: multi-volume
         spec:
           securityContext:
@@ -63,7 +63,7 @@ spec:
             fsGroup: 101
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-029-distribution.yaml
+++ b/tests/e2e/manifests/chi/test-029-distribution.yaml
@@ -9,7 +9,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.8
+          image: clickhouse/clickhouse-server:22.3
       podDistribution:
       - scope: ClickHouseInstallation
         type: ClickHouseAntiAffinity
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: yandex/clickhouse-server:21.8
+          image: clickhouse/clickhouse-server:22.3
       podDistribution:
       - scope: ClickHouseInstallation
         type: ReplicaAntiAffinity

--- a/tests/e2e/manifests/chit/tpl-clickhouse-21.8.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-21.8.yaml
@@ -13,4 +13,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:21.8

--- a/tests/e2e/manifests/chit/tpl-clickhouse-22.3.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-22.3.yaml
@@ -13,4 +13,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: clickhouse/clickhouse-server:21.3
+              image: clickhouse/clickhouse-server:22.3

--- a/tests/e2e/manifests/chit/tpl-clickhouse-alerts.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-alerts.yaml
@@ -17,4 +17,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.11 # @TODO replace to :latest after resolve https://github.com/ClickHouse/ClickHouse/issues/34014
+              image: clickhouse/clickhouse-server:22.3

--- a/tests/e2e/manifests/chit/tpl-clickhouse-auto-1.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-auto-1.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.3
+              image: clickhouse/clickhouse-server:22.3
           #    command:
           #      - "/bin/bash"
           #      - "-c"

--- a/tests/e2e/manifests/chit/tpl-clickhouse-backups-fake.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-backups-fake.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
 
             - name: clickhouse-backup
               image: nginx:latest

--- a/tests/e2e/manifests/chit/tpl-clickhouse-backups.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-backups.yaml
@@ -25,13 +25,13 @@ spec:
             fsGroup: 101
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:21.8
+              image: clickhouse/clickhouse-server:22.3
               command:
                 - clickhouse-server
                 - --config-file=/etc/clickhouse-server/config.xml
 
             - name: clickhouse-backup
-              image: altinity/clickhouse-backup:1.3.0
+              image: altinity/clickhouse-backup:1.3.1
               imagePullPolicy: IfNotPresent
               command:
                 - bash

--- a/tests/e2e/manifests/chit/tpl-clickhouse-latest.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-latest.yaml
@@ -13,4 +13,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: yandex/clickhouse-server:latest
+              image: clickhouse/clickhouse-server:latest

--- a/tests/e2e/settings.py
+++ b/tests/e2e/settings.py
@@ -50,7 +50,7 @@ clickhouse_operator_install_manifest = os.getenv('CLICKHOUSE_OPERATOR_INSTALL_MA
 # clickhouse_template = "manifests/chit/tpl-clickhouse-20.3.yaml"
 # clickhouse_template = "manifests/chit/tpl-clickhouse-20.8.yaml"
 # clickhouse_template = "manifests/chit/tpl-clickhouse-21.3.yaml"
-clickhouse_template = "manifests/chit/tpl-clickhouse-22.2.yaml"
+clickhouse_template = "manifests/chit/tpl-clickhouse-22.3.yaml"
 clickhouse_template_old = "manifests/chit/tpl-clickhouse-21.8.yaml"
 
 clickhouse_version = get_ch_version(clickhouse_template)

--- a/tests/e2e/test_clickhouse.py
+++ b/tests/e2e/test_clickhouse.py
@@ -14,7 +14,7 @@ from testflows.asserts import error
 @Name("test_ch_001. Insert quorum")
 def test_ch_001(self):
     util.require_keeper(keeper_type=self.context.keeper_type)
-    quorum_template = "manifests/chit/tpl-clickhouse-21.8.yaml"
+    quorum_template = "manifests/chit/tpl-clickhouse-22.3.yaml"
     chit_data = yaml_manifest.get_manifest_data(util.get_full_path(quorum_template))
 
     kubectl.launch(f"delete chit {chit_data['metadata']['name']}", ns=settings.test_namespace, ok_to_fail=True)
@@ -133,7 +133,7 @@ def test_ch_002(self):
     kubectl.create_and_check(
         "manifests/chi/test-ch-002-row-level.yaml",
         {
-            "apply_templates": {"manifests/chit/tpl-clickhouse-21.8.yaml"},
+            "apply_templates": {"manifests/chit/tpl-clickhouse-22.3.yaml"},
             "do_not_delete": 1,
         })
 

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -51,7 +51,7 @@ def test_examples02_2(self):
         manifest="../../docs/chi-examples/03-persistent-volume-02-pod-template.yaml",
         check={
             "pod_count": 1,
-            "pod_image": "yandex/clickhouse-server:21.8",
+            "pod_image": "clickhouse/clickhouse-server:22.3",
             "pod_volumes": {
                 "/var/lib/clickhouse",
                 "/var/log/clickhouse-server",

--- a/tests/e2e/test_keeper.py
+++ b/tests/e2e/test_keeper.py
@@ -198,5 +198,6 @@ def test(self):
         test_zookeeper_rescale,
     ]
 
+    util.install_operator_if_not_exist()
     for t in all_tests:
         Scenario(test=t)()

--- a/tests/e2e/test_metrics_alerts.py
+++ b/tests/e2e/test_metrics_alerts.py
@@ -577,7 +577,7 @@ def test_system_settings_changed(self, prometheus_operator_spec, clickhouse_oper
         fired = alerts.wait_alert_state(
             "ClickHouseSystemSettingsChanged", "firing", True, labels={"hostname": changed_svc},
             time_range="30s")
-        assert fired, error("can't get ClickHouseTooManyConnections alert in firing state")
+        assert fired, error("can't get ClickHouseSystemSettingsChanged alert in firing state")
 
     with When("rollback changed settings"):
         kubectl.create_and_check(
@@ -599,7 +599,7 @@ def test_system_settings_changed(self, prometheus_operator_spec, clickhouse_oper
 
     with Then("check ClickHouseSystemSettingsChanged gone away"):
         resolved = alerts.wait_alert_state("ClickHouseSystemSettingsChanged", "firing", False, labels={"hostname": changed_svc}, sleep_time=30)
-        assert resolved, error("can't check ClickHouseTooManyConnections alert is gone away")
+        assert resolved, error("can't check ClickHouseSystemSettingsChanged alert is gone away")
 
 
 @TestScenario
@@ -776,7 +776,7 @@ def test_keeper_alerts_outline(self, keeper_type):
     expected_alerts = {
         "zookeeper": {
             "down": "ZookeeperDown",
-            "restartRecently":"ZookeeperRestartRecently",
+            "restartRecently": "ZookeeperRestartRecently",
         },
         "clickhouse-keeper": {
             "down": "ClickHouseKeeperDown",

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -121,8 +121,8 @@ def test_005(self):
     RQ_SRS_026_ClickHouseOperator_Managing_VersionUpgrades("1.0")
 )
 def test_006(self):
-    old_version = "yandex/clickhouse-server:21.3"
-    new_version = "yandex/clickhouse-server:21.8"
+    old_version = "clickhouse/clickhouse-server:21.8"
+    new_version = "clickhouse/clickhouse-server:22.3"
     with Then("Create initial position"):
         kubectl.create_and_check(
             manifest="manifests/chi/test-006-ch-upgrade-1.yaml",

--- a/tests/image/build_docker.sh
+++ b/tests/image/build_docker.sh
@@ -7,12 +7,12 @@ OPERATOR_IMAGE="altinity/clickhouse-operator:${OPERATOR_VERSION}"
 OPERATOR_IMAGE_OLD="altinity/clickhouse-operator:${OPERATOR_VERSION_OLD}"
 METRICS_EXPORTER_IMAGE="altinity/metrics-exporter:${OPERATOR_VERSION}"
 METRICS_EXPORTER_IMAGE_OLD="altinity/metrics-exporter:${OPERATOR_VERSION_OLD}"
-CLICKHOUSE_BACKUP_IMAGE="altinity/clickhouse-backup:1.3.0"
-CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE:="yandex/clickhouse-server:21.8"}
-CLICKHOUSE_IMAGE_OLD=${CLICKHOUSE_IMAGE_OLD:="yandex/clickhouse-server:21.3"}
-CLICKHOUSE_IMAGE_LATEST=${CLICKHOUSE_IMAGE_LATEST:="yandex/clickhouse-server:latest"}
+CLICKHOUSE_BACKUP_IMAGE="altinity/clickhouse-backup:1.3.1"
+CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE:="clickhouse/clickhouse-server:22.3"}
+CLICKHOUSE_IMAGE_OLD=${CLICKHOUSE_IMAGE_OLD:="clickhouse/clickhouse-server:21.8"}
+CLICKHOUSE_IMAGE_LATEST=${CLICKHOUSE_IMAGE_LATEST:="clickhouse/clickhouse-server:latest"}
 CLICKHOUSE_OPERATOR_TESTS_IMAGE=${CLICKHOUSE_OPERATOR_TESTS_IMAGE:="registry.gitlab.com/altinity-public/container-images/clickhouse-operator-test-runner:latest"}
-ZOOKEEPER_IMAGE=${ZOOKEEPER_IMAGE:="zookeeper:3.7.0"}
+ZOOKEEPER_IMAGE=${ZOOKEEPER_IMAGE:="zookeeper:3.8.0"}
 
 K8S_VERSION=${K8S_VERSION:=1.21.6}
 MINIKUBE_PRELOADED_TARBALL="preloaded-images-k8s-v13-v${K8S_VERSION}-docker-overlay2-amd64.tar.lz4"

--- a/tests/image/requirements.txt
+++ b/tests/image/requirements.txt
@@ -1,4 +1,4 @@
-testflows==1.7.77
+testflows==1.8.19
 requests
 PyYAML<6
 docker-compose>=1.29.1

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -1,18 +1,25 @@
 from testflows.core import *
 
-from helpers.cluster import Cluster
 from helpers.argparser import argparser
+from helpers.cluster import Cluster
 from requirements.requirements import *
 
 xfails = {
-        # test_operator.py
-        "/regression/e2e.test_operator/test_023*": [(Fail, "Template annotations do not work")],
+    # test_operator.py
+    "/regression/e2e.test_operator/test_023*": [(Fail, "Template annotations do not work")],
 
-        # test_clickhouse.py
-        "/regression/e2e.test_clickhouse/test_ch_001*": [(Fail, "Insert Quorum test need to refactoring")],
+    # test_clickhouse.py
+    "/regression/e2e.test_clickhouse/test_ch_001*": [(Fail, "Insert Quorum test need to refactoring")],
 
-        # test_metrics_alerts.py
-        "/regression/e2e.test_metrics_alerts/test_clickhouse_dns_errors*": [(Fail, "DNSError profile event behavior changed on 21.9, look https://github.com/ClickHouse/ClickHouse/issues/29624")]
+    # test_metrics_alerts.py
+    "/regression/e2e.test_metrics_alerts/test_clickhouse_dns_errors*": [
+        (Fail, "DNSError behavior changed on 21.9, look https://github.com/ClickHouse/ClickHouse/issues/29624")
+    ],
+
+    # test_keeper.py
+    "/regression/e2e.test_keeper/test_clickhouse_keeper_rescale*": [
+        (Fail, "need `ruok` before quorum https://github.com/ClickHouse/ClickHouse/issues/35464, need apply file config instead use commited data for quorum https://github.com/ClickHouse/ClickHouse/issues/35465")
+    ],
 }
 
 
@@ -29,11 +36,11 @@ def regression(self, native, keeper_type):
         features = [
             "e2e.test_metrics_exporter",
             "e2e.test_metrics_alerts",
-            "e2e.test_keeper",
             "e2e.test_backup_alerts",
             "e2e.test_operator",
             "e2e.test_clickhouse",
             "e2e.test_examples",
+            "e2e.test_keeper",
         ]
         for feature_name in features:
             Feature(run=load(feature_name, "test"))


### PR DESCRIPTION
- update clickhouse-keeper manifests
- update clickhouse image to clickhouse/clickhouse-server:22.3
- update backup clickhouse-backup:1.3.1
- zookeeper:3.8.0 (acm not affected), 
- tests passed 
- add test_clickhouse_keeper to XFail https://github.com/ClickHouse/ClickHouse/issues/35464, https://github.com/ClickHouse/ClickHouse/issues/35479

@sunsingerus need 0.19.x or 0.18.4 for as properly branch