### PR TITLE
Add support for setting secure communication between clickhouse instances

### DIFF
--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-01-chi-chit.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-01-chi-chit.yaml
@@ -837,6 +837,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -989,6 +994,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -1105,6 +1115,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -844,6 +844,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -996,6 +1001,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -1112,6 +1122,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |
@@ -2206,6 +2221,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2358,6 +2378,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2474,6 +2499,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -828,6 +828,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -980,6 +985,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -1096,6 +1106,11 @@ spec:
                               More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
+                          secure:
+                            type: boolean
+                            description: |
+                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified
                           httpPort:
                             type: integer
                             description: |
@@ -2177,6 +2192,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -2329,6 +2349,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -2445,6 +2470,11 @@ spec:
                               More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
+                          secure:
+                            type: boolean
+                            description: |
+                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified
                           httpPort:
                             type: integer
                             description: |

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -837,6 +837,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -989,6 +994,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -1105,6 +1115,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |
@@ -2199,6 +2214,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2351,6 +2371,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2467,6 +2492,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -828,6 +828,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -980,6 +985,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -1096,6 +1106,11 @@ spec:
                               More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
+                          secure:
+                            type: boolean
+                            description: |
+                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified
                           httpPort:
                             type: integer
                             description: |
@@ -2177,6 +2192,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -2329,6 +2349,11 @@ spec:
                                           allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                         minimum: 1
                                         maximum: 65535
+                                      secure:
+                                        type: boolean
+                                        description: |
+                                          optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                          if specified
                                       httpPort:
                                         type: integer
                                         description: |
@@ -2445,6 +2470,11 @@ spec:
                               More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                             minimum: 1
                             maximum: 65535
+                          secure:
+                            type: boolean
+                            description: |
+                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                              if specified
                           httpPort:
                             type: integer
                             description: |

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -837,6 +837,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -989,6 +994,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -1105,6 +1115,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |
@@ -2199,6 +2214,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2351,6 +2371,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2467,6 +2492,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -844,6 +844,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -996,6 +1001,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -1112,6 +1122,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |
@@ -2206,6 +2221,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2358,6 +2378,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2474,6 +2499,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |

--- a/deploy/operator/parts/crd.yaml
+++ b/deploy/operator/parts/crd.yaml
@@ -837,6 +837,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -989,6 +994,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -1105,6 +1115,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |
@@ -2199,6 +2214,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2351,6 +2371,11 @@ spec:
                                               allows connect to `clickhouse-server` via TCP Native protocol via kubernetes `Service`
                                             minimum: 1
                                             maximum: 65535
+                                          secure:
+                                            type: boolean
+                                            description: |
+                                              optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                              if specified
                                           httpPort:
                                             type: integer
                                             description: |
@@ -2467,6 +2492,11 @@ spec:
                                   More info: https://clickhouse.tech/docs/en/interfaces/tcp/
                                 minimum: 1
                                 maximum: 65535
+                              secure:
+                                type: boolean
+                                description: |
+                                  optional, setup `secure` inside `clickhouse-server` settings for each Pod where current template will apply
+                                  if specified
                               httpPort:
                                 type: integer
                                 description: |

--- a/pkg/apis/clickhouse.altinity.com/v1/type_host.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_host.go
@@ -25,6 +25,7 @@ type ChiHost struct {
 	// DEPRECATED - to be removed soon
 	Port                int32             `json:"port,omitempty"                yaml:"port,omitempty"`
 	TCPPort             int32             `json:"tcpPort,omitempty"             yaml:"tcpPort,omitempty"`
+	Secure              bool              `json:"secure,omitempty"              yaml:"secure,omitempty"`
 	HTTPPort            int32             `json:"httpPort,omitempty"            yaml:"httpPort,omitempty"`
 	InterserverHTTPPort int32             `json:"interserverHTTPPort,omitempty" yaml:"interserverHTTPPort,omitempty"`
 	Settings            *Settings         `json:"settings,omitempty"            yaml:"settings,omitempty"`
@@ -90,7 +91,9 @@ func (host *ChiHost) MergeFrom(from *ChiHost) {
 	if (host == nil) || (from == nil) {
 		return
 	}
-
+	if !host.Secure {
+		host.Secure = from.Secure
+	}
 	if host.Port == 0 {
 		host.Port = from.Port
 	}

--- a/pkg/model/ch_config_generator.go
+++ b/pkg/model/ch_config_generator.go
@@ -317,6 +317,9 @@ func (c *ClickHouseConfigGenerator) GetRemoteServers(options *RemoteServersGener
 					util.Iline(b, 16, "<replica>")
 					util.Iline(b, 16, "    <host>%s</host>", c.getRemoteServersReplicaHostname(host))
 					util.Iline(b, 16, "    <port>%d</port>", host.TCPPort)
+					if host.Secure {
+						util.Iline(b, 16, "    <secure>1</secure>")
+					}
 					util.Iline(b, 16, "</replica>")
 				}
 				return nil
@@ -357,6 +360,9 @@ func (c *ClickHouseConfigGenerator) GetRemoteServers(options *RemoteServersGener
 				util.Iline(b, 16, "<replica>")
 				util.Iline(b, 16, "    <host>%s</host>", c.getRemoteServersReplicaHostname(host))
 				util.Iline(b, 16, "    <port>%d</port>", host.TCPPort)
+				if host.Secure {
+					util.Iline(b, 16, "    <secure>1</secure>")
+				}
 				util.Iline(b, 16, "</replica>")
 			}
 			return nil
@@ -386,6 +392,9 @@ func (c *ClickHouseConfigGenerator) GetRemoteServers(options *RemoteServersGener
 				util.Iline(b, 16, "<replica>")
 				util.Iline(b, 16, "    <host>%s</host>", c.getRemoteServersReplicaHostname(host))
 				util.Iline(b, 16, "    <port>%d</port>", host.TCPPort)
+				if host.Secure {
+					util.Iline(b, 16, "    <secure>1</secure>")
+				}
 				util.Iline(b, 16, "</replica>")
 
 				// </shard>

--- a/pkg/model/normalizer.go
+++ b/pkg/model/normalizer.go
@@ -288,6 +288,9 @@ func hostApplyHostTemplate(host *chiV1.ChiHost, template *chiV1.ChiHostTemplate)
 	if host.Name == "" {
 		host.Name = template.Spec.Name
 	}
+	if !host.Secure {
+		host.Secure = template.Spec.Secure
+	}
 
 	for _, portDistribution := range template.PortDistribution {
 		switch portDistribution.Type {

--- a/tests/e2e/manifests/chi/test-033-tls.yaml
+++ b/tests/e2e/manifests/chi/test-033-tls.yaml
@@ -1,0 +1,153 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "clickhouse-client-config"
+data:
+  config.xml: |
+    <config>
+        <openSSL>
+            <client>
+                <loadDefaultCAFile>false</loadDefaultCAFile>
+                <caConfig>/etc/clickhouse-server/tls/ca.crt</caConfig>
+                <cacheSessions>true</cacheSessions>
+                <disableProtocols>sslv2,sslv3</disableProtocols>
+                <preferServerCiphers>true</preferServerCiphers>
+                <verificationMode>strict</verificationMode>
+                <invalidCertificateHandler>
+                <name>RejectCertificateHandler</name>
+                </invalidCertificateHandler>
+            </client>
+        </openSSL>
+        <port>9440</port>
+        <secure>1</secure>
+    </config>
+---
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: test-033-tls
+spec:
+  configuration:
+    clusters:
+    - name: default
+      layout:
+        replicasCount: 1
+        shardsCount: 2
+    settings:
+      # disable non-secure ports, & configure secure ports.
+      tcp_port: _removed_
+      tcp_port_secure: 9440
+      http_port: _removed_
+      https_port: 8443
+      interserver_http_port: _removed_
+      interserver_https_port: 9010
+
+      # https://clickhouse.com/docs/en/guides/sre/configuring-ssl/
+      openSSL/server/certificateFile: "/etc/clickhouse-server/tls/tls.crt"
+      openSSL/server/privateKeyFile: "/etc/clickhouse-server/tls/tls.key"
+      openSSL/server/caConfig: "/etc/clickhouse-server/tls/ca.crt"
+      # none means we aren't requesting client certificates from clients
+      openSSL/server/verificationMode: "none"
+      openSSL/server/cacheSessions: true
+      openSSL/server/disableProtocols: "sslv2,sslv3"
+      openSSL/server/preferServerCiphers: true
+
+      openSSL/client/loadDefaultCAFile: false
+      openSSL/client/caConfig: "/etc/clickhouse-server/tls/ca.crt"
+      openSSL/client/cacheSessions: true
+      openSSL/client/disableProtocols: "sslv2,sslv3"
+      openSSL/client/preferServerCiphers: true
+      # strict verifies the server cert when configured on the client
+      openSSL/client/verificationMode: "strict"
+      openSSL/client/invalidCertificateHandler/name: RejectCertificateHandler
+    zookeeper:
+      nodes:
+      - host: zookeeper
+  defaults:
+    templates:
+      hostTemplate: host-template
+      podTemplate: pod-template
+      serviceTemplate: svc-template
+  templates:
+    hostTemplates:
+    - name: host-template
+      spec:
+        httpPort: 8443
+        interserverHTTPPort: 9010
+        secure: true
+        tcpPort: 9440
+    podTemplates:
+    - name: pod-template
+      spec:
+        containers:
+        - image: clickhouse/clickhouse-server:22.3
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 60
+            periodSeconds: 3
+          name: clickhouse-pod
+          ports:
+          - containerPort: 9440
+            name: tcp
+            protocol: TCP
+          - containerPort: 8443
+            name: https
+            protocol: TCP
+          - containerPort: 9010
+            name: interserver
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: https
+              scheme: HTTPS
+          volumeMounts:
+          - mountPath: /etc/clickhouse-server/tls
+            name: tls
+            readOnly: true
+        # enables clickhouse-client to talk to clickhouse over TLS
+          - name: client-config
+            mountPath: "/etc/clickhouse-client/"
+            readOnly: true
+        securityContext:
+          fsGroup: 101
+        volumes:
+        - name: tls
+          projected:
+            defaultMode: 288
+            sources:
+            - secret:
+                items:
+                - key: tls.crt
+                  path: tls.crt
+                - key: tls.key
+                  path: tls.key
+                name: clickhouse-cert
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: clickhouse-ca
+        # enables clickhouse-client to talk to clickhouse over TLS
+        - name: client-config
+          projected:
+            defaultMode: 0400
+            sources:
+            - configMap:
+                items:
+                - key: config.xml
+                  path: config.xml
+                name: clickhouse-client-config
+    serviceTemplates:
+    - name: svc-template
+      spec:
+        ports:
+        - name: https
+          port: 8443
+        - name: tcp
+          port: 9440
+        type: ClusterIP


### PR DESCRIPTION
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)

Fixes #668 

Verified this works when configuring clickhouse to use TLS and with no unencrypted ports.

A snippet of my CHI:
```
  templates:
    hostTemplates:
    - name: host-template
      spec:
        {{- if .Values.clickhouse.tls.enabled }}
        tcpPort: 9440
        secure: true
        httpPort: 8443
        interserverHTTPPort: 9010
        {{- else }}
        tcpPort: 9000
        httpPort: 8123
        interserverHTTPPort: 9009
        {{- end }}
```