### PR TITLE
comment out chopusername check

### DIFF
--- a/pkg/model/normalizer.go
+++ b/pkg/model/normalizer.go
@@ -1171,9 +1171,9 @@ func (n *Normalizer) normalizeConfigurationUsers(users *chiV1.Settings) *chiV1.S
 		//
 
 		// CHOp user does not handle password here
-		if username == chopUsername {
-			continue // move to the next user
-		}
+		//if username == chopUsername {
+		//	continue // move to the next user
+		//}
 
 		// Values from the secret have higher priority
 		n.substWithSecretField(users, username, "password", "k8s_secret_password")


### PR DESCRIPTION
## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)

In the 1.18.5 version, when clickhouse merges 01-clickhouse-user.xml and chop-generated-users.xml we get 
hashed password for plaintext password. When the same is done for the 1.19.0 version, the operator  kept both password and hashed password and caused invalid configuration. 