### PR TITLE
Add support of clickhouse-log via podTemplates

### DIFF
--- a/pkg/model/creator.go
+++ b/pkg/model/creator.go
@@ -474,6 +474,21 @@ func ensureClickHouseContainerSpecified(statefulSet *apps.StatefulSet) {
 	)
 }
 
+// ensureClickHouseLogContainerSpecified
+func ensureClickHouseLogContainerSpecified(statefulSet *apps.StatefulSet) {
+	_, ok := getClickHouseLogContainer(statefulSet)
+	if ok {
+		return
+	}
+
+	// No ClickHouse Log container available, let's add one
+
+	addContainer(
+		&statefulSet.Spec.Template.Spec,
+		newDefaultLogContainer(),
+	)
+}
+
 // ensureProbesSpecified
 func ensureProbesSpecified(statefulSet *apps.StatefulSet) {
 	container, ok := getClickHouseContainer(statefulSet)
@@ -546,7 +561,8 @@ func (c *Creator) setupLogContainer(statefulSet *apps.StatefulSet, host *chiv1.C
 	statefulSetName := CreateStatefulSetName(host)
 	// In case we have default LogVolumeClaimTemplate specified - need to append log container to Pod Template
 	if host.Templates.HasLogVolumeClaimTemplate() {
-		addContainer(&statefulSet.Spec.Template.Spec, newDefaultLogContainer())
+		ensureClickHouseLogContainerSpecified(statefulSet)
+
 		c.a.V(1).F().Info("add log container for statefulSet %s", statefulSetName)
 	}
 }
@@ -686,6 +702,18 @@ func getClickHouseContainer(statefulSet *apps.StatefulSet) (*corev1.Container, b
 	// Find by index
 	if len(statefulSet.Spec.Template.Spec.Containers) > 0 {
 		return &statefulSet.Spec.Template.Spec.Containers[0], true
+	}
+
+	return nil, false
+}
+
+func getClickHouseLogContainer(statefulSet *apps.StatefulSet) (*corev1.Container, bool) {
+	// Find by name
+	for i := range statefulSet.Spec.Template.Spec.Containers {
+		container := &statefulSet.Spec.Template.Spec.Containers[i]
+		if container.Name == ClickHouseLogContainerName {
+			return container, true
+		}
 	}
 
 	return nil, false


### PR DESCRIPTION
Hello!

I want to override clickhouse-log container via podTemplates section.

I found that it's not possible in current version. 

So I make some changes to support this feature.

This is Draft because I don't  check it and maybe I not found all places which should be changed. 

I'm ready for any advises how to make it better.