### PR TITLE
Use dynamic credentials secret name in config files

### DIFF
--- a/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-confd-files.yaml
+++ b/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-confd-files.yaml
@@ -10,4 +10,4 @@ metadata:
   name: {{ printf "%s-confd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-data: {{ toYaml .Values.configs.confdFiles | nindent 2 }}
+data: {{ tpl (toYaml .Values.configs.confdFiles) . | nindent 2 }}

--- a/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-configd-files.yaml
+++ b/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-configd-files.yaml
@@ -10,4 +10,4 @@ metadata:
   name: {{ printf "%s-configd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-data: {{ toYaml .Values.configs.configdFiles | nindent 2 }}
+data: {{ tpl (toYaml .Values.configs.configdFiles) . | nindent 2 }}

--- a/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
+++ b/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
@@ -10,4 +10,4 @@ metadata:
   name: {{ printf "%s-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-data: {{ toYaml .Values.configs.files | nindent 2 }}
+data: {{ tpl (toYaml .Values.configs.files) . | nindent 2 }}

--- a/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-templatesd-files.yaml
+++ b/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-templatesd-files.yaml
@@ -10,4 +10,4 @@ metadata:
   name: {{ printf "%s-templatesd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-data: {{ toYaml .Values.configs.templatesdFiles | nindent 2 }}
+data: {{ tpl (toYaml .Values.configs.templatesdFiles) . | nindent 2 }}

--- a/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-usersd-files.yaml
+++ b/deploy/helm/templates/generated/ConfigMap-etc-clickhouse-operator-usersd-files.yaml
@@ -10,4 +10,4 @@ metadata:
   name: {{ printf "%s-usersd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-data: {{ toYaml .Values.configs.usersdFiles | nindent 2 }}
+data: {{ tpl (toYaml .Values.configs.usersdFiles) . | nindent 2 }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -242,7 +242,7 @@ configs:
             # Empty `namespace` means that k8s secret would be looked in the same namespace where operator's pod is running.
             namespace: ""
             # Empty `name` means no k8s Secret would be looked for
-            name: "clickhouse-operator"
+            name: "{{ include "altinity-clickhouse-operator.fullname" . }}"
           # Port where to connect to ClickHouse instances to
           port: 8123
 


### PR DESCRIPTION
To keep in mind: values from all config maps are processed by [helm tpl function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function). So if there are unescaped special characters in config files, `helm install` command will fail.