### PR TITLE
fix grafana anonymous auth, again 

### DIFF
--- a/deploy/grafana/grafana-with-grafana-operator/grafana-cr-template.yaml
+++ b/deploy/grafana/grafana-with-grafana-operator/grafana-cr-template.yaml
@@ -27,9 +27,9 @@ spec:
     # required for Dashboard Installation - https://github.com/integr8ly/grafana-operator/issues/92
     auth.basic:
       enabled: True
-    auth.anonymous:
-      enabled: True
-      org_role: Editor
+#    auth.anonymous:
+#      enabled: True
+#      org_role: Editor
 # look to https://grafana.com/docs/grafana/latest/auth/generic-oauth/
 #    server:
 #      root_url: $GRAFANA_ROOT_URL


### PR DESCRIPTION
"message":"Grafana.integreatly.org \"grafana\" is invalid: spec.config.auth.anonymous.enabled: Invalid value: \"string\"
