### PR TITLE
Refactor ChiStatus internals to make concurrent access safe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,10 +70,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,8 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -529,6 +531,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sunsingerus/glog v1.0.1-0.20220103184348-48242e35873d h1:0e/CoQX3ZCy3rXDTflbXcj1ReYvRNpKONzr+8eDF3Hc=
 github.com/sunsingerus/glog v1.0.1-0.20220103184348-48242e35873d/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=

--- a/pkg/apis/clickhouse.altinity.com/v1/type_status.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_status.go
@@ -15,12 +15,24 @@
 package v1
 
 import (
-	"sort"
-
 	"github.com/altinity/clickhouse-operator/pkg/util"
+	"github.com/altinity/clickhouse-operator/pkg/version"
+	"sort"
+	"sync"
 )
 
-// ChiStatus defines status section of ClickHouseInstallation resource
+const (
+	maxActions = 10
+	maxErrors  = 10
+	maxTaskIDs = 10
+)
+
+// ChiStatus defines status section of ClickHouseInstallation resource.
+//
+// Note: application level reads and writes to ChiStatus fields should be done through synchronized getter/setter functions.
+// While all of these fields need to be exported for JSON and YAML serialization/deserialization, we can at least audit
+// that application logic sticks to the synchronized getter/setters by auditing whether all explicit Go field-level
+// accesses are strictly within _this_ source file OR the generated deep copy source file.
 type ChiStatus struct {
 	CHOpVersion            string                  `json:"chop-version,omitempty"           yaml:"chop-version,omitempty"`
 	CHOpCommit             string                  `json:"chop-commit,omitempty"            yaml:"chop-commit,omitempty"`
@@ -52,137 +64,8 @@ type ChiStatus struct {
 	NormalizedCHI          *ClickHouseInstallation `json:"normalized,omitempty"             yaml:"normalized,omitempty"`
 	NormalizedCHICompleted *ClickHouseInstallation `json:"normalizedCompleted,omitempty"    yaml:"normalizedCompleted,omitempty"`
 	HostsWithTablesCreated []string                `json:"hostsWithTablesCreated,omitempty" yaml:"hostsWithTablesCreated,omitempty"`
-}
 
-const (
-	maxActions = 10
-	maxErrors  = 10
-	maxTaskIDs = 10
-)
-
-// PushHostTablesCreated pushes host to the list of hosts with created tables
-func (s *ChiStatus) PushHostTablesCreated(host string) {
-	if s == nil {
-		return
-	}
-	if util.InArray(host, s.HostsWithTablesCreated) {
-		return
-	}
-
-	s.HostsWithTablesCreated = append(s.HostsWithTablesCreated, host)
-}
-
-// SyncHostTablesCreated syncs list of hosts with tables created with actual list of hosts
-func (s *ChiStatus) SyncHostTablesCreated() {
-	if s == nil {
-		return
-	}
-	if s.FQDNs == nil {
-		return
-	}
-	s.HostsWithTablesCreated = util.IntersectStringArrays(s.HostsWithTablesCreated, s.FQDNs)
-}
-
-// PushAction pushes action into status
-func (s *ChiStatus) PushAction(action string) {
-	if s == nil {
-		return
-	}
-	s.Actions = append([]string{action}, s.Actions...)
-	s.TrimActions()
-}
-
-// TrimActions trims actions
-func (s *ChiStatus) TrimActions() {
-	if s == nil {
-		return
-	}
-	if len(s.Actions) > maxActions {
-		s.Actions = s.Actions[:maxActions]
-	}
-}
-
-// PushError sets and pushes error into status
-func (s *ChiStatus) PushError(error string) {
-	if s == nil {
-		return
-	}
-	s.Errors = append([]string{error}, s.Errors...)
-	if len(s.Errors) > maxErrors {
-		s.Errors = s.Errors[:maxErrors]
-	}
-}
-
-// SetAndPushError sets and pushes error into status
-func (s *ChiStatus) SetAndPushError(error string) {
-	if s == nil {
-		return
-	}
-	s.Error = error
-	s.Errors = append([]string{error}, s.Errors...)
-	if len(s.Errors) > maxErrors {
-		s.Errors = s.Errors[:maxErrors]
-	}
-}
-
-// PushTaskIDStarted pushes task id into status
-func (s *ChiStatus) PushTaskIDStarted() {
-	if s == nil {
-		return
-	}
-	s.TaskIDsStarted = append([]string{s.TaskID}, s.TaskIDsStarted...)
-	if len(s.TaskIDsStarted) > maxTaskIDs {
-		s.TaskIDsStarted = s.TaskIDsStarted[:maxTaskIDs]
-	}
-}
-
-// PushTaskIDCompleted pushes task id into status
-func (s *ChiStatus) PushTaskIDCompleted() {
-	if s == nil {
-		return
-	}
-	s.TaskIDsCompleted = append([]string{s.TaskID}, s.TaskIDsCompleted...)
-	if len(s.TaskIDsCompleted) > maxTaskIDs {
-		s.TaskIDsCompleted = s.TaskIDsCompleted[:maxTaskIDs]
-	}
-}
-
-// ReconcileStart marks reconcile start
-func (s *ChiStatus) ReconcileStart(DeleteHostsCount int) {
-	if s == nil {
-		return
-	}
-	s.Status = StatusInProgress
-	s.HostsUpdatedCount = 0
-	s.HostsAddedCount = 0
-	s.HostsCompletedCount = 0
-	s.HostsDeletedCount = 0
-	s.HostsDeleteCount = DeleteHostsCount
-	s.PushTaskIDStarted()
-}
-
-// ReconcileComplete marks reconcile completion
-func (s *ChiStatus) ReconcileComplete() {
-	if s == nil {
-		return
-	}
-	s.Status = StatusCompleted
-	s.Action = ""
-	s.PushTaskIDCompleted()
-}
-
-// DeleteStart marks deletion start
-func (s *ChiStatus) DeleteStart() {
-	if s == nil {
-		return
-	}
-	s.Status = StatusTerminating
-	s.HostsUpdatedCount = 0
-	s.HostsAddedCount = 0
-	s.HostsCompletedCount = 0
-	s.HostsDeletedCount = 0
-	s.HostsDeleteCount = 0
-	s.PushTaskIDStarted()
+	mu sync.RWMutex
 }
 
 // CopyCHIStatusOptions specifies what to copy in CHI status options
@@ -195,138 +78,96 @@ type CopyCHIStatusOptions struct {
 	InheritableFields bool
 }
 
-// MergeActions merges actions
-func (s *ChiStatus) MergeActions(from *ChiStatus) {
-	if s == nil {
-		return
-	}
-	if from == nil {
-		return
-	}
-	s.Actions = util.MergeStringArrays(s.Actions, from.Actions)
-	sort.Sort(sort.Reverse(sort.StringSlice(s.Actions)))
-	s.TrimActions()
+// Beginning of synchronized mutator functions
+
+type FillStatusParams struct {
+	CHOpIP              string
+	ClustersCount       int
+	ShardsCount         int
+	HostsCount          int
+	TaskID              string
+	HostsUpdatedCount   int
+	HostsAddedCount     int
+	HostsCompletedCount int
+	HostsDeleteCount    int
+	HostsDeletedCount   int
+	Pods                []string
+	FQDNs               []string
+	Endpoint            string
+	NormalizedCHI       *ClickHouseInstallation
 }
 
-// CopyFrom copies
-func (s *ChiStatus) CopyFrom(from *ChiStatus, opts CopyCHIStatusOptions) {
-	if s == nil {
-		return
-	}
+// Fill is a synchronized setter for a fairly large number of fields. We take a struct type "params" argument to avoid
+// confusion of similarly typed positional arguments, and to avoid defining a lot of separate synchronized setters
+// for these fields that are typically all set together at once (during "fills").
+func (in *ChiStatus) Fill(params *FillStatusParams) {
+	doWithWriteLock(in, func(s *ChiStatus) {
+		// We always set these (build-hardcoded) version fields.
+		s.CHOpVersion = version.Version
+		s.CHOpCommit = version.GitSHA
+		s.CHOpDate = version.BuiltAt
 
-	if from == nil {
-		return
-	}
+		// Now, set fields from the provided input.
+		s.CHOpIP = params.CHOpIP
+		s.ClustersCount = params.ClustersCount
+		s.ShardsCount = params.ShardsCount
+		s.HostsCount = params.HostsCount
+		s.TaskID = params.TaskID
+		s.HostsUpdatedCount = params.HostsUpdatedCount
+		s.HostsAddedCount = params.HostsAddedCount
+		s.HostsCompletedCount = params.HostsCompletedCount
+		s.HostsDeleteCount = params.HostsDeleteCount
+		s.HostsDeletedCount = params.HostsDeletedCount
+		s.Pods = params.Pods
+		s.FQDNs = params.FQDNs
+		s.Endpoint = params.Endpoint
+		s.NormalizedCHI = params.NormalizedCHI
+	})
+}
 
-	if opts.InheritableFields {
-		s.TaskIDsStarted = from.TaskIDsStarted
-		s.TaskIDsCompleted = from.TaskIDsCompleted
-		s.Actions = from.Actions
-		s.Errors = from.Errors
-		s.HostsWithTablesCreated = from.HostsWithTablesCreated
-	}
+// SetError sets status error
+func (s *ChiStatus) SetError(err string) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.Error = err
+	})
+}
 
-	if opts.Actions {
-		s.Action = from.Action
-		s.MergeActions(from)
-		s.HostsWithTablesCreated = nil
-		if len(from.HostsWithTablesCreated) > 0 {
-			s.HostsWithTablesCreated = append(s.HostsWithTablesCreated, from.HostsWithTablesCreated...)
+// SetAndPushError sets and pushes error into status
+func (s *ChiStatus) SetAndPushError(err string) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.Error = err
+		s.Errors = append([]string{err}, s.Errors...)
+		if len(s.Errors) > maxErrors {
+			s.Errors = s.Errors[:maxErrors]
 		}
-	}
-
-	if opts.Errors {
-		s.Error = from.Error
-		s.Errors = util.MergeStringArrays(s.Errors, from.Errors)
-		sort.Sort(sort.Reverse(sort.StringSlice(s.Errors)))
-	}
-
-	if opts.MainFields {
-		s.CHOpVersion = from.CHOpVersion
-		s.CHOpCommit = from.CHOpCommit
-		s.CHOpDate = from.CHOpDate
-		s.CHOpIP = from.CHOpIP
-		s.ClustersCount = from.ClustersCount
-		s.ShardsCount = from.ShardsCount
-		s.ReplicasCount = from.ReplicasCount
-		s.HostsCount = from.HostsCount
-		s.Status = from.Status
-		s.TaskID = from.TaskID
-		s.TaskIDsStarted = from.TaskIDsStarted
-		s.TaskIDsCompleted = from.TaskIDsCompleted
-		s.Action = from.Action
-		s.MergeActions(from)
-		s.Error = from.Error
-		s.Errors = from.Errors
-		s.HostsUpdatedCount = from.HostsUpdatedCount
-		s.HostsAddedCount = from.HostsAddedCount
-		s.HostsCompletedCount = from.HostsCompletedCount
-		s.HostsDeletedCount = from.HostsDeletedCount
-		s.HostsDeleteCount = from.HostsDeleteCount
-		s.Pods = from.Pods
-		s.PodIPs = from.PodIPs
-		s.FQDNs = from.FQDNs
-		s.Endpoint = from.Endpoint
-		s.NormalizedCHI = from.NormalizedCHI
-	}
-
-	if opts.Normalized {
-		s.NormalizedCHI = from.NormalizedCHI
-	}
-
-	if opts.WholeStatus {
-		s.CHOpVersion = from.CHOpVersion
-		s.CHOpCommit = from.CHOpCommit
-		s.CHOpDate = from.CHOpDate
-		s.CHOpIP = from.CHOpIP
-		s.ClustersCount = from.ClustersCount
-		s.ShardsCount = from.ShardsCount
-		s.ReplicasCount = from.ReplicasCount
-		s.HostsCount = from.HostsCount
-		s.Status = from.Status
-		s.TaskID = from.TaskID
-		s.TaskIDsStarted = from.TaskIDsStarted
-		s.TaskIDsCompleted = from.TaskIDsCompleted
-		s.Action = from.Action
-		s.MergeActions(from)
-		s.Error = from.Error
-		s.Errors = from.Errors
-		s.HostsUpdatedCount = from.HostsUpdatedCount
-		s.HostsAddedCount = from.HostsAddedCount
-		s.HostsCompletedCount = from.HostsCompletedCount
-		s.HostsDeletedCount = from.HostsDeletedCount
-		s.HostsDeleteCount = from.HostsDeleteCount
-		s.Pods = from.Pods
-		s.PodIPs = from.PodIPs
-		s.FQDNs = from.FQDNs
-		s.Endpoint = from.Endpoint
-		s.NormalizedCHI = from.NormalizedCHI
-		s.NormalizedCHICompleted = from.NormalizedCHICompleted
-	}
+	})
 }
 
-// GetFQDNs is a getter
-func (s *ChiStatus) GetFQDNs() []string {
-	if s == nil {
-		return nil
-	}
-	return s.FQDNs
+// PushHostTablesCreated pushes host to the list of hosts with created tables
+func (s *ChiStatus) PushHostTablesCreated(host string) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		if util.InArray(host, s.HostsWithTablesCreated) {
+			return
+		}
+		s.HostsWithTablesCreated = append(s.HostsWithTablesCreated, host)
+	})
 }
 
-// GetCHOpIP is a getter
-func (s *ChiStatus) GetCHOpIP() string {
-	if s == nil {
-		return ""
-	}
-	return s.CHOpIP
+// SyncHostTablesCreated syncs list of hosts with tables created with actual list of hosts
+func (s *ChiStatus) SyncHostTablesCreated() {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		if s.FQDNs == nil {
+			return
+		}
+		s.HostsWithTablesCreated = util.IntersectStringArrays(s.HostsWithTablesCreated, s.FQDNs)
+	})
 }
 
-// GetNormalizedCHICompleted is a getter
-func (s *ChiStatus) GetNormalizedCHICompleted() *ClickHouseInstallation {
-	if s == nil {
-		return nil
-	}
-	return s.NormalizedCHICompleted
+// SetAction action setter
+func (s *ChiStatus) SetAction(action string) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.Action = action
+	})
 }
 
 // HasNormalizedCHICompleted is a checker
@@ -334,75 +175,500 @@ func (s *ChiStatus) HasNormalizedCHICompleted() bool {
 	return s.GetNormalizedCHICompleted() != nil
 }
 
-// GetNormalizedCHI is a getter
-func (s *ChiStatus) GetNormalizedCHI() *ClickHouseInstallation {
-	if s == nil {
-		return nil
-	}
-	return s.NormalizedCHI
-}
-
 // HasNormalizedCHI is a checker
 func (s *ChiStatus) HasNormalizedCHI() bool {
 	return s.GetNormalizedCHI() != nil
 }
 
-// GetStatus is a getter
-func (s *ChiStatus) GetStatus() string {
-	if s == nil {
-		return ""
-	}
-	return s.Status
+// PushAction pushes action into status
+func (s *ChiStatus) PushAction(action string) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.Actions = append([]string{action}, s.Actions...)
+		trimActionsNoSync(s)
+	})
 }
 
-// GetPods is a getter
-func (s *ChiStatus) GetPods() []string {
-	if s == nil {
-		return nil
-	}
-	return s.Pods
+// PushError sets and pushes error into status
+func (s *ChiStatus) PushError(error string) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.Errors = append([]string{error}, s.Errors...)
+		if len(s.Errors) > maxErrors {
+			s.Errors = s.Errors[:maxErrors]
+		}
+	})
 }
 
-// GetPodIPS is a getter
-func (s *ChiStatus) GetPodIPS() []string {
-	if s == nil {
-		return nil
-	}
-	return s.PodIPs
+func (s *ChiStatus) SetPodIPs(podIPs []string) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.PodIPs = podIPs
+	})
 }
 
-// HostUpdated updates updated hosts counter
+func (s *ChiStatus) HostDeleted() {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.HostsDeletedCount++
+	})
+}
+
+// HostUpdated updates the counter of updated hosts
 func (s *ChiStatus) HostUpdated() {
-	if s == nil {
-		return
-	}
-	s.HostsUpdatedCount++
-	s.HostsCompletedCount++
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.HostsUpdatedCount++
+		s.HostsCompletedCount++
+	})
 }
 
 // HostAdded updates added hosts counter
 func (s *ChiStatus) HostAdded() {
-	if s == nil {
-		return
-	}
-	s.HostsAddedCount++
-	s.HostsCompletedCount++
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.HostsAddedCount++
+		s.HostsCompletedCount++
+	})
 }
 
 // HostUnchanged updates unchanged hosts counter
 func (s *ChiStatus) HostUnchanged() {
-	if s == nil {
-		return
-	}
-	s.HostsUnchangedCount++
-	s.HostsCompletedCount++
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.HostsUnchangedCount++
+		s.HostsCompletedCount++
+	})
 }
 
 // HostFailed updates failed hosts counter
 func (s *ChiStatus) HostFailed() {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.HostsFailedCount++
+		s.HostsCompletedCount++
+	})
+}
+
+// ReconcileStart marks reconcile start
+func (s *ChiStatus) ReconcileStart(deleteHostsCount int) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		if s == nil {
+			return
+		}
+		s.Status = StatusInProgress
+		s.HostsUpdatedCount = 0
+		s.HostsAddedCount = 0
+		s.HostsCompletedCount = 0
+		s.HostsDeletedCount = 0
+		s.HostsDeleteCount = deleteHostsCount
+		pushTaskIDStartedNoSync(s)
+	})
+}
+
+// ReconcileComplete marks reconcile completion
+func (s *ChiStatus) ReconcileComplete() {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		if s == nil {
+			return
+		}
+		s.Status = StatusCompleted
+		s.Action = ""
+		pushTaskIDCompletedNoSync(s)
+	})
+}
+
+// DeleteStart marks deletion start
+func (s *ChiStatus) DeleteStart() {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		if s == nil {
+			return
+		}
+		s.Status = StatusTerminating
+		s.HostsUpdatedCount = 0
+		s.HostsAddedCount = 0
+		s.HostsCompletedCount = 0
+		s.HostsDeletedCount = 0
+		s.HostsDeleteCount = 0
+		pushTaskIDStartedNoSync(s)
+	})
+}
+
+// CopyFrom copies the state of a given ChiStatus f into the receiver ChiStatus of the call.
+func (s *ChiStatus) CopyFrom(f *ChiStatus, opts CopyCHIStatusOptions) {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		doWithReadLock(f, func(from *ChiStatus) {
+			if s == nil || from == nil {
+				return
+			}
+
+			if opts.InheritableFields {
+				s.TaskIDsStarted = from.TaskIDsStarted
+				s.TaskIDsCompleted = from.TaskIDsCompleted
+				s.Actions = from.Actions
+				s.Errors = from.Errors
+				s.HostsWithTablesCreated = from.HostsWithTablesCreated
+			}
+
+			if opts.Actions {
+				s.Action = from.Action
+				mergeActionsNoSync(s, from)
+				s.HostsWithTablesCreated = nil
+				if len(from.HostsWithTablesCreated) > 0 {
+					s.HostsWithTablesCreated = append(s.HostsWithTablesCreated, from.HostsWithTablesCreated...)
+				}
+			}
+
+			if opts.Errors {
+				s.Error = from.Error
+				s.Errors = util.MergeStringArrays(s.Errors, from.Errors)
+				sort.Sort(sort.Reverse(sort.StringSlice(s.Errors)))
+			}
+
+			if opts.MainFields {
+				s.CHOpVersion = from.CHOpVersion
+				s.CHOpCommit = from.CHOpCommit
+				s.CHOpDate = from.CHOpDate
+				s.CHOpIP = from.CHOpIP
+				s.ClustersCount = from.ClustersCount
+				s.ShardsCount = from.ShardsCount
+				s.ReplicasCount = from.ReplicasCount
+				s.HostsCount = from.HostsCount
+				s.Status = from.Status
+				s.TaskID = from.TaskID
+				s.TaskIDsStarted = from.TaskIDsStarted
+				s.TaskIDsCompleted = from.TaskIDsCompleted
+				s.Action = from.Action
+				mergeActionsNoSync(s, from)
+				s.Error = from.Error
+				s.Errors = from.Errors
+				s.HostsUpdatedCount = from.HostsUpdatedCount
+				s.HostsAddedCount = from.HostsAddedCount
+				s.HostsCompletedCount = from.HostsCompletedCount
+				s.HostsDeletedCount = from.HostsDeletedCount
+				s.HostsDeleteCount = from.HostsDeleteCount
+				s.Pods = from.Pods
+				s.PodIPs = from.PodIPs
+				s.FQDNs = from.FQDNs
+				s.Endpoint = from.Endpoint
+				s.NormalizedCHI = from.NormalizedCHI
+			}
+
+			if opts.Normalized {
+				s.NormalizedCHI = from.NormalizedCHI
+			}
+
+			if opts.WholeStatus {
+				s.CHOpVersion = from.CHOpVersion
+				s.CHOpCommit = from.CHOpCommit
+				s.CHOpDate = from.CHOpDate
+				s.CHOpIP = from.CHOpIP
+				s.ClustersCount = from.ClustersCount
+				s.ShardsCount = from.ShardsCount
+				s.ReplicasCount = from.ReplicasCount
+				s.HostsCount = from.HostsCount
+				s.Status = from.Status
+				s.TaskID = from.TaskID
+				s.TaskIDsStarted = from.TaskIDsStarted
+				s.TaskIDsCompleted = from.TaskIDsCompleted
+				s.Action = from.Action
+				mergeActionsNoSync(s, from)
+				s.Error = from.Error
+				s.Errors = from.Errors
+				s.HostsUpdatedCount = from.HostsUpdatedCount
+				s.HostsAddedCount = from.HostsAddedCount
+				s.HostsCompletedCount = from.HostsCompletedCount
+				s.HostsDeletedCount = from.HostsDeletedCount
+				s.HostsDeleteCount = from.HostsDeleteCount
+				s.Pods = from.Pods
+				s.PodIPs = from.PodIPs
+				s.FQDNs = from.FQDNs
+				s.Endpoint = from.Endpoint
+				s.NormalizedCHI = from.NormalizedCHI
+				s.NormalizedCHICompleted = from.NormalizedCHICompleted
+			}
+		})
+	})
+}
+
+func (s *ChiStatus) ClearNormalizedCHI() {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.NormalizedCHI = nil
+	})
+}
+
+func (s *ChiStatus) SetNormalizedCompletedFromCurrentNormalized() {
+	doWithWriteLock(s, func(s *ChiStatus) {
+		s.NormalizedCHICompleted = s.NormalizedCHI
+	})
+}
+
+// Beginning of synchronized getter functions
+
+func (s *ChiStatus) GetCHOpVersion() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.CHOpVersion
+	})
+}
+func (s *ChiStatus) GetCHOpCommit() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.CHOpCommit
+	})
+}
+
+func (s *ChiStatus) GetCHOpDate() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.CHOpDate
+	})
+}
+
+func (s *ChiStatus) GetCHOpIP() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.CHOpIP
+	})
+}
+
+func (s *ChiStatus) GetClustersCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.ClustersCount
+	})
+}
+
+func (s *ChiStatus) GetShardsCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.ShardsCount
+	})
+}
+
+func (s *ChiStatus) GetReplicasCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.ReplicasCount
+	})
+}
+
+func (s *ChiStatus) GetHostsCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsCount
+	})
+}
+
+func (s *ChiStatus) GetStatus() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.Status
+	})
+}
+
+func (s *ChiStatus) GetTaskID() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.TaskID
+	})
+}
+
+func (s *ChiStatus) GetTaskIDsStarted() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.TaskIDsStarted
+	})
+}
+
+func (s *ChiStatus) GetTaskIDsCompleted() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.TaskIDsCompleted
+	})
+}
+
+func (s *ChiStatus) GetAction() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.Action
+	})
+}
+
+func (s *ChiStatus) GetActions() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.Actions
+	})
+}
+
+func (s *ChiStatus) GetError() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.Error
+	})
+}
+
+func (s *ChiStatus) GetErrors() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.Errors
+	})
+}
+
+func (s *ChiStatus) GetHostsUpdatedCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsUpdatedCount
+	})
+}
+
+func (s *ChiStatus) GetHostsAddedCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsAddedCount
+	})
+}
+
+func (s *ChiStatus) GetHostsUnchangedCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsUnchangedCount
+	})
+}
+
+func (s *ChiStatus) GetHostsFailedCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsFailedCount
+	})
+}
+
+func (s *ChiStatus) GetHostsCompletedCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsCompletedCount
+	})
+}
+
+func (s *ChiStatus) GetHostsDeletedCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsDeletedCount
+	})
+}
+
+func (s *ChiStatus) GetHostsDeleteCount() int {
+	return getIntWithReadLock(s, func(s *ChiStatus) int {
+		return s.HostsDeleteCount
+	})
+}
+
+func (s *ChiStatus) GetPods() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.Pods
+	})
+}
+
+func (s *ChiStatus) GetPodIPs() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.PodIPs
+	})
+}
+
+func (s *ChiStatus) GetFQDNs() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.FQDNs
+	})
+}
+
+func (s *ChiStatus) GetEndpoint() string {
+	return getStringWithReadLock(s, func(s *ChiStatus) string {
+		return s.Endpoint
+	})
+}
+
+func (s *ChiStatus) GetNormalizedCHI() *ClickHouseInstallation {
+	return getInstallationWithReadLock(s, func(s *ChiStatus) *ClickHouseInstallation {
+		return s.NormalizedCHI
+	})
+}
+
+func (s *ChiStatus) GetNormalizedCHICompleted() *ClickHouseInstallation {
+	return getInstallationWithReadLock(s, func(s *ChiStatus) *ClickHouseInstallation {
+		return s.NormalizedCHICompleted
+	})
+}
+
+func (s *ChiStatus) GetHostsWithTablesCreated() []string {
+	return getStringArrWithReadLock(s, func(s *ChiStatus) []string {
+		return s.HostsWithTablesCreated
+	})
+}
+
+// Begin helpers
+
+func doWithWriteLock(s *ChiStatus, f func(s *ChiStatus)) {
 	if s == nil {
 		return
 	}
-	s.HostsFailedCount++
-	s.HostsCompletedCount++
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	f(s)
+}
+
+func doWithReadLock(s *ChiStatus, f func(s *ChiStatus)) {
+	if s == nil {
+		return
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	f(s)
+}
+
+func getIntWithReadLock(s *ChiStatus, f func(s *ChiStatus) int) int {
+	var zeroVal int
+	if s == nil {
+		return zeroVal
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return f(s)
+}
+
+func getStringWithReadLock(s *ChiStatus, f func(s *ChiStatus) string) string {
+	var zeroVal string
+	if s == nil {
+		return zeroVal
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return f(s)
+}
+
+func getInstallationWithReadLock(s *ChiStatus, f func(s *ChiStatus) *ClickHouseInstallation) *ClickHouseInstallation {
+	var zeroVal *ClickHouseInstallation
+	if s == nil {
+		return zeroVal
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return f(s)
+}
+
+func getStringArrWithReadLock(s *ChiStatus, f func(s *ChiStatus) []string) []string {
+	emptyArr := make([]string, 0, 0)
+	if s == nil {
+		return emptyArr
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return f(s)
+}
+
+// mergeActionsNoSync merges the actions of from into those of s (without synchronization, because synchronized
+// functions call into this).
+func mergeActionsNoSync(s *ChiStatus, from *ChiStatus) {
+	s.Actions = util.MergeStringArrays(s.Actions, from.Actions)
+	sort.Sort(sort.Reverse(sort.StringSlice(s.Actions)))
+	trimActionsNoSync(s)
+}
+
+// trimActionsNoSync trims actions (without synchronization, because synchronized functions call into this).
+func trimActionsNoSync(s *ChiStatus) {
+	if len(s.Actions) > maxActions {
+		s.Actions = s.Actions[:maxActions]
+	}
+}
+
+// pushTaskIDStartedNoSync pushes task id into status
+func pushTaskIDStartedNoSync(s *ChiStatus) {
+	s.TaskIDsStarted = append([]string{s.TaskID}, s.TaskIDsStarted...)
+	if len(s.TaskIDsStarted) > maxTaskIDs {
+		s.TaskIDsStarted = s.TaskIDsStarted[:maxTaskIDs]
+	}
+}
+
+// PushTaskIDCompleted pushes task id into status
+func pushTaskIDCompletedNoSync(s *ChiStatus) {
+	s.TaskIDsCompleted = append([]string{s.TaskID}, s.TaskIDsCompleted...)
+	if len(s.TaskIDsCompleted) > maxTaskIDs {
+		s.TaskIDsCompleted = s.TaskIDsCompleted[:maxTaskIDs]
+	}
 }

--- a/pkg/apis/clickhouse.altinity.com/v1/type_status_test.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_status_test.go
@@ -1,0 +1,248 @@
+// //go:build race
+package v1
+
+import (
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+)
+
+var normalizedChiA = &ClickHouseInstallation{}
+var fillParamsA = &FillStatusParams{
+	CHOpIP:              "1.2.3.4",
+	ClustersCount:       1,
+	ShardsCount:         2,
+	HostsCount:          3,
+	TaskID:              "task-a",
+	HostsUpdatedCount:   4,
+	HostsAddedCount:     5,
+	HostsCompletedCount: 6,
+	HostsDeleteCount:    7,
+	HostsDeletedCount:   8,
+	Pods:                []string{"pod-a-1", "pod-a-2"},
+	FQDNs:               []string{"fqdns-a-1", "fqdns-a-2"},
+	Endpoint:            "endpoint-a",
+	NormalizedCHI:       normalizedChiA, // fields not recursively checked, this is only used as a pointer
+}
+
+var normalizedChiB = &ClickHouseInstallation{}
+var fillParamsB = &FillStatusParams{
+	CHOpIP:              "5.6.7.8",
+	ClustersCount:       10,
+	ShardsCount:         20,
+	HostsCount:          30,
+	TaskID:              "task-b",
+	HostsUpdatedCount:   40,
+	HostsAddedCount:     50,
+	HostsCompletedCount: 60,
+	HostsDeleteCount:    70,
+	HostsDeletedCount:   80,
+	Pods:                []string{"pod-b-1", "pod-b-2"},
+	FQDNs:               []string{"fqdns-b-1", "fqdns-b-2"},
+	Endpoint:            "endpoint-b",
+	NormalizedCHI:       normalizedChiB, // fields not recursively checked, this is only used as a pointer
+}
+
+var copyTestStatusFrom = &ChiStatus{
+	CHOpVersion:            "version-a",
+	CHOpCommit:             "commit-a",
+	CHOpDate:               "date-a",
+	CHOpIP:                 "ip-a",
+	ClustersCount:          1,
+	ShardsCount:            2,
+	ReplicasCount:          3,
+	HostsCount:             4,
+	Status:                 "status-a",
+	TaskID:                 "task-a",
+	TaskIDsStarted:         []string{"task-a-started-1", "task-a-started-2"},
+	TaskIDsCompleted:       []string{"task-a-completed-1", "task-a-completed-2"},
+	Action:                 "action-a",
+	Actions:                []string{"action-a", "action-a-another"},
+	Error:                  "error-a",
+	Errors:                 []string{"error-a", "error-a-another"},
+	HostsUpdatedCount:      5,
+	HostsAddedCount:        6,
+	HostsUnchangedCount:    7,
+	HostsFailedCount:       8,
+	HostsCompletedCount:    9,
+	HostsDeletedCount:      10,
+	HostsDeleteCount:       11,
+	Pods:                   []string{"pod-a-1", "pod-a-2"},
+	PodIPs:                 []string{"podIP-a-1", "podIP-a-2"},
+	FQDNs:                  []string{"fqdns-a-1", "fqdns-a-2"},
+	Endpoint:               "endpt-a",
+	NormalizedCHI:          normalizedChiA,
+	NormalizedCHICompleted: normalizedChiA,
+	HostsWithTablesCreated: []string{"host-a-1", "host-a-2"},
+}
+
+// NB: These tests mostly exist to exercise synchronization and detect regressions related to them via the
+// Golang race detector. See: https://go.dev/blog/race-detector
+// In short, add -race to the go test flags when running this.
+func Test_ChiStatus_BasicOperations_SingleStatus_ConcurrencyTest(t *testing.T) {
+	type testCase struct {
+		name                       string
+		goRoutineA                 func(s *ChiStatus)
+		goRoutineB                 func(s *ChiStatus)
+		postConditionsVerification func(tt *testing.T, s *ChiStatus)
+	}
+	for _, tc := range []testCase{
+		{
+			name: "PushAction",
+			goRoutineA: func(s *ChiStatus) {
+				s.PushAction("foo")
+			},
+			goRoutineB: func(s *ChiStatus) {
+				s.PushAction("bar")
+			},
+			postConditionsVerification: func(tt *testing.T, s *ChiStatus) {
+				actual := s.GetActions()
+				require.Len(tt, actual, 2)
+				require.Contains(tt, actual, "foo")
+				require.Contains(tt, actual, "bar")
+			},
+		},
+		{
+			name: "PushError",
+			goRoutineA: func(s *ChiStatus) {
+				s.PushError("errA")
+				s.PushError("errB")
+			},
+			goRoutineB: func(s *ChiStatus) {
+				s.PushError("errC")
+			},
+			postConditionsVerification: func(tt *testing.T, s *ChiStatus) {
+				actual := s.GetErrors()
+				require.Len(t, actual, 3)
+				require.Contains(tt, actual, "errA")
+				require.Contains(tt, actual, "errB")
+				require.Contains(tt, actual, "errC")
+			},
+		},
+		{
+			name: "Fill",
+			goRoutineA: func(s *ChiStatus) {
+				s.Fill(fillParamsA)
+			},
+			goRoutineB: func(s *ChiStatus) {
+				s.Fill(fillParamsB)
+			},
+			postConditionsVerification: func(tt *testing.T, s *ChiStatus) {
+				// Fill performs hard updates (overwrites), not pushing/adding extra data.
+				// The winning goroutine should basically determine the resultant post-condition for every "filled" field.
+				var expectedParams *FillStatusParams
+				if s.CHOpIP == fillParamsA.CHOpIP {
+					expectedParams = fillParamsA
+				} else if s.CHOpIP == fillParamsB.CHOpIP {
+					expectedParams = fillParamsB
+				} else {
+					require.Fail(t, "Unexpected CHOpIP after FillStatus: %s", s.CHOpIP)
+				}
+				require.Equal(tt, expectedParams.CHOpIP, s.CHOpIP)
+				require.Equal(tt, expectedParams.ClustersCount, s.ClustersCount)
+				require.Equal(tt, expectedParams.ShardsCount, s.ShardsCount)
+				require.Equal(tt, expectedParams.HostsCount, s.HostsCount)
+				require.Equal(tt, expectedParams.TaskID, s.TaskID)
+				require.Equal(tt, expectedParams.HostsUpdatedCount, s.HostsUpdatedCount)
+				require.Equal(tt, expectedParams.HostsAddedCount, s.HostsAddedCount)
+				require.Equal(tt, expectedParams.HostsCompletedCount, s.HostsCompletedCount)
+				require.Equal(tt, expectedParams.HostsDeleteCount, s.HostsDeleteCount)
+				require.Equal(tt, expectedParams.HostsDeletedCount, s.HostsDeletedCount)
+				require.Equal(tt, expectedParams.Pods, s.Pods)
+				require.Equal(tt, expectedParams.FQDNs, s.FQDNs)
+				require.Equal(tt, expectedParams.Endpoint, s.Endpoint)
+				require.Equal(tt, expectedParams.NormalizedCHI, s.NormalizedCHI)
+			},
+		},
+		{
+			name: "CopyFrom",
+			goRoutineA: func(s *ChiStatus) {
+				s.PushAction("always-present-action") // CopyFrom preserves existing actions (does not clobber)
+				s.CopyFrom(copyTestStatusFrom, CopyCHIStatusOptions{
+					Actions:           true,
+					Errors:            true,
+					MainFields:        true,
+					WholeStatus:       true,
+					InheritableFields: true,
+				})
+			},
+			goRoutineB: func(s *ChiStatus) {
+				s.PushAction("additional-action") // this may or may not win the race, but the race will be sync
+			},
+			postConditionsVerification: func(tt *testing.T, s *ChiStatus) {
+				if len(s.GetActions()) == len(copyTestStatusFrom.GetActions())+2 {
+					require.Equal(tt, copyTestStatusFrom.GetActions(), s.GetActions())
+					require.Contains(tt, s.GetActions(), "always-present-action")
+					require.Contains(tt, s.GetActions(), "additional-action")
+					for _, action := range copyTestStatusFrom.GetActions() {
+						require.Contains(tt, s.GetActions(), action)
+					}
+				} else {
+					require.Equal(tt, len(copyTestStatusFrom.GetActions())+1, len(s.GetActions()))
+					require.Contains(tt, s.GetActions(), "additional-action")
+					for _, action := range copyTestStatusFrom.GetActions() {
+						require.Contains(tt, s.GetActions(), action)
+					}
+				}
+				require.Equal(tt, copyTestStatusFrom.GetAction(), s.GetAction())
+				require.Equal(tt, copyTestStatusFrom.GetCHOpCommit(), s.GetCHOpCommit())
+				require.Equal(tt, copyTestStatusFrom.GetCHOpDate(), s.GetCHOpDate())
+				require.Equal(tt, copyTestStatusFrom.GetCHOpIP(), s.GetCHOpIP())
+				require.Equal(tt, copyTestStatusFrom.GetCHOpVersion(), s.GetCHOpVersion())
+				require.Equal(tt, copyTestStatusFrom.GetClustersCount(), s.GetClustersCount())
+				require.Equal(tt, copyTestStatusFrom.GetEndpoint(), s.GetEndpoint())
+				require.Equal(tt, copyTestStatusFrom.GetError(), s.GetError())
+				require.Equal(tt, copyTestStatusFrom.GetErrors(), s.GetErrors())
+				require.Equal(tt, copyTestStatusFrom.GetErrors(), s.GetErrors())
+				require.Equal(tt, copyTestStatusFrom.GetFQDNs(), s.GetFQDNs())
+				require.Equal(tt, copyTestStatusFrom.GetHostsAddedCount(), s.GetHostsAddedCount())
+				require.Equal(tt, copyTestStatusFrom.GetHostsCompletedCount(), s.GetHostsCompletedCount())
+				require.Equal(tt, copyTestStatusFrom.GetHostsCount(), s.GetHostsCount())
+				require.Equal(tt, copyTestStatusFrom.GetHostsDeleteCount(), s.GetHostsDeleteCount())
+				require.Equal(tt, copyTestStatusFrom.GetHostsDeletedCount(), s.GetHostsDeletedCount())
+				require.Equal(tt, copyTestStatusFrom.GetHostsUpdatedCount(), s.GetHostsUpdatedCount())
+				require.Equal(tt, copyTestStatusFrom.GetHostsWithTablesCreated(), s.GetHostsWithTablesCreated())
+				require.Equal(tt, copyTestStatusFrom.GetHostsWithTablesCreated(), s.GetHostsWithTablesCreated())
+				require.Equal(tt, copyTestStatusFrom.GetHostsWithTablesCreated(), s.GetHostsWithTablesCreated())
+				require.Equal(tt, copyTestStatusFrom.GetNormalizedCHI(), s.GetNormalizedCHI())
+				require.Equal(tt, copyTestStatusFrom.GetNormalizedCHICompleted(), s.GetNormalizedCHICompleted())
+				require.Equal(tt, copyTestStatusFrom.GetPodIPs(), s.GetPodIPs())
+				require.Equal(tt, copyTestStatusFrom.GetPods(), s.GetPods())
+				require.Equal(tt, copyTestStatusFrom.GetReplicasCount(), s.GetReplicasCount())
+				require.Equal(tt, copyTestStatusFrom.GetShardsCount(), s.GetShardsCount())
+				require.Equal(tt, copyTestStatusFrom.GetStatus(), s.GetStatus())
+				require.Equal(tt, copyTestStatusFrom.GetTaskID(), s.GetTaskID())
+				require.Equal(tt, copyTestStatusFrom.GetTaskIDsCompleted(), s.GetTaskIDsCompleted())
+				require.Equal(tt, copyTestStatusFrom.GetTaskIDsStarted(), s.GetTaskIDsStarted())
+			},
+		},
+	} {
+		t.Run(tc.name, func(tt *testing.T) {
+			status := &ChiStatus{}
+			startWg := sync.WaitGroup{}
+			doneWg := sync.WaitGroup{}
+			startWg.Add(2) // We will make sure both goroutines begin execution, i.e., that they don't execute sequentially.
+			doneWg.Add(2)  // We also need to synchronize the test over the completion of both.
+
+			go func() {
+				startWg.Done()
+				startWg.Wait() // Block until the other goroutine has begun execution
+				tc.goRoutineA(status)
+				doneWg.Done()
+			}()
+
+			go func() {
+				startWg.Done()
+				startWg.Wait() // Block until the other goroutine has begun execution
+
+				tc.goRoutineB(status)
+				doneWg.Done()
+			}()
+
+			doneWg.Wait() // Block until both goroutines have completed execution
+
+			// Verify post-conditions
+			tc.postConditionsVerification(tt, status)
+		})
+	}
+}

--- a/pkg/apis/clickhouse.altinity.com/v1/types.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/types.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -42,6 +43,8 @@ type ClickHouseInstallation struct {
 	Status            *ChiStatus `json:"status,omitempty"   yaml:"status,omitempty"`
 
 	Attributes ComparableAttributes `json:"-" yaml:"-"`
+
+	statusMu sync.Mutex
 }
 
 // ComparableAttributes specifies CHI attributes that are comparable

--- a/pkg/controller/chi/announcer.go
+++ b/pkg/controller/chi/announcer.go
@@ -282,9 +282,9 @@ func (a Announcer) writeCHIStatus(format string, args ...interface{}) {
 
 	if a.writeStatusAction {
 		if len(args) > 0 {
-			a.chi.EnsureStatus().Action = fmt.Sprintf(format, args...)
+			a.chi.EnsureStatus().SetAction(fmt.Sprintf(format, args...))
 		} else {
-			a.chi.EnsureStatus().Action = fmt.Sprint(format)
+			a.chi.EnsureStatus().SetAction(fmt.Sprint(format))
 		}
 	}
 	if a.writeStatusActions {
@@ -296,10 +296,11 @@ func (a Announcer) writeCHIStatus(format string, args ...interface{}) {
 	}
 	if a.writeStatusError {
 		if len(args) > 0 {
-			a.chi.EnsureStatus().Error = fmt.Sprintf(format, args...)
+			// PR review question: should we prefix the string in the SetError call? If so, we can SetAndPushError.
+			a.chi.EnsureStatus().SetError(fmt.Sprintf(format, args...))
 			a.chi.EnsureStatus().PushError(prefix + fmt.Sprintf(format, args...))
 		} else {
-			a.chi.EnsureStatus().Error = fmt.Sprint(format)
+			a.chi.EnsureStatus().SetError(fmt.Sprint(format))
 			a.chi.EnsureStatus().PushError(prefix + fmt.Sprint(format))
 		}
 	}

--- a/pkg/controller/chi/controller.go
+++ b/pkg/controller/chi/controller.go
@@ -800,7 +800,7 @@ func (c *Controller) doUpdateCHIObjectStatus(ctx context.Context, chi *chiV1.Cli
 
 	// Update status of a real object.
 	cur.EnsureStatus().CopyFrom(chi.Status, opts.CopyCHIStatusOptions)
-	cur.EnsureStatus().PodIPs = podIPs
+	cur.EnsureStatus().SetPodIPs(podIPs)
 
 	_new, err := c.chopClient.ClickhouseV1().ClickHouseInstallations(chi.Namespace).UpdateStatus(ctx, cur, newUpdateOptions())
 	if err != nil {

--- a/pkg/controller/chi/worker-deleter.go
+++ b/pkg/controller/chi/worker-deleter.go
@@ -445,7 +445,7 @@ func (w *worker) deleteHost(ctx context.Context, chi *chiV1.ClickHouseInstallati
 	err = w.c.deleteHost(ctx, host)
 
 	// When deleting the whole CHI (not particular host), CHI may already be unavailable, so update CHI tolerantly
-	chi.EnsureStatus().HostsDeletedCount++
+	chi.EnsureStatus().HostDeleted()
 	_ = w.c.updateCHIObjectStatus(ctx, chi, UpdateCHIStatusOptions{
 		TolerateAbsence: true,
 		CopyCHIStatusOptions: chiV1.CopyCHIStatusOptions{

--- a/pkg/controller/chi/worker-reconciler.go
+++ b/pkg/controller/chi/worker-reconciler.go
@@ -467,8 +467,8 @@ func (w *worker) reconcileHost(ctx context.Context, host *chiV1.ChiHost) error {
 	)
 
 	if host.CHI != nil && host.CHI.Status != nil {
-		hostsCompleted = host.CHI.Status.HostsCompletedCount
-		hostsCount = host.CHI.Status.HostsCount
+		hostsCompleted = host.CHI.Status.GetHostsCompletedCount()
+		hostsCount = host.CHI.Status.GetHostsCount()
 	}
 
 	w.a.V(1).

--- a/pkg/controller/chi/worker.go
+++ b/pkg/controller/chi/worker.go
@@ -508,7 +508,7 @@ func (w *worker) waitForIPAddresses(ctx context.Context, chi *chiV1.ClickHouseIn
 	}
 	start := time.Now()
 	w.c.poll(ctx, chi, func(c *chiV1.ClickHouseInstallation, e error) bool {
-		if len(c.Status.GetPodIPS()) >= len(c.Status.GetPods()) {
+		if len(c.Status.GetPodIPs()) >= len(c.Status.GetPods()) {
 			// Stop polling
 			w.a.V(1).M(c).Info("all IP addresses are in place")
 			return false
@@ -786,7 +786,7 @@ func (w *worker) shouldMigrateTables(host *chiV1.ChiHost) bool {
 		// Stopped host is not able to receive any data
 		return false
 
-	case util.InArray(chopModel.CreateFQDN(host), host.GetCHI().EnsureStatus().HostsWithTablesCreated):
+	case util.InArray(chopModel.CreateFQDN(host), host.GetCHI().EnsureStatus().GetHostsWithTablesCreated()):
 		// This host is listed as having tables created already
 		return false
 


### PR DESCRIPTION
Background: https://github.com/Altinity/clickhouse-operator/issues/1109
Related PR(s):
* #1115
* #1124

This PR adds `sync.RWMutex` based synchronization over the mutable state of `ChiStatus`. It should be relatively straightforward. (Also, around the initialization of `ClickHouseInstallation`'s own status field via `EnsureStatus`).

The most eyebrow raising bits are probably in the sequenced lock acquisition in `MergeActions` and `CopyFrom` creating some risk of deadlocking (to be discussed, I'm sure). The only other potentially "hairy" concern is some of the generated code I've found for `DeepCopy` helpers on all types. 

Meta: I began this by trying to define a mediator through which all updates would be made. However, the presence of logic inside some of the other raw types inside of the `v1` package (such as the `ClickHouseInstallation` AKA chi) made it apparent to me that it's not that much cleaner to separate the two. My workaround to this was to at least make sure that all field level read and write accesses to the `ChiStatus` struct were strictly within its single source file (`type_status`) – with the exception of the deepcopy generated files (which don't seem to be used directly AFAIK, and hopefully aren't used at runtime from potentially competing goroutines).

Note: I'll squash all commits from feedback pre-merge.

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [X] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [X] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)
