### PR TITLE
Fix nil pointer deref in metrics exporter (#1187) 

### DIFF
--- a/pkg/apis/metrics/exporter.go
+++ b/pkg/apis/metrics/exporter.go
@@ -292,7 +292,7 @@ func (e *Exporter) DiscoveryWatchedCHIs(kubeClient kube.Interface, chopClient *c
 			log.V(1).Infof("Skip stopped CHI %s/%s\n", chi.Namespace, chi.Name)
 		} else {
 			log.V(1).Infof("Add explicitly found CHI %s/%s", chi.Namespace, chi.Name)
-			if chi.Status.NormalizedCHICompleted == nil {
+			if !chi.EnsureStatus().GetNormalizedCHICompleted() {
 				log.V(1).Infof("Explicitly found CHI %s/%s is not completed yet, skip it\n", chi.Namespace, chi.Name)
 			} else {
 				log.V(1).Infof("Explicitly found CHI %s/%s is completed, adding it\n", chi.Namespace, chi.Name)


### PR DESCRIPTION
This is a very targeted fix for the NPE shown in #1187 since it's a known problem. The general pattern of guarding status lookups may be worth thinking about. Maybe we just need an intermediate type that decouples the application level usage of this state from its serialization/deserialization, at which point we can use basic language features like field visibility to reduce the probability of future unsafe accesses. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [ ] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [ ] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [ ] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)

