### PR TITLE
Fix syntax issue introduced in #1188 NPE bugfix

### DIFF
--- a/pkg/apis/metrics/exporter.go
+++ b/pkg/apis/metrics/exporter.go
@@ -295,7 +295,7 @@ func (e *Exporter) DiscoveryWatchedCHIs(kubeClient kube.Interface, chopClient *c
 			continue
 		}
 
-		if !chi.GetStatus().HasNormalizedCHICompleted() {
+		if !chi.EnsureStatus().HasNormalizedCHICompleted() {
 			log.V(1).Infof("CHI %s/%s is not completed yet, skip it\n", chi.Namespace, chi.Name)
 			continue
 		}


### PR DESCRIPTION
While manually writing the fix in #1188 using a text editor, I misread the return type of the `GetNormalizedCHICompleted` function as returning a bool rather than a pointer to a CHI. That broke the build of `0.21.3` once #1188 was merged.

Now, this looks more similar to the original state of the code (just using getters instead of direct field access):
https://github.com/Altinity/clickhouse-operator/pull/1188/files#diff-6dd1bf383889aa0b3dde98cf3579859d84b90dd638c4829390596f9237e62f65L295

cc @sunsingerus 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)
