### PR TITLE
Fix maxAllowedWorkers math in concurrent reconcile (#1109)

### DIFF
--- a/pkg/controller/chi/worker-chi-reconciler.go
+++ b/pkg/controller/chi/worker-chi-reconciler.go
@@ -381,7 +381,7 @@ func (w *worker) getReconcileShardsWorkersNum(shards []*chiV1.ChiShard) int {
 	maxPct := float64(chop.Config().Reconcile.Runtime.ReconcileShardsMaxConcurrencyPercent)
 
 	// Always return at least 1, up to maxAvailable, but never exceeding maxSafe
-	maxAllowedWorkers := math.Max(math.Floor(maxPct/100.0)*float64(len(shards)), 1)
+	maxAllowedWorkers := math.Max(math.Floor(maxPct/100.0*float64(len(shards))), 1)
 	return int(math.Min(maxAvailableWorkers, maxAllowedWorkers))
 }
 


### PR DESCRIPTION
(Follow-on to #1109)

I made a very basic mistake in the math behind concurrent reconciliation. It has been effectively limited to either 100% or sequential. After this bag, values like 80%, 50%, etc will actually work as expected. My fault for doing most validation work with maximum concurrency level (100% of shards).

I'm staging this PR now before I forget, but I'm happy to add some unit tests for this function if we'd like to avoid a regression here.

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [ ] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)