### PR TITLE
Fix ServiceMonitor for Clickhouse Metrics

### DIFF
--- a/deploy/helm/templates/servicemonitor.yaml
+++ b/deploy/helm/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "altinity-clickhouse-operator.fullname" . }}
+  name: {{ printf "%s-clickhouse-metrics" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: clickhouse-operator-metrics
+    - port: clickhouse-metrics
   selector:
     matchLabels:
       {{- include "altinity-clickhouse-operator.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [ ] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [ ] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [ ] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.

---

After I upgraded to `v0.22.0` I saw that my metrics where missing and then I found out that the ServiceMonitor was scraping the old port name, this PR fixes it. Thanks!