### PR TITLE
ADD the user migration function when clickhouse expanding capacity.

### DIFF
--- a/pkg/controller/chi/exec.go
+++ b/pkg/controller/chi/exec.go
@@ -1,0 +1,71 @@
+package chi
+
+import (
+	"fmt"
+	log "github.com/altinity/clickhouse-operator/pkg/announcer"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+func NewShellCommandWrapper(c string) *ShellCommandWrapper {
+	cmd := exec.Command("/bin/bash", "-c", c)
+	return &ShellCommandWrapper{Cmd: cmd}
+}
+
+type ShellCommandWrapper struct {
+	*exec.Cmd
+}
+
+func (c *ShellCommandWrapper) print(s string, level int, depth int) {
+	_, file, line, ok := runtime.Caller(depth)
+	prefix := "???]"
+	if ok {
+		prefix = fmt.Sprintf("%s:%d]", filepath.Base(file), line)
+	}
+	log.V(1).Info("%s %s", prefix, s)
+}
+
+func (c *ShellCommandWrapper) Run() error {
+	c.print(c.String(), 2, 3)
+	return c.Cmd.Run()
+}
+
+func (c *ShellCommandWrapper) CombinedOutput() (string, error) {
+	c.print(c.String(), 4, 3)
+	o, err := c.Cmd.CombinedOutput()
+	outputString := string(o)
+	if err != nil {
+		return outputString, err
+	}
+	return outputString, nil
+}
+
+func Shell(envs map[string]string, stdout io.Writer, c string, a ...interface{}) (string, error) {
+	if len(a) > 0 {
+		c = fmt.Sprintf(c, a...)
+	}
+	cmd := NewShellCommandWrapper(c)
+	for key, value := range envs {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
+	if stdout == nil {
+		return cmd.CombinedOutput()
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = os.Stderr
+	return "", cmd.Run()
+}
+
+func SyncUsers(namespace, srcPodName, dstPodName, containerName, dirPath string) error {
+	baseArgs := fmt.Sprintf("-n %s -c %s", namespace, containerName)
+	command := fmt.Sprintf("/kubectl exec %s %s  -- tar cf - %s /tmp/ | /kubectl exec %s -i %s -- tar xvf - -C /", baseArgs, srcPodName, dirPath, baseArgs, dstPodName)
+	out, err := Shell(nil, nil, command)
+	if err != nil {
+		return err
+	}
+	log.V(1).Info(out)
+	return nil
+}

--- a/pkg/controller/chi/worker-chi-reconciler.go
+++ b/pkg/controller/chi/worker-chi-reconciler.go
@@ -668,6 +668,8 @@ func (w *worker) reconcileHost(ctx context.Context, host *chiV1.ChiHost) error {
 	// time.Sleep(30 * time.Second)
 	_ = w.migrateTables(ctx, host, migrateTableOpts)
 
+	_ = w.migrateUsers(ctx, host)
+
 	if err := w.includeHost(ctx, host); err != nil {
 		metricsHostReconcilesErrors(ctx)
 		w.a.V(1).


### PR DESCRIPTION
The function of synchronizing user information from the original host to the new host when clickhouse is added. First, it is judged whether the current host is working and whether it is added. Start user synchronization operation for new host. Select a working host from the original cluster, which is different from the current host, and name it select host. Compare the user information in the current host and the select host, and if they are different, perform user synchronization operation, and copy the /var/lib/clickhouse/access directory from the select host to the current host. Then execute the reload user information command “system reload users” in clickhouse-client to synchronize user information.
