### PR TITLE
Add user synchronization

### DIFF
--- a/pkg/controller/chi/exec.go
+++ b/pkg/controller/chi/exec.go
@@ -1,0 +1,68 @@
+package chi
+
+import (
+	"fmt"
+	log "github.com/altinity/clickhouse-operator/pkg/announcer"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+func NewShellCommandWrapper(c string) *ShellCommandWrapper {
+	cmd := exec.Command("/bin/bash", "-c", c)
+	return &ShellCommandWrapper{Cmd: cmd}
+}
+
+type ShellCommandWrapper struct {
+	*exec.Cmd
+}
+
+func (c *ShellCommandWrapper) print(s string, level int, depth int) {
+	_, file, line, ok := runtime.Caller(depth)
+	prefix := "???]"
+	if ok {
+		prefix = fmt.Sprintf("%s:%d]", filepath.Base(file), line)
+	}
+	log.V(1).Info("%s %s", prefix, s)
+}
+
+func (c *ShellCommandWrapper) CombinedOutput() (string, error) {
+	c.print(c.String(), 4, 3)
+	o, err := c.Cmd.CombinedOutput()
+	outputString := string(o)
+	if err != nil {
+		return outputString, err
+	}
+	return outputString, nil
+}
+
+func Shell(envs map[string]string, stdout io.Writer, c string, a ...interface{}) (string, error) {
+	if len(a) > 0 {
+		c = fmt.Sprintf(c, a...)
+	}
+	cmd := NewShellCommandWrapper(c)
+	for key, value := range envs {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
+	if stdout == nil {
+		return cmd.CombinedOutput()
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = os.Stderr
+	return "", cmd.Run()
+}
+
+func SyncUsers(namespace, srcPodName, dstPodName, containerName, dirPath string) error {
+	baseArgs := fmt.Sprintf("-n %s -c %s", namespace, containerName)
+	command := fmt.Sprintf("/kubectl exec %s %s  -- tar cf - %s /tmp/ | /kubectl exec %s -i %s -- tar xvf - -C /", baseArgs, srcPodName, dirPath, baseArgs, dstPodName)
+	out, err := Shell(nil, nil, command)
+	if err != nil {
+		return err
+	}
+	log.V(1).Info(out)
+	// restart clickhouse
+	_, _ = Shell(nil, nil, fmt.Sprintf("/kubectl exec %s %s -- clickhouse restart &", baseArgs, dstPodName))
+	return nil
+}

--- a/pkg/controller/chi/worker-chi-reconciler.go
+++ b/pkg/controller/chi/worker-chi-reconciler.go
@@ -708,6 +708,8 @@ func (w *worker) reconcileHost(ctx context.Context, host *api.ChiHost) error {
 	}
 	_ = w.migrateTables(ctx, host, migrateTableOpts)
 
+	_ = w.migrateUsers(ctx, host)
+
 	if err := w.includeHost(ctx, host); err != nil {
 		metricsHostReconcilesErrors(ctx)
 		w.a.V(1).

--- a/pkg/controller/chi/worker.go
+++ b/pkg/controller/chi/worker.go
@@ -887,6 +887,112 @@ func (a migrateTableOptionsArr) First() *migrateTableOptions {
 	return nil
 }
 
+// migrateUsers
+func (w *worker) migrateUsers(ctx context.Context, host *api.ChiHost) error {
+	if util.IsContextDone(ctx) {
+		log.V(2).Info("ctx is done")
+		return nil
+	}
+	if !w.shouldMigrateUsers(host) {
+		w.a.V(1).
+			M(host).F().
+			Info("No need to add users on host %d to shard %d in cluster %s", host.Address.ReplicaIndex, host.Address.ShardIndex, host.Address.ClusterName)
+		return nil
+	}
+	// Need to migrate users
+	w.a.V(1).
+		WithEvent(host.GetCHI(), eventActionCreate, eventReasonCreateStarted).
+		WithStatusAction(host.GetCHI()).
+		M(host).F().
+		Info("Adding users on shard/host:%d/%d cluster:%s", host.Address.ShardIndex, host.Address.ReplicaIndex, host.Address.ClusterName)
+	err := w.syncUsers(ctx, host)
+
+	if err != nil {
+		w.a.M(host).F().Error("ERROR sync User on host %s. err: %v", host.Name, err)
+	}
+	_ = w.c.waitHostReady(ctx, host)
+	return err
+}
+
+func (w *worker) shouldMigrateUsers(host *api.ChiHost) bool {
+	switch {
+	case host.GetCHI().IsStopped():
+		// Stopped host is not able to receive data
+		return false
+	case host.GetReconcileAttributes().GetStatus() == api.ObjectStatusSame:
+		// No need to migrate on the same host
+		return false
+	}
+
+	return true
+}
+
+func (w *worker) syncUsers(ctx context.Context, host *api.ChiHost) error {
+	if util.IsContextDone(ctx) {
+		log.V(2).Info("ctx is done")
+		return nil
+	}
+	needSync, selectHost := w.needSyncUsers(ctx, host)
+	if needSync {
+		srcSts, _ := w.c.getStatefulSet(selectHost)
+		dstSts, _ := w.c.getStatefulSet(host)
+
+		namespace := host.CHI.Namespace
+		// find the first hosts， and get the default path
+		path, err := w.schemer.HostDefaultDisk(ctx, selectHost)
+		err = SyncUsers(namespace, srcSts.Name+"-0", dstSts.Name+"-0", "clickhouse", path+"access")
+		if err != nil {
+			return err
+		}
+	}
+	log.V(1).Info("need not sync users")
+	return nil
+}
+
+func (w *worker) needSyncUsers(ctx context.Context, host *api.ChiHost) (bool, *api.ChiHost) {
+	selectedHost := w.getSelectedHost(host)
+	if selectedHost.Name == host.Name {
+		return false, selectedHost
+	}
+	selectUsers, err := w.schemer.HostGetUsers(ctx, selectedHost)
+	log.V(1).Info("host %s selectUsers is %v", selectedHost.Name, selectUsers)
+	if err != nil {
+		w.a.M(host).F().Error("ERROR HostGetUser on host %s. err: %v", selectedHost.Name, err)
+	}
+	// 如果 当前shard 只有一个host， 则从其他的shard 进行查询并判断
+	users, err := w.schemer.HostGetUsers(ctx, host)
+	log.V(1).Info("host %s users is %v", host.Name, selectUsers)
+	if err != nil {
+		w.a.M(host).F().Error("ERROR HostGetUser on host %s. err: %v", host.Name, err)
+	}
+	if len(selectUsers) == len(users) {
+		return false, selectedHost
+	}
+	return true, selectedHost
+}
+
+func (w *worker) getSelectedHost(host *api.ChiHost) *api.ChiHost {
+	for clusterIndex := range host.GetCHI().Spec.Configuration.Clusters {
+		cluster := host.GetCHI().Spec.Configuration.Clusters[clusterIndex]
+		for shardIndex := range cluster.Layout.Shards {
+			shard := &cluster.Layout.Shards[shardIndex]
+			for replicaIndex := range shard.Hosts {
+				curHost := shard.Hosts[replicaIndex]
+				if curHost.Name != host.Name {
+					curSts, err := w.c.getStatefulSet(curHost)
+					if err != nil {
+						continue
+					}
+					if curSts.Status.Replicas == curSts.Status.ReadyReplicas {
+						return curHost
+					}
+				}
+			}
+		}
+	}
+	return host
+}
+
 // migrateTables
 func (w *worker) migrateTables(ctx context.Context, host *api.ChiHost, opts ...*migrateTableOptions) error {
 	if util.IsContextDone(ctx) {

--- a/pkg/model/chi/cluster_schemer.go
+++ b/pkg/model/chi/cluster_schemer.go
@@ -17,6 +17,7 @@ package chi
 import (
 	"context"
 	"fmt"
+	r "github.com/altinity/clickhouse-operator/pkg/util/retry"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -300,6 +301,72 @@ func (s *ClusterSchemer) CHIDropDnsCache(ctx context.Context, chi *api.ClickHous
 func (s *ClusterSchemer) HostActiveQueriesNum(ctx context.Context, host *api.ChiHost) (int, error) {
 	sql := `SELECT count() FROM system.processes`
 	return s.QueryHostInt(ctx, host, sql)
+}
+
+func (s *ClusterSchemer) HostDefaultDisk(ctx context.Context, host *api.ChiHost) (string, error) {
+	sql := "SELECT name, path FROM system.disks;"
+	defaultPath := ""
+	err := r.Retry(ctx, 10, "Query DefaultDisk", log.V(1).M(host).F(),
+		func() error {
+			q, err := s.QueryHost(ctx, host, sql)
+			if err != nil {
+				return err
+			}
+			if q == nil {
+				return fmt.Errorf("empty query")
+			}
+			if q.Rows == nil {
+				return fmt.Errorf("no rows")
+			}
+			for q.Rows.Next() {
+				var name, path string
+				if err := q.Rows.Scan(&name, &path); err != nil {
+					log.V(1).F().Error("UNABLE to scan row err: %v", err)
+					return err
+				}
+				if name == "default" {
+					defaultPath = path
+				}
+			}
+			defer q.Close()
+			return nil
+		})
+	if err != nil {
+		return "", fmt.Errorf("cann not found default disk path")
+	}
+	return defaultPath, nil
+}
+
+func (s *ClusterSchemer) HostGetUsers(ctx context.Context, host *api.ChiHost) ([]string, error) {
+	sql := "SELECT name FROM system.users;"
+	var users []string
+	err := r.Retry(ctx, 10, "Select sql", log.V(1).M(host).F(),
+		func() error {
+			q, err := s.QueryHost(ctx, host, sql)
+			if err != nil {
+				return err
+			}
+			if q == nil {
+				return fmt.Errorf("empty query")
+			}
+			if q.Rows == nil {
+				return fmt.Errorf("no rows")
+			}
+			for q.Rows.Next() {
+				var user string
+				if err := q.Rows.Scan(&user); err != nil {
+					log.V(1).F().Error("UNABLE to scan row err: %v", err)
+					return err
+				}
+				users = append(users, user)
+			}
+			defer q.Close()
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
 }
 
 // HostClickHouseVersion returns ClickHouse version on the host


### PR DESCRIPTION
The function of synchronizing user information from the original host to the new host when clickhouse is added. First, it is judged whether the current host is working and whether it is added. Start user synchronization operation for new host. Select a working host from the original cluster, which is different from the current host, and name it select host. Compare the user information in the current host and the select host, and if they are different, perform user synchronization operation, and copy the /var/lib/clickhouse/access directory from the select host to the current host. Then execute the reload user information command “system reload users” in clickhouse-client to synchronize user information.
