### PR TITLE
Changed Merge metric from ProfileEvent to CurrentMetric

### DIFF
--- a/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
+++ b/grafana-dashboard/Altinity_ClickHouse_Operator_dashboard.json
@@ -2102,7 +2102,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "rate(chi_clickhouse_event_Merge{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}[1m])",
+          "expr": "chi_clickhouse_metric_Merge{exported_namespace=~\"$exported_namespace\",chi=~\"$chi\",hostname=~\"$hostname\"}",
           "intervalFactor": 2,
           "legendFormat": "merges {{hostname}}",
           "refId": "A",
@@ -2118,7 +2118,7 @@
         "msResolution": false,
         "shared": true,
         "sort": 2,
-        "value_type": "cumulative"
+        "value_type": "individual"
       },
       "type": "graph",
       "xaxis": {


### PR DESCRIPTION
To have a more detailed count of current merges in a particular point in time, changed the ProfileEvent rate function to a CurrentMetric. New Altinity Monitoring dashboard (@filimonov) uses CurrentMetric to measure merges instead of using a ProfileEvent with a rate.