### PR TITLE
docs: Updated ClickhouseKeeper example with securityContext

### DIFF
--- a/docs/chk-examples/02-extended-1-node.yaml
+++ b/docs/chk-examples/02-extended-1-node.yaml
@@ -38,9 +38,12 @@ spec:
                 limits:
                   memory: "4Gi"
                   cpu: "2"
+          securityContext:
+            fsGroup: 101
     volumeClaimTemplates:
       - name: default
         metadata:
+          # NOTE: one volume that will be used for both coordination/snapshots/ and logs/
           name: both-paths
         spec:
           accessModes:


### PR DESCRIPTION
Without securityContext I was getting "permission denied" writing to /var/lib/c-k/coordination/ directories.