### PR TITLE
clustergen: add all-clusters cluster

### DIFF
--- a/pkg/model/chi/ch_config_generator.go
+++ b/pkg/model/chi/ch_config_generator.go
@@ -33,6 +33,7 @@ const (
 	// 2. Cluster with all shards (1 replica). Used to gather/scatter data over all replicas.
 	OneShardAllReplicasClusterName = "all-replicated"
 	AllShardsOneReplicaClusterName = "all-sharded"
+	AllClustersClusterName         = "all-clusters"
 )
 
 // ClickHouseConfigGenerator generates ClickHouse configuration files content for specified CHI
@@ -436,6 +437,35 @@ func (c *ClickHouseConfigGenerator) GetRemoteServers(options *RemoteServersGener
 			}
 			return nil
 		})
+		// </my_cluster_name>
+		util.Iline(b, 8, "</%s>", clusterName)
+
+		// All shards from all clusters
+		util.Iline(b, 8, "<%s>", AllClustersClusterName)
+
+		c.chi.WalkClusters(func(cluster *api.Cluster) error {
+			cluster.WalkShards(func(index int, shard *api.ChiShard) error {
+				if c.ShardHostsNum(shard, options) < 1 {
+					// Skip empty shard
+					return nil
+				}
+				util.Iline(b, 12, "<shard>")
+				util.Iline(b, 12, "    <internal_replication>%s</internal_replication>", shard.InternalReplication)
+
+				shard.WalkHosts(func(host *api.ChiHost) error {
+					if options.Include(host) {
+						c.getRemoteServersReplica(host, b)
+					}
+					return nil
+				})
+				util.Iline(b, 12, "</shard>")
+
+				return nil
+			})
+
+			return nil
+		})
+
 		// </my_cluster_name>
 		util.Iline(b, 8, "</%s>", clusterName)
 	}


### PR DESCRIPTION
Adds an `all-shards` cluster, which contains the shard definitions for each cluster specified in the ClickhouseInstallation. This is used by our `query` nodes to allow scattering reads across all clusters in the CHI while respecting the shard/replica.

Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


fixes #1291 