### PR TITLE
Enable global CHI watching from any namespace with WATCH_ALL_NAMESPACES Env Var

### DIFF
--- a/pkg/apis/deployment/env_vars.go
+++ b/pkg/apis/deployment/env_vars.go
@@ -48,7 +48,11 @@ const (
 	WATCH_NAMESPACE = "WATCH_NAMESPACE"
 	// WATCH_NAMESPACES and WATCH_NAMESPACE specifies what namespaces to watch
 	WATCH_NAMESPACES = "WATCH_NAMESPACES"
+	// WATCH_ALL_NAMESPACES enables watching all namespaces. When configured, 
+	// both WATCH_NAMESPACE and WATCH_NAMESPACES settings will be ignored.
+	WATCH_ALL_NAMESPACES = "WATCH_ALL_NAMESPACES"
 
 	// CHOP_CONFIG path to clickhouse operator configuration file
 	CHOP_CONFIG = "CHOP_CONFIG"
 )
+

--- a/pkg/chop/config_manager.go
+++ b/pkg/chop/config_manager.go
@@ -340,6 +340,7 @@ func (cm *ConfigManager) listSupportedEnvVarNames() []string {
 
 		deployment.WATCH_NAMESPACE,
 		deployment.WATCH_NAMESPACES,
+		deployment.WATCH_ALL_NAMESPACES,
 	}
 }
 
@@ -447,3 +448,4 @@ func (cm *ConfigManager) fetchSecretCredentials() {
 func (cm *ConfigManager) Postprocess() {
 	cm.config.Postprocess()
 }
+


### PR DESCRIPTION
Introduce a new environment variable WATCH_ALL_NAMESPACES, enabling the Operator to monitor CHIs resources across all namespaces, regardless of the namespace in which the operator is deployed. This enhancement removes the previous limitation where the operator could only watch all namespaces when deployed in the kube-system namespace or a specified set of namespaces when configured with watch_namespaces. With this change, users now have the flexibility to deploy the Operator in any desired namespace and still retain the capability to watch CHIs cluster-wide, including those in **dynamically created namespaces**.

reference:https://github.com/Altinity/clickhouse-operator/issues/294