### PR TITLE
fix chk reconciler

### DIFF
--- a/pkg/controller/chk/status.go
+++ b/pkg/controller/chk/status.go
@@ -63,6 +63,7 @@ func (r *Reconciler) reconcileClusterStatus(chk *apiChk.ClickHouseKeeperInstalla
 
 		cur.Status.NormalizedCHK = nil
 		cur.Status.NormalizedCHKCompleted = chk.DeepCopy()
+		cur.Status.NormalizedCHKCompleted.ObjectMeta.ResourceVersion = ""
 		cur.Status.NormalizedCHKCompleted.ObjectMeta.ManagedFields = nil
 		cur.Status.NormalizedCHKCompleted.Status = nil
 


### PR DESCRIPTION
When ResourceVersion is put into status, it creates infinite reconcile loop