### PR TITLE
Fix installing zookeeper operator script

### DIFF
--- a/deploy/zookeeper/zookeeper-with-zookeeper-operator/install-zookeeper-operator.sh
+++ b/deploy/zookeeper/zookeeper-with-zookeeper-operator/install-zookeeper-operator.sh
@@ -2,10 +2,10 @@
 ZOOKEEPER_OPERATOR_VERSION=${ZOOKEEPER_OPERATOR_VERSION:-0.2.15}
 ZOOKEEPER_OPERATOR_NAMESPACE=${ZOOKEEPER_OPERATOR_NAMESPACE:-zookeeper-operator}
 kubectl create ns "${ZOOKEEPER_OPERATOR_NAMESPACE}" || true
-kubectl apply -f "https://raw.githubusercontent.com/pravega/zookeeper-operator/raw/v${ZOOKEEPER_OPERATOR_VERSION}/config/crd/bases/zookeeper.pravega.io_zookeeperclusters.yaml"
+kubectl apply -f "https://raw.githubusercontent.com/pravega/zookeeper-operator/v${ZOOKEEPER_OPERATOR_VERSION}/config/crd/bases/zookeeper.pravega.io_zookeeperclusters.yaml"
 kubectl apply -n "${ZOOKEEPER_OPERATOR_NAMESPACE}" -f <(
-  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/raw/v${ZOOKEEPER_OPERATOR_VERSION}/config/rbac/all_ns_rbac.yaml" | sed -e "s/namespace: default/namespace: ${ZOOKEEPER_OPERATOR_NAMESPACE}/g"
+  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/v${ZOOKEEPER_OPERATOR_VERSION}/config/rbac/all_ns_rbac.yaml" | sed -e "s/namespace: default/namespace: ${ZOOKEEPER_OPERATOR_NAMESPACE}/g"
 )
 kubectl apply -n "${ZOOKEEPER_OPERATOR_NAMESPACE}" -f <(
-  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/raw/v${ZOOKEEPER_OPERATOR_VERSION}/config/manager/manager.yaml" | yq eval ".spec.template.spec.containers[0].image=\"pravega/zookeeper-operator:${ZOOKEEPER_OPERATOR_VERSION}\" | del(.spec.template.spec.containers[0].env[] | select(.name == \"WATCH_NAMESPACE\") | .spec.template.spec.containers[0].env[] += {\"name\": \"WATCH_NAMESPACE\",\"value\":\"\"} )" -
+  curl -sL "https://raw.githubusercontent.com/pravega/zookeeper-operator/v${ZOOKEEPER_OPERATOR_VERSION}/config/manager/manager.yaml" | yq eval ".spec.template.spec.containers[0].image=\"pravega/zookeeper-operator:${ZOOKEEPER_OPERATOR_VERSION}\" | del(.spec.template.spec.containers[0].env[] | select(.name == \"WATCH_NAMESPACE\") | .spec.template.spec.containers[0].env[] += {\"name\": \"WATCH_NAMESPACE\",\"value\":\"\"} )" -
 )


### PR DESCRIPTION
When executing `install-zookeeper-operator.sh` exceptions happen:

```
$ ./install-zookeeper-operator.sh
namespace/zookeeper-operator created
error: unable to read URL "https://raw.githubusercontent.com/pravega/zookeeper-operator/raw/v0.2.15/config/crd/bases/zookeeper.pravega.io_zookeeperclusters.yaml", server reported 404 Not Found, status code=404
error: error validating "/dev/fd/63": error validating data: [apiVersion not set, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false
error: error validating "/dev/fd/63": error validating data: [apiVersion not set, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false
```

This PR fixes exceptions above.

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x ] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [ x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [ x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
