### PR TITLE
actualize test_keeper for `clickhouse-keeper_with_chk`

### DIFF
--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
@@ -160,7 +160,7 @@ data:
     mkdir -p /tmp/clickhouse-keeper/config.d/
     if [[ "true" == "${ACTIVE_ENSEMBLE}" ]]; then
       # get current config from clickhouse-keeper
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || true) 
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || true) 
       # generate dynamic config, add current server to xml
       {
         echo "<yandex><keeper_server>"
@@ -220,7 +220,7 @@ data:
     fi
     export MY_ID=$((ORD+1))
 
-    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     CLUSTER_SIZE=$(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E '^server\.[0-9]+=') 
     echo "CLUSTER_SIZE=$CLUSTER_SIZE, MyId=$MY_ID"
     # If CLUSTER_SIZE > 1, this server is being permanently removed from raft_configuration.
@@ -230,7 +230,7 @@ data:
 
     # Wait to remove $MY_ID from quorum
     # for (( i = 0; i < 6; i++ )); do
-    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     #    if [[ "0" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=$HOST.+participant;[0-1]$") ]]; then
     #      echo "$MY_ID removed from quorum"
     #      break
@@ -300,9 +300,18 @@ data:
         echo "Failed to parse name and ordinal of Pod"
         exit 1
       fi
+      set +e
+      HTTP_READY_STATUS=$(wget -qO- http://127.0.0.1:9182/ready)
+      if [[ "0" == "$?" ]]; then
+        if [[ "0" != $(echo $HTTP_READY_STATUS | grep -c '"status":"ok"') ]]; then
+          echo $HTTP_READY_STATUS
+          exit 0
+        fi
+      fi
+      set -e
       MY_ID=$((ORD+1))
       
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || exit 0)
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || exit 0)
       # Check to see if clickhouse-keeper for this node is a participant in raft cluster
       if [[ "1" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=${HOST}.+participant;1$") ]]; then
         echo "clickhouse-keeper instance is available and an active participant"

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
@@ -142,7 +142,7 @@ data:
     mkdir -p /tmp/clickhouse-keeper/config.d/
     if [[ "true" == "${ACTIVE_ENSEMBLE}" ]]; then
       # get current config from clickhouse-keeper
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || true) 
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || true) 
       # generate dynamic config, add current server to xml
       {
         echo "<yandex><keeper_server>"
@@ -202,7 +202,7 @@ data:
     fi
     export MY_ID=$((ORD+1))
 
-    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     CLUSTER_SIZE=$(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E '^server\.[0-9]+=') 
     echo "CLUSTER_SIZE=$CLUSTER_SIZE, MyId=$MY_ID"
     # If CLUSTER_SIZE > 1, this server is being permanently removed from raft_configuration.
@@ -212,7 +212,7 @@ data:
 
     # Wait to remove $MY_ID from quorum
     # for (( i = 0; i < 6; i++ )); do
-    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     #    if [[ "0" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=$HOST.+participant;[0-1]$") ]]; then
     #      echo "$MY_ID removed from quorum"
     #      break
@@ -282,9 +282,18 @@ data:
         echo "Failed to parse name and ordinal of Pod"
         exit 1
       fi
+      set +e
+      HTTP_READY_STATUS=$(wget -qO- http://127.0.0.1:9182/ready)
+      if [[ "0" == "$?" ]]; then
+        if [[ "0" != $(echo $HTTP_READY_STATUS | grep -c '"status":"ok"') ]]; then
+          echo $HTTP_READY_STATUS
+          exit 0
+        fi
+      fi
+      set -e
       MY_ID=$((ORD+1))
       
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || exit 0)
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || exit 0)
       # Check to see if clickhouse-keeper for this node is a participant in raft cluster
       if [[ "1" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=${HOST}.+participant;1$") ]]; then
         echo "clickhouse-keeper instance is available and an active participant"

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
@@ -160,7 +160,7 @@ data:
     mkdir -p /tmp/clickhouse-keeper/config.d/
     if [[ "true" == "${ACTIVE_ENSEMBLE}" ]]; then
       # get current config from clickhouse-keeper
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || true) 
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || true) 
       # generate dynamic config, add current server to xml
       {
         echo "<yandex><keeper_server>"
@@ -220,7 +220,7 @@ data:
     fi
     export MY_ID=$((ORD+1))
 
-    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     CLUSTER_SIZE=$(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E '^server\.[0-9]+=') 
     echo "CLUSTER_SIZE=$CLUSTER_SIZE, MyId=$MY_ID"
     # If CLUSTER_SIZE > 1, this server is being permanently removed from raft_configuration.
@@ -230,7 +230,7 @@ data:
 
     # Wait to remove $MY_ID from quorum
     # for (( i = 0; i < 6; i++ )); do
-    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     #    if [[ "0" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=$HOST.+participant;[0-1]$") ]]; then
     #      echo "$MY_ID removed from quorum"
     #      break
@@ -300,9 +300,18 @@ data:
         echo "Failed to parse name and ordinal of Pod"
         exit 1
       fi
+      set +e
+      HTTP_READY_STATUS=$(wget -qO- http://127.0.0.1:9182/ready)
+      if [[ "0" == "$?" ]]; then
+        if [[ "0" != $(echo $HTTP_READY_STATUS | grep -c '"status":"ok"') ]]; then
+          echo $HTTP_READY_STATUS
+          exit 0
+        fi
+      fi
+      set -e
       MY_ID=$((ORD+1))
       
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || exit 0)
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || exit 0)
       # Check to see if clickhouse-keeper for this node is a participant in raft cluster
       if [[ "1" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=${HOST}.+participant;1$") ]]; then
         echo "clickhouse-keeper instance is available and an active participant"

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
@@ -142,7 +142,7 @@ data:
     mkdir -p /tmp/clickhouse-keeper/config.d/
     if [[ "true" == "${ACTIVE_ENSEMBLE}" ]]; then
       # get current config from clickhouse-keeper
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || true) 
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || true) 
       # generate dynamic config, add current server to xml
       {
         echo "<yandex><keeper_server>"
@@ -202,7 +202,7 @@ data:
     fi
     export MY_ID=$((ORD+1))
 
-    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     CLUSTER_SIZE=$(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E '^server\.[0-9]+=') 
     echo "CLUSTER_SIZE=$CLUSTER_SIZE, MyId=$MY_ID"
     # If CLUSTER_SIZE > 1, this server is being permanently removed from raft_configuration.
@@ -212,7 +212,7 @@ data:
 
     # Wait to remove $MY_ID from quorum
     # for (( i = 0; i < 6; i++ )); do
-    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get /keeper/config")
+    #    CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h localhost -p ${CLIENT_PORT} -q "get '/keeper/config'")
     #    if [[ "0" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=$HOST.+participant;[0-1]$") ]]; then
     #      echo "$MY_ID removed from quorum"
     #      break
@@ -282,9 +282,18 @@ data:
         echo "Failed to parse name and ordinal of Pod"
         exit 1
       fi
+      set +e
+      HTTP_READY_STATUS=$(wget -qO- http://127.0.0.1:9182/ready)
+      if [[ "0" == "$?" ]]; then
+        if [[ "0" != $(echo $HTTP_READY_STATUS | grep -c '"status":"ok"') ]]; then
+          echo $HTTP_READY_STATUS
+          exit 0
+        fi
+      fi
+      set -e
       MY_ID=$((ORD+1))
       
-      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get /keeper/config" || exit 0)
+      CURRENT_KEEPER_CONFIG=$(clickhouse-keeper-client --history-file=/dev/null -h ${CLIENT_HOST} -p ${CLIENT_PORT} -q "get '/keeper/config'" || exit 0)
       # Check to see if clickhouse-keeper for this node is a participant in raft cluster
       if [[ "1" == $(echo -e "${CURRENT_KEEPER_CONFIG}" | grep -c -E "^server.${MY_ID}=${HOST}.+participant;1$") ]]; then
         echo "clickhouse-keeper instance is available and an active participant"

--- a/docs/chk-examples/clickhouse-keeper-1-node-for-test-only.yaml
+++ b/docs/chk-examples/clickhouse-keeper-1-node-for-test-only.yaml
@@ -14,14 +14,21 @@ spec:
     - port: 7000
       name: prometheus
   selector:
-    app: clickhouse-keeper
-    what: node
+    clickhouse-keeper.altinity.com/chk: clickhouse-keeper
+    clickhouse-keeper.altinity.com/ready: "yes"
 ---
 apiVersion: "clickhouse-keeper.altinity.com/v1"
 kind: "ClickHouseKeeperInstallation"
 metadata:
   name: clickhouse-keeper
+  labels:
+    app: clickhouse-keeper
 spec:
+  defaults:
+    templates:
+      dataVolumeClaimTemplate: data-volume
+      logVolumeClaimTemplate: log-volume
+      podTemplate: latest-with-volume-mounts
   configuration:
     clusters:
       - name: "test-only"
@@ -31,7 +38,8 @@ spec:
       logger/level: "trace"
       logger/console: "true"
       listen_host: "0.0.0.0"
-      keeper_server/storage_path: /var/lib/clickhouse-keeper
+      http_control/port: 9182
+      http_control/readiness/endpoint: /ready
       keeper_server/tcp_port: "2181"
       keeper_server/four_letter_word_white_list: "*"
       keeper_server/coordination_settings/raft_logs_level: "information"
@@ -43,11 +51,28 @@ spec:
       prometheus/asynchronous_metrics: "true"
       prometheus/status_info: "false"
   templates:
+    podTemplates:
+      - name: latest-with-volume-mounts
+        spec:
+          containers:
+            - name: clickhouse-keeper
+              imagePullPolicy: Always
+              image: "clickhouse/clickhouse-keeper:latest-alpine"
+              volumeMounts:
+                - name: data-volume
+                  mountPath: /var/lib/clickhouse
     volumeClaimTemplates:
-      - name: both-paths
+      - name: data-volume
         spec:
           accessModes:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 5Gi
+              storage: 1Gi
+      - name: log-volume
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/docs/chk-examples/clickhouse-keeper-3-node-for-test-only-version-24.yaml
+++ b/docs/chk-examples/clickhouse-keeper-3-node-for-test-only-version-24.yaml
@@ -14,8 +14,8 @@ spec:
     - port: 7000
       name: prometheus
   selector:
-    app: clickhouse-keeper
-    what: node
+    clickhouse-keeper.altinity.com/chk: clickhouse-keeper
+    clickhouse-keeper.altinity.com/ready: "yes"
 ---
 apiVersion: "clickhouse-keeper.altinity.com/v1"
 kind: "ClickHouseKeeperInstallation"
@@ -32,7 +32,7 @@ spec:
           containers:
             - name: clickhouse-keeper
               imagePullPolicy: IfNotPresent
-              image: "clickhouse/clickhouse-keeper:24.3.5.46"
+              image: "clickhouse/clickhouse-keeper:24.8"
               volumeMounts:
                 - name: default
                   mountPath: /var/lib/clickhouse

--- a/docs/chk-examples/clickhouse-keeper-3-node-for-test-only.yaml
+++ b/docs/chk-examples/clickhouse-keeper-3-node-for-test-only.yaml
@@ -14,14 +14,21 @@ spec:
     - port: 7000
       name: prometheus
   selector:
-    app: clickhouse-keeper
-    what: node
+    clickhouse-keeper.altinity.com/chk: clickhouse-keeper
+    clickhouse-keeper.altinity.com/ready: "yes"
 ---
 apiVersion: "clickhouse-keeper.altinity.com/v1"
 kind: "ClickHouseKeeperInstallation"
 metadata:
   name: clickhouse-keeper
+  labels:
+    app: clickhouse-keeper
 spec:
+  defaults:
+    templates:
+      dataVolumeClaimTemplate: data-volume
+      logVolumeClaimTemplate: log-volume
+      podTemplate: latest-with-volume-mounts
   configuration:
     clusters:
       - name: "test-only"
@@ -31,7 +38,8 @@ spec:
       logger/level: "trace"
       logger/console: "true"
       listen_host: "0.0.0.0"
-      keeper_server/storage_path: /var/lib/clickhouse-keeper
+      http_control/port: 9182
+      http_control/readiness/endpoint: /ready
       keeper_server/tcp_port: "2181"
       keeper_server/four_letter_word_white_list: "*"
       keeper_server/coordination_settings/raft_logs_level: "information"
@@ -43,11 +51,28 @@ spec:
       prometheus/asynchronous_metrics: "true"
       prometheus/status_info: "false"
   templates:
+    podTemplates:
+      - name: latest-with-volume-mounts
+        spec:
+          containers:
+            - name: clickhouse-keeper
+              imagePullPolicy: Always
+              image: "clickhouse/clickhouse-keeper:latest-alpine"
+              volumeMounts:
+                - name: data-volume
+                  mountPath: /var/lib/clickhouse
     volumeClaimTemplates:
-      - name: both-paths
+      - name: data-volume
         spec:
           accessModes:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 5Gi
+              storage: 1Gi
+      - name: log-volume
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/docs/chk-examples/clickhouse-keeper-3-node-with-volume-for-test-only.yaml
+++ b/docs/chk-examples/clickhouse-keeper-3-node-with-volume-for-test-only.yaml
@@ -14,8 +14,8 @@ spec:
     - port: 7000
       name: prometheus
   selector:
-    app: clickhouse-keeper
-    what: node
+    clickhouse-keeper.altinity.com/chk: clickhouse-keeper
+    clickhouse-keeper.altinity.com/ready: "yes"
 ---
 apiVersion: "clickhouse-keeper.altinity.com/v1"
 kind: "ClickHouseKeeperInstallation"
@@ -31,7 +31,7 @@ spec:
       logger/level: "trace"
       logger/console: "true"
       listen_host: "0.0.0.0"
-      keeper_server/storage_path: /var/lib/clickhouse-keeper
+      keeper_server/storage_path: /var/lib/clickhouse
       keeper_server/tcp_port: "2181"
       keeper_server/four_letter_word_white_list: "*"
       keeper_server/coordination_settings/raft_logs_level: "information"

--- a/tests/e2e/manifests/chi/test-cluster-for-clickhouse-keeper_with_chk-1.yaml
+++ b/tests/e2e/manifests/chi/test-cluster-for-clickhouse-keeper_with_chk-1.yaml
@@ -9,10 +9,10 @@ spec:
   configuration:
     zookeeper:
       nodes:
-        - host: clickhouse-keeper
+        - host: keeper-clickhouse-keeper
           port: 2181
     clusters:
       - name: default
         layout:
           shardsCount: 1
-          replicasCount: 2
+          replicasCount: 1

--- a/tests/e2e/manifests/chi/test-cluster-for-clickhouse-keeper_with_chk-2.yaml
+++ b/tests/e2e/manifests/chi/test-cluster-for-clickhouse-keeper_with_chk-2.yaml
@@ -9,10 +9,10 @@ spec:
   configuration:
     zookeeper:
       nodes:
-        - host: clickhouse-keeper
+        - host: keeper-clickhouse-keeper
           port: 2181
     clusters:
       - name: default
         layout:
           shardsCount: 1
-          replicasCount: 1
+          replicasCount: 2

--- a/tests/e2e/test_keeper.py
+++ b/tests/e2e/test_keeper.py
@@ -106,7 +106,8 @@ def check_zk_root_znode(chi, keeper_type, pod_count, retry_count=15):
             "zookeeper": "2",
             "zookeeper-operator": "3",
             "clickhouse-keeper": "2",
-            "clickhouse-keeper_with_CHKI": "2",
+            "clickhouse-keeper_with_chk": "2",
+            "CHK": "2",
         }
         if expected_out[keeper_type] != out.strip(" \t\r\n") and i + 1 < retry_count:
             with Then(f"{keeper_type} system.zookeeper not ready, wait {(i + 1) * 3} sec"):
@@ -353,7 +354,7 @@ def test_clickhouse_keeper_rescale(self):
 
 
 @TestScenario
-@Name("test_clickhouse_keeper_rescale_CHKI using ClickHouseKeeperInstallation. Check KEEPER scale-up / scale-down cases")
+@Name("test_clickhouse_keeper_rescale_chk. Using ClickHouseKeeperInstallation. Check KEEPER scale-up / scale-down cases")
 @Requirements(RQ_SRS_026_ClickHouseOperator_CustomResource_Kind_ClickHouseKeeperInstallation("1.0"))
 def test_clickhouse_keeper_rescale_chk(self):
     test_keeper_rescale_outline(

--- a/tests/e2e/util.py
+++ b/tests/e2e/util.py
@@ -83,7 +83,7 @@ def require_keeper(keeper_manifest="", keeper_type=settings.keeper_type, force_i
         if keeper_type == "clickhouse-keeper":
             keeper_manifest = "clickhouse-keeper-1-node-256M-for-test-only.yaml" if keeper_manifest == "" else keeper_manifest
             keeper_manifest = f"../../deploy/clickhouse-keeper/clickhouse-keeper-manually/{keeper_manifest}"
-        if keeper_type == "CHK":
+        if keeper_type == "CHK" or keeper_type == "clickhouse-keeper_with_chk":
             keeper_manifest = (
                 "clickhouse-keeper-1-node-for-test-only.yaml" if keeper_manifest == "" else keeper_manifest
             )
@@ -102,6 +102,7 @@ def require_keeper(keeper_manifest="", keeper_type=settings.keeper_type, force_i
         expected_docs = {
             "zookeeper": 5 if "scaleout-pvc" in keeper_manifest else 4,
             "clickhouse-keeper": 7,
+            "clickhouse-keeper_with_chk": 2,
             "CHK": 2,
             "zookeeper-operator": 3 if "probes" in keeper_manifest else 1,
         }
@@ -109,6 +110,7 @@ def require_keeper(keeper_manifest="", keeper_type=settings.keeper_type, force_i
             "zookeeper": "zookeeper",
             "zookeeper-operator": "zookeeper",
             "clickhouse-keeper": "clickhouse-keeper",
+            "clickhouse-keeper_with_chk": "chk-clickhouse-keeper-test-only-0",
             "CHK": "chk-clickhouse-keeper-test-only-0"
         }
         assert (
@@ -117,7 +119,7 @@ def require_keeper(keeper_manifest="", keeper_type=settings.keeper_type, force_i
         with Given(f"Install {keeper_type} {keeper_nodes} nodes"):
             kubectl.apply(get_full_path(keeper_manifest, lookup_in_host=False))
             for pod_num in range(keeper_nodes):
-                if keeper_type == "CHK":
+                if keeper_type == "CHK" or keeper_type == "clickhouse-keeper_with_chk" :
                     pod_name = f"{expected_pod_prefix[keeper_type]}-{pod_num}-0"
                 else:
                     pod_name = f"{expected_pod_prefix[keeper_type]}-{pod_num}"
@@ -164,7 +166,7 @@ def install_clickhouse_and_keeper(
             keeper_manifest = "zookeeper-1-node-1GB-for-tests-only.yaml"
         if keeper_type == "clickhouse-keeper":
             keeper_manifest = "clickhouse-keeper-1-node-256M-for-test-only.yaml"
-        if keeper_type == "clickhouse-keeper_with_CHKI":
+        if keeper_type == "clickhouse-keeper_with_chk" or keeper_type == "CHK":
             keeper_manifest = "clickhouse-keeper-1-node-for-test-only.yaml"
         if keeper_type == "zookeeper-operator":
             keeper_manifest = "zookeeper-operator-1-node.yaml"

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -13,9 +13,9 @@ xfails = {
     # test_clickhouse.py
     "/regression/e2e.test_clickhouse/test_ch_001*": [(Fail, "Insert Quorum test need to refactoring")],
     # test_metrics_alerts.py
-    "/regression/e2e.test_metrics_alerts/test_clickhouse_keeper_alerts*": [
-        (Fail, "clickhouse-keeper wrong prometheus endpoint format, look https://github.com/ClickHouse/ClickHouse/issues/46136")
-    ],
+    # "/regression/e2e.test_metrics_alerts/test_clickhouse_keeper_alerts*": [
+    #     (Fail, "clickhouse-keeper wrong prometheus endpoint format, look https://github.com/ClickHouse/ClickHouse/issues/46136")
+    # ],
     # test_keeper.py
     # "/regression/e2e.test_keeper/test_clickhouse_keeper_rescale*": [
     #     (Fail, "need `ruok` before quorum https://github.com/ClickHouse/ClickHouse/issues/35464, need apply file config instead use commited data for quorum https://github.com/ClickHouse/ClickHouse/issues/35465. --force-recovery useless https://github.com/ClickHouse/ClickHouse/issues/37434"),


### PR DESCRIPTION
`python3 ./tests/regression.py --only="/regression/e2e.test_keeper/test_clickhouse_keeper_rescale_chk*" --native`

still not work after scaledown 3->1
cause clickhouse-keeper still think they have 3 peers
we need implements reconfig add, reconfig remove logic inside clickhouse-operator