### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/util/array.go
+++ b/pkg/util/array.go
@@ -78,8 +78,8 @@ func RemoveFromArray(needle string, haystack []string) []string {
 
 // Unzip makes two 1-value columns (slices) out of one 2-value column (slice)
 func Unzip(slice [][]string) ([]string, []string) {
-	col1 := make([]string, len(slice))
-	col2 := make([]string, len(slice))
+	col1 := make([]string, 0, len(slice))
+	col2 := make([]string, 0, len(slice))
 	for i := 0; i < len(slice); i++ {
 		col1 = append(col1, slice[i][0])
 		if len(slice[i]) > 1 {


### PR DESCRIPTION
Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [ ] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [ ] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW