### PR TITLE
fix: don't b64 encode configmap data

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
+++ b/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
@@ -15,6 +15,6 @@ metadata:
 {{- end }}
 data:
 {{- range $path, $_ := .Files.Glob "files/*.json" }}
-  {{ $path | trimPrefix "files/" }}: {{ $.Files.Get $path | b64enc -}}
+  {{ $path | trimPrefix "files/" }}: |- {{ $.Files.Get $path | nindent 4 -}}
 {{ end }}
 {{- end }}


### PR DESCRIPTION
In [this](https://github.com/Altinity/clickhouse-operator/pull/1457) PR the Dashboards were switched from secret to configmap, but the base64 encoding wasn't removed.  

Also, a little bit of formatting was needed, as otherwise the deployment would fail.

----

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
