### PR TITLE
fix: Helm Chart fix Grafana Dashboards

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
+++ b/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
@@ -15,6 +15,7 @@ metadata:
 {{- end }}
 data:
 {{- range $path, $_ := .Files.Glob "files/*.json" }}
-  {{ $path | trimPrefix "files/" }}: {{ $.Files.Get $path | b64enc -}}
+  {{ $path | trimPrefix "files/" }}: |-
+{{ $.Files.Get $path | indent 4 -}}
 {{ end }}
 {{- end }}


### PR DESCRIPTION
Dashboards inside configmap shouldn't be in a base64 format, Grafana sidecar expected it in a plain json

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x ] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x ] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x ] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)
