### PR TITLE
Inherit PVC storage value if current value is greater than value in spec

### DIFF
--- a/pkg/controller/common/storage/storage-pvc.go
+++ b/pkg/controller/common/storage/storage-pvc.go
@@ -49,7 +49,7 @@ func (c *PVC) UpdateOrCreate(ctx context.Context, pvc *core.PersistentVolumeClai
 		return nil, fmt.Errorf("task is done")
 	}
 
-	_, err := c.Get(ctx, pvc.Namespace, pvc.Name)
+	oldPvc, err := c.Get(ctx, pvc.Namespace, pvc.Name)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			log.V(1).M(pvc).F().Error("PVC not found, need to create %s", util.NamespacedName(pvc))
@@ -62,6 +62,14 @@ func (c *PVC) UpdateOrCreate(ctx context.Context, pvc *core.PersistentVolumeClai
 		// In case of any non-NotFound API error - unable to proceed
 		log.V(1).M(pvc).F().Error("ERROR unable to get PVC(%s) err: %v", util.NamespacedName(pvc), err)
 		return nil, err
+	}    
+
+	oldStorageRequest := oldPvc.Spec.Resources.Requests[core.ResourceStorage]	
+	newStorageRequest  := pvc.Spec.Resources.Requests[core.ResourceStorage]
+
+	if oldStorageRequest.Cmp(newStorageRequest) == 1 {
+		log.V(1).M(pvc).F().Info("PVC storage was increased externally to greater value and value cannot be decreased, using greater value")
+		pvc.Spec.Resources.Requests[core.ResourceStorage] = oldStorageRequest
 	}
 
 	pvcUpdated, err := c.Update(ctx, pvc)


### PR DESCRIPTION
Handles cases such as PVC storage size controlled by external controller such as [pvc-autoresizer](https://github.com/topolvm/pvc-autoresizer)

 ---
Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
