### PR TITLE
feat: ability to suspend `ClickHouseInstallation` and `ClickHouseKeeper` reconciliation

### DIFF
--- a/cmd/operator/app/thread_keeper_test.go
+++ b/cmd/operator/app/thread_keeper_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse-keeper.altinity.com/v1"
+)
+
+func Test_keeperPredicateCreate(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+		evt  event.CreateEvent
+	}{
+		{
+			name: "skips create when suspended",
+			want: false,
+			evt: event.CreateEvent{
+				Object: &api.ClickHouseKeeperInstallation{
+					Spec: api.ChkSpec{
+						Suspend: types.NewStringBool(true),
+					},
+				},
+			},
+		},
+		{
+			name: "queues create when not suspended",
+			want: true,
+			evt: event.CreateEvent{
+				Object: &api.ClickHouseKeeperInstallation{
+					Spec: api.ChkSpec{
+						Suspend: types.NewStringBool(false),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := keeperPredicate()
+			if got := predicate.Create(tt.evt); tt.want != got {
+				t.Errorf("keeperPredicate.Create() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_keeperPredicateUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+		evt  event.UpdateEvent
+	}{
+		{
+			name: "skips update when suspended",
+			want: false,
+			evt: event.UpdateEvent{
+				ObjectNew: &api.ClickHouseKeeperInstallation{
+					Spec: api.ChkSpec{
+						Suspend: types.NewStringBool(true),
+					},
+				},
+			},
+		},
+		{
+			name: "queues update when not suspended",
+			want: true,
+			evt: event.UpdateEvent{
+				ObjectNew: &api.ClickHouseKeeperInstallation{
+					Spec: api.ChkSpec{
+						Suspend: types.NewStringBool(false),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := keeperPredicate()
+			if got := predicate.Update(tt.evt); tt.want != got {
+				t.Errorf("keeperPredicate.Update() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_keeperPredicateDelete(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+		evt  event.DeleteEvent
+	}{
+		{
+			name: "deletes even when suspended",
+			want: true,
+			evt: event.DeleteEvent{
+				Object: &api.ClickHouseKeeperInstallation{
+					Spec: api.ChkSpec{
+						Suspend: types.NewStringBool(true),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := keeperPredicate()
+			if got := predicate.Delete(tt.evt); tt.want != got {
+				t.Errorf("keeperPredicate.Delete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-01-chi-chit.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-01-chi-chit.yaml
@@ -92,6 +92,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -308,6 +313,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-03-chk.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-03-chk.yaml
@@ -88,6 +88,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -296,6 +301,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -92,6 +92,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -308,6 +313,38 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend: &TypeStringBool
+                  type: string
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
                 troubleshoot:
                   !!merge <<: *TypeStringBool
                   description: |

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -92,6 +92,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -308,6 +313,38 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend: &TypeStringBool
+                  type: string
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
                 troubleshoot:
                   !!merge <<: *TypeStringBool
                   description: |

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
@@ -88,6 +88,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -271,6 +276,38 @@ spec:
                     Works as the following:
                      - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.
                      - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                suspend: &TypeStringBool
+                  type: string
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                   enum:
                     # List StringBoolXXX constants from model
                     - ""

--- a/deploy/helm/clickhouse-operator/templates/generated/ServiceAccount-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ServiceAccount-clickhouse-operator.yaml
@@ -13,7 +13,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -99,6 +99,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -315,6 +320,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -1379,6 +1391,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -1595,6 +1612,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -3111,6 +3135,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -3319,6 +3348,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -88,6 +88,10 @@ spec:
       type: date
       description: Age of the resource
       JSONPath: .metadata.creationTimestamp
+    - name: suspend
+      type: string
+      description: Suspend reconciliation
+      JSONPath: .spec.suspend
   subresources:
     status: {}
   validation:
@@ -304,6 +308,13 @@ spec:
               enum:
                 - ""
                 - "RollingUpdate"
+            suspend:
+              !!merge <<: *TypeStringBool
+              description: |
+                Suspend reconciliation of resources managed by a ClickHouse Installation.
+                Works as the following:
+                 - When `suspend` is `true` operator stops reconciling all resources.
+                 - When `suspend` is `false` or not set, operator reconciles all resources.
             troubleshoot:
               !!merge <<: *TypeStringBool
               description: |
@@ -1359,6 +1370,10 @@ spec:
       type: date
       description: Age of the resource
       JSONPath: .metadata.creationTimestamp
+    - name: suspend
+      type: string
+      description: Suspend reconciliation
+      JSONPath: .spec.suspend
   validation:
     openAPIV3Schema:
       description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters"
@@ -1573,6 +1588,13 @@ spec:
               enum:
                 - ""
                 - "RollingUpdate"
+            suspend:
+              !!merge <<: *TypeStringBool
+              description: |
+                Suspend reconciliation of resources managed by a ClickHouse Installation.
+                Works as the following:
+                 - When `suspend` is `true` operator stops reconciling all resources.
+                 - When `suspend` is `false` or not set, operator reconciles all resources.
             troubleshoot:
               !!merge <<: *TypeStringBool
               description: |
@@ -3074,6 +3096,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -3282,6 +3309,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  !!merge <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |
@@ -3835,7 +3869,6 @@ metadata:
   namespace: kube-system
   labels:
     clickhouse.altinity.com/chop: 0.24.3
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -92,6 +92,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -308,6 +313,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -1372,6 +1384,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -1588,6 +1605,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -3104,6 +3128,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -3312,6 +3341,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -88,6 +88,10 @@ spec:
       type: date
       description: Age of the resource
       JSONPath: .metadata.creationTimestamp
+    - name: suspend
+      type: string
+      description: Suspend reconciliation
+      JSONPath: .spec.suspend
   subresources:
     status: {}
   validation:
@@ -304,6 +308,13 @@ spec:
               enum:
                 - ""
                 - "RollingUpdate"
+            suspend:
+              !!merge <<: *TypeStringBool
+              description: |
+                Suspend reconciliation of resources managed by a ClickHouse Installation.
+                Works as the following:
+                 - When `suspend` is `true` operator stops reconciling all resources.
+                 - When `suspend` is `false` or not set, operator reconciles all resources.
             troubleshoot:
               !!merge <<: *TypeStringBool
               description: |
@@ -1359,6 +1370,10 @@ spec:
       type: date
       description: Age of the resource
       JSONPath: .metadata.creationTimestamp
+    - name: suspend
+      type: string
+      description: Suspend reconciliation
+      JSONPath: .spec.suspend
   validation:
     openAPIV3Schema:
       description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters"
@@ -1573,6 +1588,13 @@ spec:
               enum:
                 - ""
                 - "RollingUpdate"
+            suspend:
+              !!merge <<: *TypeStringBool
+              description: |
+                Suspend reconciliation of resources managed by a ClickHouse Installation.
+                Works as the following:
+                 - When `suspend` is `true` operator stops reconciling all resources.
+                 - When `suspend` is `false` or not set, operator reconciles all resources.
             troubleshoot:
               !!merge <<: *TypeStringBool
               description: |
@@ -3074,6 +3096,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -3282,6 +3309,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  !!merge <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |
@@ -3835,7 +3869,6 @@ metadata:
   namespace: ${OPERATOR_NAMESPACE}
   labels:
     clickhouse.altinity.com/chop: 0.24.3
-
 # Template Parameters:
 #
 # NAMESPACE=${OPERATOR_NAMESPACE}

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -92,6 +92,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -308,6 +313,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -1372,6 +1384,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -1588,6 +1605,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -3104,6 +3128,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -3312,6 +3341,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -99,6 +99,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -315,6 +320,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -1379,6 +1391,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -1595,6 +1612,13 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   <<: *TypeStringBool
                   description: |
@@ -3111,6 +3135,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -3319,6 +3348,13 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |

--- a/deploy/operator/parts/crd.yaml
+++ b/deploy/operator/parts/crd.yaml
@@ -92,6 +92,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -308,6 +313,38 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   type: string
                   enum:
@@ -1997,6 +2034,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -2213,6 +2255,38 @@ spec:
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   type: string
                   enum:
@@ -4523,6 +4597,11 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
@@ -4731,6 +4810,38 @@ spec:
                     - "disabled"
                     - "Enabled"
                     - "enabled"
+                suspend:
+                  type: string
+                  enum:
+                    # List StringBoolXXX constants from model
+                    - ""
+                    - "0"
+                    - "1"
+                    - "False"
+                    - "false"
+                    - "True"
+                    - "true"
+                    - "No"
+                    - "no"
+                    - "Yes"
+                    - "yes"
+                    - "Off"
+                    - "off"
+                    - "On"
+                    - "on"
+                    - "Disable"
+                    - "disable"
+                    - "Enable"
+                    - "enable"
+                    - "Disabled"
+                    - "disabled"
+                    - "Enabled"
+                    - "enabled"
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Keeper.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all keeper resources.
+                     - When `suspend` is `false` or not set, operator reconciles all keeper resources.
                 namespaceDomainPattern:
                   type: string
                   description: |

--- a/pkg/apis/clickhouse-keeper.altinity.com/v1/type_spec.go
+++ b/pkg/apis/clickhouse-keeper.altinity.com/v1/type_spec.go
@@ -23,6 +23,7 @@ import (
 type ChkSpec struct {
 	TaskID                 *types.String       `json:"taskID,omitempty"                 yaml:"taskID,omitempty"`
 	NamespaceDomainPattern *types.String       `json:"namespaceDomainPattern,omitempty" yaml:"namespaceDomainPattern,omitempty"`
+	Suspend                *types.StringBool   `json:"suspend,omitempty"                yaml:"suspend,omitempty"`
 	Reconciling            *apiChi.Reconciling `json:"reconciling,omitempty"            yaml:"reconciling,omitempty"`
 	Defaults               *apiChi.Defaults    `json:"defaults,omitempty"               yaml:"defaults,omitempty"`
 	Configuration          *Configuration      `json:"configuration,omitempty"          yaml:"configuration,omitempty"`
@@ -91,12 +92,18 @@ func (spec *ChkSpec) MergeFrom(from *ChkSpec, _type apiChi.MergeType) {
 		if !spec.NamespaceDomainPattern.HasValue() {
 			spec.NamespaceDomainPattern = spec.NamespaceDomainPattern.MergeFrom(from.NamespaceDomainPattern)
 		}
+		if !spec.Suspend.HasValue() {
+			spec.Suspend = spec.Suspend.MergeFrom(from.Suspend)
+		}
 	case apiChi.MergeTypeOverrideByNonEmptyValues:
 		if from.HasTaskID() {
 			spec.TaskID = spec.TaskID.MergeFrom(from.TaskID)
 		}
 		if from.NamespaceDomainPattern.HasValue() {
 			spec.NamespaceDomainPattern = spec.NamespaceDomainPattern.MergeFrom(from.NamespaceDomainPattern)
+		}
+		if spec.Suspend.HasValue() {
+			spec.Suspend = spec.Suspend.MergeFrom(from.Suspend)
 		}
 	}
 

--- a/pkg/apis/clickhouse-keeper.altinity.com/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/clickhouse-keeper.altinity.com/v1/zz_generated.deepcopy.go
@@ -293,6 +293,11 @@ func (in *ChkSpec) DeepCopyInto(out *ChkSpec) {
 		*out = new(types.String)
 		**out = **in
 	}
+	if in.Suspend != nil {
+		in, out := &in.Suspend, &out.Suspend
+		*out = new(types.StringBool)
+		**out = **in
+	}
 	if in.Reconciling != nil {
 		in, out := &in.Reconciling, &out.Reconciling
 		*out = new(clickhousealtinitycomv1.Reconciling)

--- a/pkg/apis/clickhouse.altinity.com/v1/type_spec.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_spec.go
@@ -24,6 +24,7 @@ type ChiSpec struct {
 	Stop                   *types.StringBool `json:"stop,omitempty"                   yaml:"stop,omitempty"`
 	Restart                *types.String     `json:"restart,omitempty"                yaml:"restart,omitempty"`
 	Troubleshoot           *types.StringBool `json:"troubleshoot,omitempty"           yaml:"troubleshoot,omitempty"`
+	Suspend                *types.StringBool `json:"suspend,omitempty"                yaml:"suspend,omitempty"`
 	NamespaceDomainPattern *types.String     `json:"namespaceDomainPattern,omitempty" yaml:"namespaceDomainPattern,omitempty"`
 	Templating             *ChiTemplating    `json:"templating,omitempty"             yaml:"templating,omitempty"`
 	Reconciling            *Reconciling      `json:"reconciling,omitempty"            yaml:"reconciling,omitempty"`
@@ -132,6 +133,9 @@ func (spec *ChiSpec) MergeFrom(from *ChiSpec, _type MergeType) {
 		if !spec.NamespaceDomainPattern.HasValue() {
 			spec.NamespaceDomainPattern = spec.NamespaceDomainPattern.MergeFrom(from.NamespaceDomainPattern)
 		}
+		if !spec.Suspend.HasValue() {
+			spec.Suspend = spec.Suspend.MergeFrom(from.Suspend)
+		}
 	case MergeTypeOverrideByNonEmptyValues:
 		if from.HasTaskID() {
 			spec.TaskID = spec.TaskID.MergeFrom(from.TaskID)
@@ -150,6 +154,10 @@ func (spec *ChiSpec) MergeFrom(from *ChiSpec, _type MergeType) {
 		}
 		if from.NamespaceDomainPattern.HasValue() {
 			spec.NamespaceDomainPattern = spec.NamespaceDomainPattern.MergeFrom(from.NamespaceDomainPattern)
+		}
+		if from.Suspend.HasValue() {
+			// Override by non-empty values only
+			spec.Suspend = from.Suspend
 		}
 	}
 

--- a/pkg/apis/clickhouse.altinity.com/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/zz_generated.deepcopy.go
@@ -305,6 +305,11 @@ func (in *ChiSpec) DeepCopyInto(out *ChiSpec) {
 		*out = new(types.StringBool)
 		**out = **in
 	}
+	if in.Suspend != nil {
+		in, out := &in.Suspend, &out.Suspend
+		*out = new(types.StringBool)
+		**out = **in
+	}
 	if in.NamespaceDomainPattern != nil {
 		in, out := &in.NamespaceDomainPattern, &out.NamespaceDomainPattern
 		*out = new(types.String)

--- a/pkg/controller/chi/controller_test.go
+++ b/pkg/controller/chi/controller_test.go
@@ -1,0 +1,47 @@
+package chi
+
+import (
+	"testing"
+
+	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+	"github.com/altinity/clickhouse-operator/pkg/chop"
+)
+
+func init() {
+	chop.New(nil, nil, "")
+}
+
+func Test_shouldEnqueue(t *testing.T) {
+	tests := []struct {
+		name string
+		chi  *api.ClickHouseInstallation
+		want bool
+	}{
+		{
+			name: "skips when chi is suspended",
+			chi: &api.ClickHouseInstallation{
+				Spec: api.ChiSpec{
+					Suspend: types.NewStringBool(true),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enqueues when chi is not suspended",
+			chi: &api.ClickHouseInstallation{
+				Spec: api.ChiSpec{
+					Suspend: types.NewStringBool(false),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldEnqueue(tt.chi); got != tt.want {
+				t.Errorf("shouldEnqueue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/chk/worker-chk-reconciler.go
+++ b/pkg/controller/chk/worker-chk-reconciler.go
@@ -43,6 +43,11 @@ func (w *worker) reconcileCR(ctx context.Context, old, new *apiChk.ClickHouseKee
 		return nil
 	}
 
+	if new.Spec.Suspend.Value() {
+		log.V(2).M(new).F().Info("CR is suspended, skip reconcile")
+		return nil
+	}
+
 	w.a.M(new).S().P()
 	defer w.a.M(new).E().P()
 


### PR DESCRIPTION
For ClickHouse technical maintenance or debugging, it would be ideal to suspend reconciliation. For our use-case, we plan on suspending CRs during Blue/Green cluster upgrades, so as we move workloads from one cluster to another (one namespace at a time), we would need the operator to suspend any reconciliation and only resume once the namespace is fully migrated to the new cluster

Closes https://github.com/Altinity/clickhouse-operator/issues/1433

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
