### PR TITLE
allow trigger helm release after edit releases, not only publish 0.24.1

### DIFF
--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -2,7 +2,9 @@ name: release_chart
 
 on:
   release:
-    types: [ published ]
+    types:
+    - published
+    - edited
 
 jobs:
   release_chart:
@@ -27,6 +29,7 @@ jobs:
         run: cr package deploy/helm/clickhouse-operator
 
       - name: Get Release Assets
+        id: get_assets
         run: |
           CHART_PATH=$(ls .cr-release-packages/altinity-clickhouse-operator-*.tgz)
           ASSET_NAME=$(basename ${CHART_PATH})
@@ -41,7 +44,7 @@ jobs:
         if: steps.get_assets.outputs.asset_id != ''
         run: |
           curl -X DELETE -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository
+          "https://api.github.com/repos/${{ github.repository }}
 
       - name: Upload Release Artifacts
         run: |


### PR DESCRIPTION
fix #1584 