### PR TITLE
feat(helm): add namespace override capability for multi-namespace deployments

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/_helpers.tpl
+++ b/deploy/helm/clickhouse-operator/templates/_helpers.tpl
@@ -1,5 +1,16 @@
 {{/* vim: set filetype=go-template: */}}
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "altinity-clickhouse-operator.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "altinity-clickhouse-operator.name" -}}

--- a/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
+++ b/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "altinity-clickhouse-operator.fullname" . }}-dashboards
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels:
     {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 {{- if .Values.dashboards.additionalLabels }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ClusterRole-clickhouse-operator-kube-system.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ClusterRole-clickhouse-operator-kube-system.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ include "altinity-clickhouse-operator.fullname" . }}
   #namespace: kube-system
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
 rules:
   #
   # Core API group

--- a/deploy/helm/clickhouse-operator/templates/generated/ClusterRoleBinding-clickhouse-operator-kube-system.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ClusterRoleBinding-clickhouse-operator-kube-system.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ include "altinity-clickhouse-operator.fullname" . }}
   #namespace: kube-system
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -19,5 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
 {{- end }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-confd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-confd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-confd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.confdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-configd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-configd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-configd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.configdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.files) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-templatesd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-templatesd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-templatesd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.templatesdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-usersd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-usersd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-usersd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.usersdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-confd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-confd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-keeper-confd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperConfdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-configd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-configd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-keeper-configd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperConfigdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-templatesd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-templatesd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-keeper-templatesd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperTemplatesdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-usersd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-usersd-files.yaml
@@ -8,6 +8,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-keeper-usersd-files" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperUsersdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
@@ -13,7 +13,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ include "altinity-clickhouse-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 spec:
   replicas: 1

--- a/deploy/helm/clickhouse-operator/templates/generated/Secret-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Secret-clickhouse-operator.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "altinity-clickhouse-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 type: Opaque
 data:

--- a/deploy/helm/clickhouse-operator/templates/generated/Service-clickhouse-operator-metrics.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Service-clickhouse-operator-metrics.yaml
@@ -12,7 +12,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ printf "%s-metrics" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
 spec:
   ports:

--- a/deploy/helm/clickhouse-operator/templates/generated/ServiceAccount-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ServiceAccount-clickhouse-operator.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 

--- a/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ printf "%s-clickhouse-metrics" (include "altinity-clickhouse-operator.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels:
     {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   {{- if .Values.serviceMonitor.additionalLabels }}

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -1,3 +1,5 @@
+namespaceOverride: ""
+
 operator:
   image:
     # operator.image.repository -- image repository
@@ -755,13 +757,13 @@ additionalResources: []
 #    kind: ConfigMap
 #    metadata:
 #      name: {{ include "altinity-clickhouse-operator.fullname" . }}-cm
-#      namespace: {{ .Release.Namespace }}
+#      namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
 #  - |
 #     apiVersion: v1
 #     kind: Secret
 #     metadata:
 #       name: {{ include "altinity-clickhouse-operator.fullname" . }}-s
-#       namespace: {{ .Release.Namespace }}
+#       namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
 #     stringData:
 #       mykey: my-value
 #  - |
@@ -769,7 +771,7 @@ additionalResources: []
 #     kind: ClickHouseInstallation
 #     metadata:
 #       name: {{ include "altinity-clickhouse-operator.fullname" . }}-chi
-#       namespace: {{ .Release.Namespace }}
+#       namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
 #     spec:
 #       configuration:
 #         clusters:

--- a/dev/generate_helm_chart.sh
+++ b/dev/generate_helm_chart.sh
@@ -162,7 +162,7 @@ function update_service_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ printf \"%s-metrics\" (include \"altinity-clickhouse-operator.fullname\" .) }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ .Release.Namespace }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
   yq e -i '.spec.selector |= "{{ include \"altinity-clickhouse-operator.selectorLabels\" . | nindent 4 }}"' "${file}"
 
@@ -179,7 +179,7 @@ function update_deployment_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ .Release.Namespace }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
   yq e -i '.spec.selector.matchLabels |= "{{ include \"altinity-clickhouse-operator.selectorLabels\" . | nindent 6 }}"' "${file}"
 
@@ -252,7 +252,7 @@ function update_configmap_resource() {
   camel_cased_name=$(to_camel_case "${name_suffix}")
 
   yq e -i '.metadata.name |= "{{ printf \"%s-'"${name_suffix}"'\" (include \"altinity-clickhouse-operator.fullname\" .) }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ .Release.Namespace }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
   yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-data\" (list . .Values.configs.'"${camel_cased_name}"') | nindent 2 }}"' "${file}"
 
@@ -275,10 +275,10 @@ function update_clusterrolebinding_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ .Release.Namespace }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
   yq e -i '.roleRef.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '(.subjects[] | select(.kind == "ServiceAccount")) |= with(. ; .name = "{{ include \"altinity-clickhouse-operator.serviceAccountName\" . }}" | .namespace = "{{ .Release.Namespace }}")' "${file}"
+  yq e -i '(.subjects[] | select(.kind == "ServiceAccount")) |= with(. ; .name = "{{ include \"altinity-clickhouse-operator.serviceAccountName\" . }}" | .namespace = "{{ include "altinity-clickhouse-operator.namespace" . }}")' "${file}"
 
   printf '%s\n%s\n' '{{- if .Values.rbac.create -}}' "$(cat "${file}")" >"${file}"
   printf '%s\n%s\n' "$(cat "${file}")" '{{- end }}' >"${file}"
@@ -296,7 +296,7 @@ function update_clusterrole_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ .Release.Namespace }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
 
   yq e -i '(.rules[] | select(.resourceNames | contains(["clickhouse-operator"])) | .resourceNames) = ["{{ include \"altinity-clickhouse-operator.fullname\" . }}"]' "${file}"
@@ -317,7 +317,7 @@ function update_serviceaccount_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.serviceAccountName\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ .Release.Namespace }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
   yq e -i '.metadata.annotations |= "{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}"' "${file}"
 
@@ -337,7 +337,7 @@ function update_secret_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ .Release.Namespace }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
 
   yq e -i '.data.username |= "{{ .Values.secret.username | b64enc }}"' "${file}"


### PR DESCRIPTION
Adds a new helper template "altinity-clickhouse-operator.namespace" that allows overriding the release namespace via Values.namespaceOverride. Updates all resource templates to use this helper instead of directly referencing .Release.Namespace. This change enables multi-namespace deployments in combined charts while maintaining backward compatibility.
