### PR TITLE
Fixing warnings in cicd for tests.

### DIFF
--- a/tests/e2e/kubectl.py
+++ b/tests/e2e/kubectl.py
@@ -458,7 +458,7 @@ def get_default_storage_class(ns=None):
     out = launch(
         f"get storageclass "
         f"-o=custom-columns="
-        f'DEFAULT:".metadata.annotations.storageclass\.kubernetes\.io/is-default-class",NAME:.metadata.name',
+        r'DEFAULT:".metadata.annotations.storageclass\.kubernetes\.io/is-default-class",NAME:.metadata.name',
         ns=ns,
     ).splitlines()
     for line in out[1:]:
@@ -468,7 +468,7 @@ def get_default_storage_class(ns=None):
     out = launch(
         f"get storageclass "
         f"-o=custom-columns="
-        f'DEFAULT:".metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class",NAME:.metadata.name',
+        r'DEFAULT:".metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class",NAME:.metadata.name',
         ns=ns,
     ).splitlines()
     for line in out[1:]:

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -2880,7 +2880,7 @@ def test_025(self):
         kubectl.wait_field(
             "pod",
             "chi-test-025-rescaling-default-0-1-0",
-            ".metadata.labels.clickhouse\.altinity\.com/ready",
+            r".metadata.labels.clickhouse\.altinity\.com/ready",
             "yes",
             backoff=1,
         )
@@ -5181,9 +5181,9 @@ def test_053(self):
         time.sleep(10)
 
         with Then("Pod annotation kubectl.kubernetes.io/restartedAt should be populated"):
-            assert kubectl.get_field("pod", pod, ".metadata.annotations.kubectl\.kubernetes\.io/restartedAt") != "<none>"
+            assert kubectl.get_field("pod", pod, r".metadata.annotations.kubectl\.kubernetes\.io/restartedAt") != "<none>"
         with And("PodTemplate annotation kubectl.kubernetes.io/restartedAt should be populated"):
-            assert kubectl.get_field("statefulset", sts, ".spec.template.metadata.annotations.kubectl\.kubernetes\.io/restartedAt") != "<none>"
+            assert kubectl.get_field("statefulset", sts, r".spec.template.metadata.annotations.kubectl\.kubernetes\.io/restartedAt") != "<none>"
 
         start_time = kubectl.get_field("pod", pod, ".status.startTime")
 


### PR DESCRIPTION
Fixing SyntaxWarnings in the tests.

```
/home/runner/work/clickhouse-operator/clickhouse-operator/tests/e2e/kubectl.py:461: SyntaxWarning: invalid escape sequence '\.'
  f'DEFAULT:".metadata.annotations.storageclass\.kubernetes\.io/is-default-class",NAME:.metadata.name',
/home/runner/work/clickhouse-operator/clickhouse-operator/tests/e2e/kubectl.py:471: SyntaxWarning: invalid escape sequence '\.'
  f'DEFAULT:".metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class",NAME:.metadata.name',
/home/runner/work/clickhouse-operator/clickhouse-operator/tests/e2e/test_operator.py:2883: SyntaxWarning: invalid escape sequence '\.'
  ".metadata.labels.clickhouse\.altinity\.com/ready",
/home/runner/work/clickhouse-operator/clickhouse-operator/tests/e2e/test_operator.py:5184: SyntaxWarning: invalid escape sequence '\.'
  assert kubectl.get_field("pod", pod, ".metadata.annotations.kubectl\.kubernetes\.io/restartedAt") != "<none>"
/home/runner/work/clickhouse-operator/clickhouse-operator/tests/e2e/test_operator.py:5186: SyntaxWarning: invalid escape sequence '\.'
  assert kubectl.get_field("statefulset", sts, ".spec.template.metadata.annotations.kubectl\.kubernetes\.io/restartedAt") != "<none>"
  ```