### PR TITLE
fixing a typo in keeper prometheus alert

### DIFF
--- a/deploy/prometheus/prometheus-alert-rules-chkeeper.yaml
+++ b/deploy/prometheus/prometheus-alert-rules-chkeeper.yaml
@@ -11,7 +11,7 @@ spec:
     - name: ClickHouseKeeperRules
       rules:
         - alert: ClickHouseKeeperDown
-          expr: up{app=~'clickhouse-keeper.*'} == 0 or zk_ruok{app=~'clickhouse-keeeper.*'} == 0
+          expr: up{app=~'clickhouse-keeper.*'} == 0 or zk_ruok{app=~'clickhouse-keeper.*'} == 0
           labels:
             severity: critical
           annotations:


### PR DESCRIPTION
Fixing a mistyped name in the Keeper alerts that ships with the default rules pack.