### PR TITLE
Add common labels and annotations to all resources

### DIFF
--- a/deploy/helm/clickhouse-operator/README.md
+++ b/deploy/helm/clickhouse-operator/README.md
@@ -28,6 +28,8 @@ For upgrade please install CRDs separately:
 |-----|------|---------|-------------|
 | additionalResources | list | `[]` | list of additional resources to create (processed via `tpl` function), useful for create ClickHouse clusters together with clickhouse-operator. check `kubectl explain chi` for details |
 | affinity | object | `{}` | affinity for scheduler pod assignment, check `kubectl explain pod.spec.affinity` for details |
+| commonAnnotations | object | `{}` | set of annotations that will be applied to all the resources for the operator |
+| commonLabels | object | `{}` | set of labels that will be applied to all the resources for the operator |
 | configs | object | check the `values.yaml` file for the config content (auto-generated from latest operator release) | clickhouse operator configs |
 | dashboards.additionalLabels | object | `{"grafana_dashboard":""}` | labels to add to a secret with dashboards |
 | dashboards.annotations | object | `{}` | annotations to add to a secret with dashboards |
@@ -43,6 +45,7 @@ For upgrade please install CRDs separately:
 | metrics.image.tag | string | `""` | image tag (chart's appVersion value will be used if not set) |
 | metrics.resources | object | `{}` | custom resource configuration |
 | nameOverride | string | `""` | override name of the chart |
+| namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` | node for scheduler pod assignment, check `kubectl explain pod.spec.nodeSelector` for details |
 | operator.containerSecurityContext | object | `{}` |  |
 | operator.env | list | `[]` | additional environment variables for the clickhouse-operator container in deployment possible format value `[{"name": "SAMPLE", "value": "text"}]` |

--- a/deploy/helm/clickhouse-operator/templates/_helpers.tpl
+++ b/deploy/helm/clickhouse-operator/templates/_helpers.tpl
@@ -51,8 +51,8 @@ helm.sh/chart: {{ include "altinity-clickhouse-operator.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
@@ -63,6 +63,17 @@ Selector labels
 {{- define "altinity-clickhouse-operator.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "altinity-clickhouse-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Common annotations
+*/}}
+{{- define "altinity-clickhouse-operator.annotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name }}
+meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+{{- if .Values.commonAnnotations }}
+{{ toYaml .Values.commonAnnotations }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
+++ b/deploy/helm/clickhouse-operator/templates/dashboards-configmap.yaml
@@ -6,13 +6,14 @@ metadata:
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels:
     {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-{{- if .Values.dashboards.additionalLabels }}
+    {{- if .Values.dashboards.additionalLabels }}
     {{- toYaml .Values.dashboards.additionalLabels | nindent 4 }}
-{{- end }}
-{{- with .Values.dashboards.annotations }}
+    {{- end }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
+    {{- if .Values.dashboards.annotations }}
+    {{- toYaml .Values.dashboards.annotations | nindent 4 }}
+    {{- end }}
 data:
 {{- range $path, $_ := .Files.Glob "files/*.json" }}
   {{ $path | trimPrefix "files/" }}: |- {{ $.Files.Get $path | nindent 4 -}}

--- a/deploy/helm/clickhouse-operator/templates/generated/ClusterRole-clickhouse-operator-kube-system.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ClusterRole-clickhouse-operator-kube-system.yaml
@@ -13,6 +13,7 @@ metadata:
   #namespace: kube-system
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 rules:
   #
   # Core API group

--- a/deploy/helm/clickhouse-operator/templates/generated/ClusterRoleBinding-clickhouse-operator-kube-system.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ClusterRoleBinding-clickhouse-operator-kube-system.yaml
@@ -12,6 +12,7 @@ metadata:
   #namespace: kube-system
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-confd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-confd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-confd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.confdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-configd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-configd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-configd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.configdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.files) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-templatesd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-templatesd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-templatesd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.templatesdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-usersd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-usersd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-usersd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.usersdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-confd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-confd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-keeper-confd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperConfdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-configd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-configd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-keeper-configd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperConfigdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-templatesd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-templatesd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-keeper-templatesd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperTemplatesdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-usersd-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-keeper-operator-usersd-files.yaml
@@ -10,4 +10,5 @@ metadata:
   name: {{ printf "%s-keeper-usersd-files" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.keeperUsersdFiles) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
@@ -15,15 +15,16 @@ metadata:
   name: {{ include "altinity-clickhouse-operator.fullname" . }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels: {{ include "altinity-clickhouse-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 8 }}
+      labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 8 }}{{ if .Values.podLabels }}{{ toYaml .Values.podLabels | nindent 8 }}{{ end }}
       annotations:
-        {{ toYaml .Values.podAnnotations | nindent 8 }}
+        {{ if .Values.podAnnotations }}{{ toYaml .Values.podAnnotations | nindent 8 }}{{ end }}
         checksum/files: {{ include (print $.Template.BasePath "/generated/ConfigMap-etc-clickhouse-operator-files.yaml") . | sha256sum }}
         checksum/confd-files: {{ include (print $.Template.BasePath "/generated/ConfigMap-etc-clickhouse-operator-confd-files.yaml") . | sha256sum }}
         checksum/configd-files: {{ include (print $.Template.BasePath "/generated/ConfigMap-etc-clickhouse-operator-configd-files.yaml") . | sha256sum }}

--- a/deploy/helm/clickhouse-operator/templates/generated/Secret-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Secret-clickhouse-operator.yaml
@@ -13,6 +13,7 @@ metadata:
   name: {{ include "altinity-clickhouse-operator.fullname" . }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 type: Opaque
 data:
   username: {{ .Values.secret.username | b64enc }}

--- a/deploy/helm/clickhouse-operator/templates/generated/Service-clickhouse-operator-metrics.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Service-clickhouse-operator-metrics.yaml
@@ -14,6 +14,7 @@ metadata:
   name: {{ printf "%s-metrics" (include "altinity-clickhouse-operator.fullname" .) }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 spec:
   ports:
     - port: 8888

--- a/deploy/helm/clickhouse-operator/templates/generated/ServiceAccount-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ServiceAccount-clickhouse-operator.yaml
@@ -12,8 +12,7 @@ metadata:
   name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
-
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}{{ if .Values.serviceAccount.annotations }}{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}{{ end }}
 # Template Parameters:
 #
 # NAMESPACE=kube-system

--- a/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
@@ -6,9 +6,10 @@ metadata:
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels:
     {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
-  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
-  {{- end }}
+    {{- end }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 spec:
   endpoints:
     - port: clickhouse-metrics # 8888

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -1,5 +1,8 @@
 namespaceOverride: ""
-
+# commonLabels -- set of labels that will be applied to all the resources for the operator
+commonLabels: {}
+# commonAnnotations -- set of annotations that will be applied to all the resources for the operator
+commonAnnotations: {}
 operator:
   image:
     # operator.image.repository -- image repository

--- a/dev/generate_helm_chart.sh
+++ b/dev/generate_helm_chart.sh
@@ -162,8 +162,9 @@ function update_service_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ printf \"%s-metrics\" (include \"altinity-clickhouse-operator.fullname\" .) }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
+  yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
   yq e -i '.spec.selector |= "{{ include \"altinity-clickhouse-operator.selectorLabels\" . | nindent 4 }}"' "${file}"
 
   perl -pi -e "s/'//g" "${file}"
@@ -179,16 +180,17 @@ function update_deployment_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
+  yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
   yq e -i '.spec.selector.matchLabels |= "{{ include \"altinity-clickhouse-operator.selectorLabels\" . | nindent 6 }}"' "${file}"
 
   readonly annotations=$(yq e '.spec.template.metadata.annotations' "${file}")
   a_data="${annotations}" yq e -i '.podAnnotations |= env(a_data)' "${values_yaml}"
   yq e -i '.spec.template.metadata.annotations = {}' "${file}"
 
-  yq e -i '.spec.template.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 8 }}"' "${file}"
-  yq e -i '.spec.template.metadata.annotations += {"{{ toYaml .Values.podAnnotations | nindent 8 }}": null}' "${file}"
+  yq e -i '.spec.template.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 8 }}{{ if .Values.podLabels }}{{ toYaml .Values.podLabels | nindent 8 }}{{ end }}"' "${file}"
+  yq e -i '.spec.template.metadata.annotations += {"{{ if .Values.podAnnotations }}{{ toYaml .Values.podAnnotations | nindent 8 }}{{ end }}": null}' "${file}"
   yq e -i '.spec.template.spec.imagePullSecrets |= "{{ toYaml .Values.imagePullSecrets | nindent 8 }}"' "${file}"
   yq e -i '.spec.template.spec.serviceAccountName |= "{{ include \"altinity-clickhouse-operator.serviceAccountName\" . }}"' "${file}"
   yq e -i '.spec.template.spec.nodeSelector |= "{{ toYaml .Values.nodeSelector | nindent 8 }}"' "${file}"
@@ -206,7 +208,7 @@ function update_deployment_resource() {
     cmName="${cmName/etc-keeper-operator-/keeper-}"
     yq e -i '.spec.template.metadata.annotations += {"checksum/'"${cmName}"'": "{{ include (print $.Template.BasePath \"/generated/ConfigMap-'"${cm}"'.yaml\") . | sha256sum }}"}' "${file}"
   done
-
+  
   yq e -i '.spec.template.spec.containers[0].name |= "{{ .Chart.Name }}"' "${file}"
   yq e -i '.spec.template.spec.containers[0].image |= "{{ .Values.operator.image.repository }}:{{ include \"altinity-clickhouse-operator.operator.tag\" . }}"' "${file}"
   yq e -i '.spec.template.spec.containers[0].imagePullPolicy |= "{{ .Values.operator.image.pullPolicy }}"' "${file}"
@@ -222,7 +224,7 @@ function update_deployment_resource() {
   yq e -i '(.spec.template.spec.containers[1].env[] | select(.valueFrom.resourceFieldRef.containerName == "clickhouse-operator") | .valueFrom.resourceFieldRef.containerName) = "{{ .Chart.Name }}"' "${file}"
   yq e -i '.spec.template.spec.containers[1].env += ["{{ with .Values.metrics.env }}{{ toYaml . | nindent 12 }}{{ end }}"]' "${file}"
 
-  perl -pi -e "s/'{{ toYaml .Values.podAnnotations \| nindent 8 }}': null/{{ toYaml .Values.podAnnotations \| nindent 8 }}/g" "${file}"
+  perl -pi -e "s/'{{ if .Values.podAnnotations }}{{ toYaml .Values.podAnnotations \| nindent 8 }}{{ end }}': null/{{ if .Values.podAnnotations }}{{ toYaml .Values.podAnnotations \| nindent 8 }}{{ end }}/g" "${file}"
   perl -pi -e "s/- '{{ with .Values.operator.env }}{{ toYaml . \| nindent 12 }}{{ end }}'/{{ with .Values.operator.env }}{{ toYaml . \| nindent 12 }}{{ end }}/g" "${file}"
   perl -pi -e "s/- '{{ with .Values.metrics.env }}{{ toYaml . \| nindent 12 }}{{ end }}'/{{ with .Values.metrics.env }}{{ toYaml . \| nindent 12 }}{{ end }}/g" "${file}"
   perl -pi -e 's/(\s+\- name: metrics-exporter)/{{ if .Values.metrics.enabled }}\n$1/g' "${file}"
@@ -235,7 +237,7 @@ function update_configmap_resource() {
   readonly name=$(yq e '.metadata.name' "${file}")
   local data
   data=$(yq e '.data' "${file}")
-
+  
   if [ "${name}" = "etc-clickhouse-operator-files" ]; then
     local search='name: "clickhouse-operator"'
     local replace="name: '{{ include \"altinity-clickhouse-operator.fullname\" . }}'"
@@ -252,8 +254,9 @@ function update_configmap_resource() {
   camel_cased_name=$(to_camel_case "${name_suffix}")
 
   yq e -i '.metadata.name |= "{{ printf \"%s-'"${name_suffix}"'\" (include \"altinity-clickhouse-operator.fullname\" .) }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
+  yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
   yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-data\" (list . .Values.configs.'"${camel_cased_name}"') | nindent 2 }}"' "${file}"
 
   if [ -z "${data}" ]; then
@@ -275,10 +278,11 @@ function update_clusterrolebinding_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
+  yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
   yq e -i '.roleRef.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '(.subjects[] | select(.kind == "ServiceAccount")) |= with(. ; .name = "{{ include \"altinity-clickhouse-operator.serviceAccountName\" . }}" | .namespace = "{{ include "altinity-clickhouse-operator.namespace" . }}")' "${file}"
+  yq e -i '(.subjects[] | select(.kind == "ServiceAccount")) |= with(. ; .name = "{{ include \"altinity-clickhouse-operator.serviceAccountName\" . }}" | .namespace = "{{ include \"altinity-clickhouse-operator.namespace\" . }}")' "${file}"
 
   printf '%s\n%s\n' '{{- if .Values.rbac.create -}}' "$(cat "${file}")" >"${file}"
   printf '%s\n%s\n' "$(cat "${file}")" '{{- end }}' >"${file}"
@@ -296,9 +300,9 @@ function update_clusterrole_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
-
+  yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
   yq e -i '(.rules[] | select(.resourceNames | contains(["clickhouse-operator"])) | .resourceNames) = ["{{ include \"altinity-clickhouse-operator.fullname\" . }}"]' "${file}"
 
   printf '%s\n%s\n' '{{- if .Values.rbac.create -}}' "$(cat "${file}")" >"${file}"
@@ -317,9 +321,9 @@ function update_serviceaccount_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.serviceAccountName\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
-  yq e -i '.metadata.annotations |= "{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}"' "${file}"
+  yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}{{ if .Values.serviceAccount.annotations }}{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}{{ end }}"' "${file}"
 
   printf '%s\n%s\n' '{{- if .Values.serviceAccount.create -}}' "$(cat "${file}")" >"${file}"
   printf '%s\n%s\n' "$(cat "${file}")" '{{- end -}}' >"${file}"
@@ -337,8 +341,9 @@ function update_secret_resource() {
   fi
 
   yq e -i '.metadata.name |= "{{ include \"altinity-clickhouse-operator.fullname\" . }}"' "${file}"
-  yq e -i '.metadata.namespace |= "{{ include "altinity-clickhouse-operator.namespace" . }}"' "${file}"
+  yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
+  yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
 
   yq e -i '.data.username |= "{{ .Values.secret.username | b64enc }}"' "${file}"
   yq e -i '.data.password |= "{{ .Values.secret.password | b64enc }}"' "${file}"


### PR DESCRIPTION
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

This PR contains the following changes:

- Fields for common labels and annotations added to values.yaml. These fields will be used to populate labels and annotations for all the resources generated from the templates and any additional resources like ServiceMonitors, and dashboards configmap.
- podLabels has been removed from common labels helper function and replaced with the new commonLabels field. podLabels and podAnnotations have been added separately to ONLY pod template for operator deployment.
- Helper function for common annotations has been created in helper.tpl and Templates for every resource involved has been updated to take into account of these annotations.
- Readme file has been updated to include two new fields: commonLabels and commonAnnotations
- Updates made to generate_helm_chart.sh to include common labels and annotations changes to all the generated resources
- Fix a bug in the generate_helm_chart.sh where double quotes were not being escaped in `yq` command for namespace fields which caused error in running the script.
- Proper comments for commonLabels and commonAnnotations in values.yaml added to generate correct readme using generate_helm_chart.sh
