### PR TITLE
Edited template for ServiceMonitor

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
@@ -11,24 +11,39 @@ metadata:
     {{- end }}
   annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 spec:
+spec:
   endpoints:
     - port: clickhouse-metrics # 8888
+      {{- with .Values.serviceMonitor.clickhouseMetrics.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.clickhouseMetrics.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.clickhouseMetrics.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.clickhouseMetrics.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     - port: operator-metrics # 9999
+      {{- with .Values.serviceMonitor.operatorMetrics.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.operatorMetrics.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.operatorMetrics.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.operatorMetrics.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   selector:
     matchLabels:
       {{- include "altinity-clickhouse-operator.selectorLabels" . | nindent 6 }}
-  {{- with .Values.serviceMonitor.interval }}
-  interval: {{ . }}
-  {{- end }}
-  {{- with .Values.serviceMonitor.scrapeTimeout }}
-  scrapeTimeout: {{ . }}
-  {{- end }}
-  {{- with .Values.serviceMonitor.relabelings }}
-  relabelings:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  {{- with .Values.serviceMonitor.metricRelabelings }}
-  metricRelabelings:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
 {{- end }}

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -94,17 +94,28 @@ podSecurityContext: {}
 topologySpreadConstraints: []
 serviceMonitor:
   # serviceMonitor.enabled -- ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator)
+  # In serviceMonitor will be created two endpoints clickhouse-metrics on port 8888 and operator-metrics # 9999. Ypu can specify interval, scrapeTimeout, relabelings, metricRelabelings for each endpoint below
   enabled: false
   # serviceMonitor.additionalLabels -- additional labels for service monitor
   additionalLabels: {}
-  # serviceMonitor.interval --
-  interval: 30s
-  # serviceMonitor.scrapeTimeout -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
-  scrapeTimeout: ""
-  # serviceMonitor.relabelings -- Prometheus [RelabelConfigs] to apply to samples before scraping
-  relabelings: []
-  # serviceMonitor.metricRelabelings -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestio
-  metricRelabelings: []
+  clickhouseMetrics:
+    # serviceMonitor.interval for clickhouse-metrics endpoint --
+    interval: 30s
+    # serviceMonitor.scrapeTimeout for clickhouse-metrics endpoint -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+    scrapeTimeout: ""
+    # serviceMonitor.relabelings for clickhouse-metrics endpoint -- Prometheus [RelabelConfigs] to apply to samples before scraping
+    relabelings: []
+    # serviceMonitor.metricRelabelings for clickhouse-metrics endpoint -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestio
+    metricRelabelings: []
+  operatorMetrics:
+    # serviceMonitor.interval for operator-metrics endpoint --
+    interval: 30s
+    # serviceMonitor.scrapeTimeout for operator-metrics endpoint -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+    scrapeTimeout: ""
+    # serviceMonitor.relabelings for operator-metrics endpoint -- Prometheus [RelabelConfigs] to apply to samples before scraping
+    relabelings: []
+    # serviceMonitor.metricRelabelings  for operator-metrics endpoint-- Prometheus [MetricRelabelConfigs] to apply to samples before ingestio
+    metricRelabelings: []    
 # configs -- clickhouse operator configs
 # @default -- check the `values.yaml` file for the config content (auto-generated from latest operator release)
 configs:


### PR DESCRIPTION
Signed-off-by: Anastasiya Lomakova <dnk209@gmail.com>

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.


I've tried to follow test recommendations: `please test and confirm with logs proposed changes works as expected for serviceMonitor with prometheus-operator which we use to test prometheus look ./deploy/prometheus/create-prometheus.sh`

and deployed prom at my minikube with this script. 
The manifest of ServiceMonitor I received:
```
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  annotations:
    meta.helm.sh/release-name: test-cluster
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2025-05-30T07:26:21Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: test-cluster
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: altinity-clickhouse-operator
    app.kubernetes.io/version: 0.25.1
    helm.sh/chart: altinity-clickhouse-operator-0.25.1
  name: test-cluster-altinity-clickhouse-operator-clickhouse-metrics
  namespace: default
  resourceVersion: "4542"
  uid: 31b9a20a-4f26-4a74-9a9e-7e6f369b251f
spec:
  endpoints:
  - interval: 30s
    port: clickhouse-metrics
  - interval: 30s
    port: operator-metrics
  selector:
    matchLabels:
      app.kubernetes.io/instance: test-cluster
      app.kubernetes.io/name: altinity-clickhouse-operator
```

Metrics seemed to be appeared in prom
![image](https://github.com/user-attachments/assets/eff582c4-c71e-40fa-9afe-184d3a68cae0)

I just wonder why just it couldn't be rendered by helm template command? Isn't it the same?
Also I do not now exactly if there is the necessity of dividing relable configs to different endpoint (to be honest I've never saw anyone who uses it) but still I've decided to divide it. 

