### PR TITLE
feat: Automatic CHI reconciliation on operator secret changes

### DIFF
--- a/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
@@ -596,6 +596,9 @@ type OperatorConfig struct {
 	TerminationGracePeriod int `json:"terminationGracePeriod" yaml:"terminationGracePeriod"`
 	// Revision history limit
 	RevisionHistoryLimit int `json:"revisionHistoryLimit" yaml:"revisionHistoryLimit"`
+
+	// Secret hash used to verify that CHOP secret is not changed
+	CHOPSecretHash string `json:"chopSecretHash" yaml:"chopSecretHash"`
 }
 
 // MergeFrom merges
@@ -920,7 +923,6 @@ func (c *OperatorConfig) normalizeSectionClickHouseAccess() {
 	}
 	// Adjust seconds to time.Duration
 	c.ClickHouse.Access.Timeouts.Query = c.ClickHouse.Access.Timeouts.Query * time.Second
-
 }
 
 func (c *OperatorConfig) normalizeSectionClickHouseMetrics() {
@@ -954,15 +956,15 @@ func (c *OperatorConfig) normalizeSectionReconcileRuntime() {
 		c.Reconcile.Runtime.ReconcileShardsMaxConcurrencyPercent = defaultReconcileShardsMaxConcurrencyPercent
 	}
 
-	//reconcileWaitExclude: true
-	//reconcileWaitInclude: false
+	// reconcileWaitExclude: true
+	// reconcileWaitInclude: false
 }
 
 func (c *OperatorConfig) normalizeSectionLabel() {
-	//config.IncludeIntoPropagationAnnotations
-	//config.ExcludeFromPropagationAnnotations
-	//config.IncludeIntoPropagationLabels
-	//config.ExcludeFromPropagationLabels
+	// config.IncludeIntoPropagationAnnotations
+	// config.ExcludeFromPropagationAnnotations
+	// config.IncludeIntoPropagationLabels
+	// config.ExcludeFromPropagationLabels
 	// Whether to append *Scope* labels to StatefulSet and Pod.
 	c.Label.Runtime.AppendScope = c.Label.AppendScopeString.Value()
 }
@@ -1102,11 +1104,11 @@ func (c *OperatorConfig) copyWithHiddenCredentials() *OperatorConfig {
 	if conf.ClickHouse.Config.User.Default.Password != "" {
 		conf.ClickHouse.Config.User.Default.Password = PasswordReplacer
 	}
-	//conf.ClickHouse.Access.Username = UsernameReplacer
+	// conf.ClickHouse.Access.Username = UsernameReplacer
 	if conf.ClickHouse.Access.Password != "" {
 		conf.ClickHouse.Access.Password = PasswordReplacer
 	}
-	//conf.ClickHouse.Access.Secret.Runtime.Username = UsernameReplacer
+	// conf.ClickHouse.Access.Secret.Runtime.Username = UsernameReplacer
 	if conf.ClickHouse.Access.Secret.Runtime.Password != "" {
 		conf.ClickHouse.Access.Secret.Runtime.Password = PasswordReplacer
 	}
@@ -1148,7 +1150,7 @@ func (c *OperatorConfig) GetInformerNamespace() string {
 
 		// This contradicts current implementation of multiple namespaces in config's watchNamespaces field,
 		// but k8s has possibility to specify one/all namespaces only, no 'multiple namespaces' option
-		var labelRegexp = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+		labelRegexp := regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 		if labelRegexp.MatchString(c.Watch.Namespaces[0]) {
 			namespace = c.Watch.Namespaces[0]
 		}

--- a/pkg/controller/chi/worker-status-helpers.go
+++ b/pkg/controller/chi/worker-status-helpers.go
@@ -176,7 +176,11 @@ func (w *worker) isGenerationTheSame(old, new *api.ClickHouseInstallation) bool 
 		return false
 	}
 
-	return old.GetGeneration() == new.GetGeneration()
+	if old.GetGeneration() == new.GetGeneration() {
+		return true
+	}
+
+	return false
 }
 
 // getRemoteServersGeneratorOptions build base set of RemoteServersOptions

--- a/pkg/controller/chk/worker-chk-reconciler.go
+++ b/pkg/controller/chk/worker-chk-reconciler.go
@@ -596,9 +596,7 @@ func (w *worker) reconcileHostPrepare(ctx context.Context, host *api.Host) error
 
 // reconcileHostMain reconciles specified ClickHouse host
 func (w *worker) reconcileHostMain(ctx context.Context, host *api.Host) error {
-	var (
-		reconcileStatefulSetOpts *statefulset.ReconcileOptions
-	)
+	var reconcileStatefulSetOpts *statefulset.ReconcileOptions
 
 	//if !host.IsLast() {
 	//	reconcileStatefulSetOpts = reconcileStatefulSetOpts.SetDoNotWait()


### PR DESCRIPTION
This PR introduces a mechanism to automatically reconcile all ClickHouseInstallations (CHIs) when the operator's configured Kubernetes Secret (specified in `config.yaml` under `clickhouse.access.secret`) is updated.

**Key Changes:**

*   **Secret Watcher & Configuration Update:**
    *   The `ConfigManager` now includes a watcher for the configured ClickHouse access secret (`pkg/chop/config_manager.go`).
    *   When the secret is added, updated, or deleted, the `ConfigManager` updates its internal configuration (username, password) and calculates a SHA256 hash of the secret's data.
    *   This hash (`CHOPSecretHash`) is stored in the `OperatorConfig` (`pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go`).

*   **CHI Reconciliation Trigger:**
    *   A callback mechanism is introduced in `ConfigManager` that gets invoked when the `CHOPSecretHash` changes (`pkg/chop/config_manager.go`).
    *   This callback triggers the `reconcileAllCHIsOnConfigChange` function (`cmd/operator/app/thread_chi.go`).
    *   This function iterates through all CHIs in the watched namespaces and performs the following to trigger a reconciliation:
        *   Adds/Updates an annotation `internal.altinity.com/chop-secret-hash` on the CHI's metadata and its pod templates with the new `chopSecretHash`.
        *   Increments the CHI's `.metadata.generation`.
    *   These changes ensure that the CHI controller detects a change and re-processes the CHI, applying the updated secret credentials.

*   **Action Plan Update:**
    *   The `ActionPlan` (`pkg/model/common/action_plan/action_plan.go`) now also considers changes in annotations when determining if there are actions to be performed. This is necessary for the annotation-based reconciliation trigger to work correctly.

*   **Controller Enhancement:**
    *   The CHI controller (`pkg/controller/chi/controller.go`) is now equipped with a `chiLister` for efficient access to CHI resources when reconciling all CHIs.

**Benefits:**

*   Ensures that ClickHouse clusters managed by the operator promptly pick up changes to their access credentials or other configurations stored in the designated secret, without requiring manual intervention or operator restarts.
*   Improves the security and manageability of the operator by allowing dynamic updates to sensitive information. That allows, for example, the use of [external-secrets](https://external-secrets.io/latest/).

**How to Test:**

1.  Configure the operator to use a Kubernetes secret for ClickHouse access credentials in its `config.yaml`.
2.  Deploy the operator and a CHI.
3.  Modify the data (e.g., password) in the configured Kubernetes secret.
4.  Observe that the operator logs indicate a configuration change and trigger reconciliation for the CHI.
5.  Verify that the CHI's pods are eventually updated/restarted to use the new credentials (depending on how the CHI is configured to use the secret).

**Caveats**

For this reconciliation to happen, the ClickHouse pods needs to be restarted. A future update might change that.