### PR TITLE
fix: proper place for ServiceMonitor endpoints scrape timings

### DIFF
--- a/deploy/helm/clickhouse-operator/Chart.yaml
+++ b/deploy/helm/clickhouse-operator/Chart.yaml
@@ -13,8 +13,8 @@ description: |-
     kubectl apply -f https://github.com/Altinity/clickhouse-operator/raw/master/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
   ```
 type: application
-version: 0.25.0
-appVersion: 0.25.0
+version: 0.25.1
+appVersion: 0.25.1
 home: https://github.com/Altinity/clickhouse-operator
 icon: https://logosandtypes.com/wp-content/uploads/2020/12/altinity.svg
 maintainers:

--- a/deploy/helm/clickhouse-operator/templates/_helpers.tpl
+++ b/deploy/helm/clickhouse-operator/templates/_helpers.tpl
@@ -84,6 +84,18 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create common config for ServiceMonitor endpoints
+*/}}
+{{- define "altinity-clickhouse-operator.serviceMonitorEndpointConfig" -}}
+{{- with .Values.serviceMonitor.interval -}}
+interval: {{ . }}
+{{- end }}
+{{- with .Values.serviceMonitor.scrapeTimeout }}
+scrapeTimeout: {{ . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create the tag for the docker image to use
 */}}
 {{- define "altinity-clickhouse-operator.operator.tag" -}}

--- a/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
@@ -13,16 +13,12 @@ metadata:
 spec:
   endpoints:
     - port: clickhouse-metrics # 8888
+      {{- include "altinity-clickhouse-operator.serviceMonitorEndpointConfig" . | nindent 6 }}
     - port: operator-metrics # 9999
+      {{- include "altinity-clickhouse-operator.serviceMonitorEndpointConfig" . | nindent 6 }}
   selector:
     matchLabels:
       {{- include "altinity-clickhouse-operator.selectorLabels" . | nindent 6 }}
-  {{- with .Values.serviceMonitor.interval }}
-  interval: {{ . }}
-  {{- end }}
-  {{- with .Values.serviceMonitor.scrapeTimeout }}
-  scrapeTimeout: {{ . }}
-  {{- end }}
   {{- with .Values.serviceMonitor.relabelings }}
   relabelings:
     {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
ServiceMonitor is not valid, interval and scrapeTimeout should be both set for endpoints [ref](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint)

Hence, resource applies anyway, it doesn't have those scrapeTimeout and interval and fallbacks into default values set for prometheus operator