### PR TITLE
fix serviceMonitor template

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
@@ -13,13 +13,17 @@ metadata:
 spec:
   endpoints:
     - port: clickhouse-metrics # 8888
+    {{- with .Values.serviceMonitor.clickhouse.interval }}
+      interval: {{ . }}
+    {{- end }}
     - port: operator-metrics # 9999
+    {{- with .Values.serviceMonitor.operator.interval }}
+      interval: {{ . }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "altinity-clickhouse-operator.selectorLabels" . | nindent 6 }}
-  {{- with .Values.serviceMonitor.interval }}
-  interval: {{ . }}
-  {{- end }}
+  
   {{- with .Values.serviceMonitor.scrapeTimeout }}
   scrapeTimeout: {{ . }}
   {{- end }}

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -97,14 +97,18 @@ serviceMonitor:
   enabled: false
   # serviceMonitor.additionalLabels -- additional labels for service monitor
   additionalLabels: {}
-  # serviceMonitor.interval --
-  interval: 30s
   # serviceMonitor.scrapeTimeout -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
   scrapeTimeout: ""
   # serviceMonitor.relabelings -- Prometheus [RelabelConfigs] to apply to samples before scraping
   relabelings: []
   # serviceMonitor.metricRelabelings -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestio
   metricRelabelings: []
+  # serviceMonitor.clickhouse.interval --
+  clickhouse:
+    interval: 30s
+  # serviceMonitor.operator.interval --
+  operator:
+    interval: 30s
 # configs -- clickhouse operator configs
 # @default -- check the `values.yaml` file for the config content (auto-generated from latest operator release)
 configs:


### PR DESCRIPTION
Fix for https://github.com/Altinity/clickhouse-operator/issues/1759

The latest serviceMonitor template https://github.com/Altinity/clickhouse-operator/blob/master/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml has an invalid field interval, which broke our clickhouse installation.
See the API docs for serviceMonitor apiVersion: monitoring.coreos.com/v1
https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitor