### PR TITLE
Fix manual keeper workaround, hostname -d in old kubernetes version doesn't work in alpine images

### DIFF
--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
@@ -111,7 +111,10 @@ metadata:
 data:
   env.sh: |
     #!/usr/bin/env bash
-    export DOMAIN=`hostname -d`
+    HOST=$(hostname -s)
+    FQDN=$(hostname -f)
+    DOMAIN=${FQDN#${HOST}.}
+    export DOMAIN
     export CLIENT_HOST=clickhouse-keeper
     export CLIENT_PORT=2181
     export RAFT_PORT=9444
@@ -353,6 +356,7 @@ spec:
         prometheus.io/port: '7000'
         prometheus.io/scrape: 'true'
     spec:
+      setHostnameAsFQDN: true
 # affinity removed to allow use in single node test environment
 #      affinity:
 #        podAntiAffinity:

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
@@ -93,7 +93,10 @@ metadata:
 data:
   env.sh: |
     #!/usr/bin/env bash
-    export DOMAIN=`hostname -d`
+    HOST=$(hostname -s)
+    FQDN=$(hostname -f)
+    DOMAIN=${FQDN#${HOST}.}
+    export DOMAIN
     export CLIENT_HOST=clickhouse-keeper
     export CLIENT_PORT=2181
     export RAFT_PORT=9444
@@ -335,6 +338,7 @@ spec:
         prometheus.io/port: '7000'
         prometheus.io/scrape: 'true'
     spec:
+      setHostnameAsFQDN: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
@@ -111,7 +111,10 @@ metadata:
 data:
   env.sh: |
     #!/usr/bin/env bash
-    export DOMAIN=`hostname -d`
+    HOST=$(hostname -s)
+    FQDN=$(hostname -f)
+    DOMAIN=${FQDN#${HOST}.}
+    export DOMAIN
     export CLIENT_HOST=clickhouse-keeper
     export CLIENT_PORT=2181
     export RAFT_PORT=9444
@@ -353,6 +356,7 @@ spec:
         prometheus.io/port: '7000'
         prometheus.io/scrape: 'true'
     spec:
+      setHostnameAsFQDN: true
 # affinity removed to allow use in single node test environment
 #      affinity:
 #        podAntiAffinity:

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
@@ -93,7 +93,10 @@ metadata:
 data:
   env.sh: |
     #!/usr/bin/env bash
-    export DOMAIN=`hostname -d`
+    HOST=$(hostname -s)
+    FQDN=$(hostname -f)
+    DOMAIN=${FQDN#${HOST}.}
+    export DOMAIN
     export CLIENT_HOST=clickhouse-keeper
     export CLIENT_PORT=2181
     export RAFT_PORT=9444
@@ -335,6 +338,7 @@ spec:
         prometheus.io/port: '7000'
         prometheus.io/scrape: 'true'
     spec:
+      setHostnameAsFQDN: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
fix https://github.com/Altinity/clickhouse-operator/issues/1765

* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)
