### PR TITLE
improve manually clickhouse-keeper manifests to allow run in old kube…

### DIFF
--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
@@ -112,7 +112,7 @@ data:
   env.sh: |
     #!/usr/bin/env bash
     HOST=$(hostname -s)
-    FQDN=$(hostname -f)
+    FQDN=$(cat /etc/hostname)
     DOMAIN=${FQDN#${HOST}.}
     export DOMAIN
     export CLIENT_HOST=clickhouse-keeper

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
@@ -94,7 +94,7 @@ data:
   env.sh: |
     #!/usr/bin/env bash
     HOST=$(hostname -s)
-    FQDN=$(hostname -f)
+    FQDN=$(cat /etc/hostname)
     DOMAIN=${FQDN#${HOST}.}
     export DOMAIN
     export CLIENT_HOST=clickhouse-keeper

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
@@ -112,7 +112,7 @@ data:
   env.sh: |
     #!/usr/bin/env bash
     HOST=$(hostname -s)
-    FQDN=$(hostname -f)
+    FQDN=$(cat /etc/hostname)
     DOMAIN=${FQDN#${HOST}.}
     export DOMAIN
     export CLIENT_HOST=clickhouse-keeper

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
@@ -94,7 +94,7 @@ data:
   env.sh: |
     #!/usr/bin/env bash
     HOST=$(hostname -s)
-    FQDN=$(hostname -f)
+    FQDN=$(cat /etc/hostname)
     DOMAIN=${FQDN#${HOST}.}
     export DOMAIN
     export CLIENT_HOST=clickhouse-keeper


### PR DESCRIPTION
improve manually clickhouse-keeper manifests to allow run in old kubernetes with broken dns where alpine can't run `hostname -d` and `hostname -f`

fix https://github.com/Altinity/clickhouse-operator/issues/1765

* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)
