### PR TITLE
deny list implementation via predicates

### DIFF
--- a/cmd/operator/app/thread_chi.go
+++ b/cmd/operator/app/thread_chi.go
@@ -63,6 +63,13 @@ func initClickHouse(ctx context.Context) {
 	log.V(1).F().Info("Config parsed:")
 	log.Info("\n" + chop.Config().String(true))
 
+	// Log namespace deny list configuration
+	if len(chop.Config().Watch.NamespacesDenyList) > 0 {
+		log.Info("Namespace deny list configured: %v - these namespaces will NOT be reconciled", chop.Config().Watch.NamespacesDenyList)
+	} else {
+		log.V(1).Info("No namespace deny list configured - all watched namespaces will be reconciled")
+	}
+
 	// Create Informers
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(
 		kubeClient,

--- a/cmd/operator/app/thread_keeper.go
+++ b/cmd/operator/app/thread_keeper.go
@@ -93,6 +93,12 @@ func keeperPredicate() predicate.Funcs {
 				return false
 			}
 
+			// Check if namespace should be watched (includes deny list check)
+			if !chop.Config().IsWatchedNamespace(obj.Namespace) {
+				logger.V(2).Info("chkInformer: skip event, namespace is not watched or is in deny list", "namespace", obj.Namespace)
+				return false
+			}
+
 			if obj.Spec.Suspend.Value() {
 				return false
 			}
@@ -104,6 +110,12 @@ func keeperPredicate() predicate.Funcs {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			obj, ok := e.ObjectNew.(*api.ClickHouseKeeperInstallation)
 			if !ok {
+				return false
+			}
+
+			// Check if namespace should be watched (includes deny list check)
+			if !chop.Config().IsWatchedNamespace(obj.Namespace) {
+				logger.V(2).Info("chkInformer: skip event, namespace is not watched or is in deny list", "namespace", obj.Namespace)
 				return false
 			}
 

--- a/pkg/apis/deployment/env_vars.go
+++ b/pkg/apis/deployment/env_vars.go
@@ -48,6 +48,8 @@ const (
 	WATCH_NAMESPACE = "WATCH_NAMESPACE"
 	// WATCH_NAMESPACES and WATCH_NAMESPACE specifies what namespaces to watch
 	WATCH_NAMESPACES = "WATCH_NAMESPACES"
+	// NAMESPACES_DENY_LIST specifies namespaces that should be excluded from reconciliation
+	NAMESPACES_DENY_LIST = "NAMESPACES_DENY_LIST"
 
 	// CHOP_CONFIG path to clickhouse operator configuration file
 	CHOP_CONFIG = "CHOP_CONFIG"

--- a/pkg/chop/config_manager.go
+++ b/pkg/chop/config_manager.go
@@ -340,6 +340,7 @@ func (cm *ConfigManager) listSupportedEnvVarNames() []string {
 
 		deployment.WATCH_NAMESPACE,
 		deployment.WATCH_NAMESPACES,
+		deployment.NAMESPACES_DENY_LIST,
 	}
 }
 

--- a/pkg/controller/chi/controller.go
+++ b/pkg/controller/chi/controller.go
@@ -186,6 +186,7 @@ func (c *Controller) addEventHandlersCHIT(
 		AddFunc: func(obj interface{}) {
 			chit := obj.(*api.ClickHouseInstallationTemplate)
 			if !chop.Config().IsWatchedNamespace(chit.Namespace) {
+				log.V(2).M(chit).Info("chitInformer: skip event, namespace '%s' is not watched or is in deny list", chit.Namespace)
 				return
 			}
 			log.V(3).M(chit).Info("chitInformer.AddFunc")
@@ -218,6 +219,7 @@ func (c *Controller) addEventHandlersChopConfig(
 		AddFunc: func(obj interface{}) {
 			chopConfig := obj.(*api.ClickHouseOperatorConfiguration)
 			if !chop.Config().IsWatchedNamespace(chopConfig.Namespace) {
+				log.V(2).M(chopConfig).Info("chopInformer: skip event, namespace '%s' is not watched or is in deny list", chopConfig.Namespace)
 				return
 			}
 			log.V(3).M(chopConfig).Info("chopInformer.AddFunc")
@@ -857,6 +859,7 @@ func (c *Controller) handleObject(obj interface{}) {
 
 func shouldEnqueue(chi *api.ClickHouseInstallation) bool {
 	if !chop.Config().IsWatchedNamespace(chi.Namespace) {
+		log.V(2).M(chi).Info("chiInformer: skip enqueue, namespace '%s' is not watched or is in deny list", chi.Namespace)
 		return false
 	}
 


### PR DESCRIPTION
- Use case: I want the operator to watch all namespaces but exclude namespaces x, y, and z. This is particularly useful in a multi-tenant scenario where the operator is reconciling X number of CHIs and has full watch privileges across namespaces. At that point, we can restrict the operator from watching specific namespaces where secure applications are running.

- Predicates based implementation will filter out the event before enqueueing it in worker-queue .

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--