### PR TITLE
There is no 'helm repo upgrade', should be 'update'

### DIFF
--- a/docs/operator_installation_details.md
+++ b/docs/operator_installation_details.md
@@ -64,7 +64,7 @@ helm install clickhouse-operator clickhouse-operator/altinity-clickhouse-operato
 ```
 upgrade
 ```bash
-helm repo upgrade clickhouse-operator
+helm repo update clickhouse-operator
 helm upgrade clickhouse-operator clickhouse-operator/altinity-clickhouse-operator
 ```
 


### PR DESCRIPTION
Just a small documentation change. `helm repo upgrade` doesn't work, should be `helm repo update`

