### PR TITLE
Hotfix port names, to avoid warning during helm install

### DIFF
--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-no-configmap.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-no-configmap.yaml
@@ -89,7 +89,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
 
         - name: metrics-exporter
           image: ${METRICS_EXPORTER_IMAGE}
@@ -146,4 +146,4 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 8888
-              name: metrics
+              name: clickhouse-metrics

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-with-configmap.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-with-configmap.yaml
@@ -136,7 +136,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
 
         - name: metrics-exporter
           image: ${METRICS_EXPORTER_IMAGE}
@@ -212,4 +212,4 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 8888
-              name: metrics
+              name: clickhouse-metrics

--- a/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
@@ -139,7 +139,7 @@ spec:
             {{ with .Values.operator.env }}{{ toYaml . | nindent 12 }}{{ end }}
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
           resources: {{ toYaml .Values.operator.resources | nindent 12 }}
           securityContext: {{ toYaml .Values.operator.containerSecurityContext | nindent 12 }}
 {{ if .Values.metrics.enabled }}
@@ -217,7 +217,7 @@ spec:
             {{ with .Values.metrics.env }}{{ toYaml . | nindent 12 }}{{ end }}
           ports:
             - containerPort: 8888
-              name: metrics
+              name: clickhouse-metrics
           resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
           securityContext: {{ toYaml .Values.metrics.containerSecurityContext | nindent 12 }}
 {{ end }}

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -5493,7 +5493,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
 
         - name: metrics-exporter
           image: altinity/metrics-exporter:0.25.3
@@ -5569,7 +5569,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 8888
-              name: metrics
+              name: clickhouse-metrics
 ---
 # Template Parameters:
 #

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -5669,7 +5669,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
         - name: metrics-exporter
           image: altinity/metrics-exporter:0.25.3
           imagePullPolicy: Always
@@ -5743,7 +5743,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 8888
-              name: metrics
+              name: clickhouse-metrics
 ---
 # Template Parameters:
 #

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -5739,7 +5739,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
 
         - name: metrics-exporter
           image: altinity/metrics-exporter:0.25.3
@@ -5815,7 +5815,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 8888
-              name: metrics
+              name: clickhouse-metrics
 ---
 # Template Parameters:
 #

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -5427,7 +5427,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
         - name: metrics-exporter
           image: ${METRICS_EXPORTER_IMAGE}
           imagePullPolicy: ${METRICS_EXPORTER_IMAGE_PULL_POLICY}

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -5486,7 +5486,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
 
         - name: metrics-exporter
           image: ${METRICS_EXPORTER_IMAGE}

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -5493,7 +5493,7 @@ spec:
                   resource: limits.memory
           ports:
             - containerPort: 9999
-              name: metrics
+              name: operator-metrics
 
         - name: metrics-exporter
           image: altinity/metrics-exporter:0.25.3


### PR DESCRIPTION
helm install warning
```
W0805 01:09:19.296842   62217 warnings.go:70] spec.template.spec.containers[1].ports[0]: duplicate port name "metrics" with spec.template.spec.containers[0].ports[0], services and probes that select ports by name will use spec.template.spec.containers[0].ports[0]
```

look details in https://altinitydbworkspace.slack.com/archives/C02K1MWEK2L/p1754345587373229

* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
