### PR TITLE
Add Zookeeper compression support to ClickHouseInstallation CRD

### DIFF
--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-01-chi-chit.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-01-chi-chit.yaml
@@ -620,6 +620,9 @@ spec:
                         identity:
                           type: string
                           description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                        use_compression:
+                          !!merge <<: *TypeStringBool
+                          description: "Enables compression in Keeper protocol if set to true"
                     users:
                       type: object
                       description: |

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -620,6 +620,9 @@ spec:
                         identity:
                           type: string
                           description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                        use_compression:
+                          !!merge <<: *TypeStringBool
+                          description: "Enables compression in Keeper protocol if set to true"
                     users:
                       type: object
                       description: |

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -620,6 +620,9 @@ spec:
                         identity:
                           type: string
                           description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                        use_compression:
+                          !!merge <<: *TypeStringBool
+                          description: "Enables compression in Keeper protocol if set to true"
                     users:
                       type: object
                       description: |

--- a/pkg/apis/clickhouse.altinity.com/v1/type_zookeeper.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_zookeeper.go
@@ -15,19 +15,23 @@
 package v1
 
 import (
-	"gopkg.in/d4l3k/messagediff.v1"
 	"strings"
+
+	"gopkg.in/d4l3k/messagediff.v1"
+
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
 )
 
 // ZookeeperConfig defines zookeeper section of .spec.configuration
 // Refers to
-// https://clickhouse.yandex/docs/en/single/index.html?#server-settings_zookeeper
+// https://clickhouse.com/docs/operations/server-configuration-parameters/settings#zookeeper
 type ZookeeperConfig struct {
-	Nodes              ZookeeperNodes `json:"nodes,omitempty"                yaml:"nodes,omitempty"`
-	SessionTimeoutMs   int            `json:"session_timeout_ms,omitempty"   yaml:"session_timeout_ms,omitempty"`
-	OperationTimeoutMs int            `json:"operation_timeout_ms,omitempty" yaml:"operation_timeout_ms,omitempty"`
-	Root               string         `json:"root,omitempty"                 yaml:"root,omitempty"`
-	Identity           string         `json:"identity,omitempty"             yaml:"identity,omitempty"`
+	Nodes              ZookeeperNodes    `json:"nodes,omitempty"                yaml:"nodes,omitempty"`
+	SessionTimeoutMs   int               `json:"session_timeout_ms,omitempty"   yaml:"session_timeout_ms,omitempty"`
+	OperationTimeoutMs int               `json:"operation_timeout_ms,omitempty" yaml:"operation_timeout_ms,omitempty"`
+	Root               string            `json:"root,omitempty"                 yaml:"root,omitempty"`
+	Identity           string            `json:"identity,omitempty"             yaml:"identity,omitempty"`
+	UseCompression     *types.StringBool `json:"use_compression,omitempty"      yaml:"use_compression,omitempty"`
 }
 
 type ZookeeperNodes []ZookeeperNode
@@ -114,6 +118,7 @@ func (zkc *ZookeeperConfig) MergeFrom(from *ZookeeperConfig, _type MergeType) *Z
 	if from.Identity != "" {
 		zkc.Identity = from.Identity
 	}
+	zkc.UseCompression = zkc.UseCompression.MergeFrom(from.UseCompression)
 
 	return zkc
 }

--- a/pkg/model/chi/config/generator.go
+++ b/pkg/model/chi/config/generator.go
@@ -165,6 +165,11 @@ func (c *Generator) getHostZookeeper(host *chi.Host) string {
 		util.Iline(b, 8, "<identity>%s</identity>", zk.Identity)
 	}
 
+	// Append use_compression
+	if zk.UseCompression != nil && zk.UseCompression.IsValid() {
+		util.Iline(b, 8, "<use_compression>%s</use_compression>", zk.UseCompression.String())
+	}
+
 	// </zookeeper>
 	util.Iline(b, 4, "</zookeeper>")
 


### PR DESCRIPTION
## Summary

This PR adds support for configuring Zookeeper compression through the ClickHouseInstallation CRD by introducing the `use_compression` field in the zookeeper configuration section as defined in the [ClickHouse server config settings](https://clickhouse.com/docs/operations/server-configuration-parameters/settings#zookeeper)

## Changes

  - Added use_compression boolean field to the Zookeeper configuration spec in the CRD
  - Updated the operator to properly generate <use_compression> XML configuration when specified
  - Field is optional and defaults to false to maintain backward compatibility

## Configuration Example

```yaml
  apiVersion: "clickhouse.altinity.com/v1"
  kind: ClickHouseInstallation
  metadata:
    name: example
  spec:
    configuration:
      zookeeper:
        nodes:
          - host: keeper.example.com
            port: 2181
        session_timeout_ms: 30000
        operation_timeout_ms: 10000
        root: /clickhouse
        identity: user:password
        use_compression: "true"  # <-- New field
```

## Testing
In a local KinD environment, confirmed the operator correctly generates the Zookeeper configuration:

```xml
<yandex>
    <zookeeper>
        <node>
            <host>keeper-local.clickhouse-kind.svc.cluster.local</host>
            <port>2181</port>
        </node>
        <session_timeout_ms>30000</session_timeout_ms>
        <operation_timeout_ms>10000</operation_timeout_ms>
        <root>/local</root>
        <identity>user:password</identity>
        <use_compression>true</use_compression>
    </zookeeper>
</yandex>
```

  Network Traffic Comparison

  Measured network traffic for identical operations (creating ReplicatedMergeTree table + inserting 10,000 rows):

  | Configuration       | Bytes Received | Bytes Transmitted | Total          | Reduction |
  |---------------------|----------------|-------------------|----------------|-----------|
  | With compression    | 2,008          | 2,894             | 4,902          | -         |
  | Without compression (removed field) | 14,013         | 16,695            | 30,708         | -         |

## Backward Compatibility

  - The field is optional and omitting it maintains current behavior (no compression)
  - Existing ClickHouseInstallation resources will continue to work without modification
  - No changes required for users who don't need compression

---

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
