### PR TITLE
Try attach table if INCORRECT_DATA(error code 117) with "CREATE TABLE"

### DIFF
--- a/pkg/model/clickhouse/cluster.go
+++ b/pkg/model/clickhouse/cluster.go
@@ -167,6 +167,12 @@ func (c *Cluster) exec(ctx context.Context, host string, queries []string, _opts
 					sqlAttach := strings.ReplaceAll(sql, "CREATE TABLE", "ATTACH TABLE")
 					err = conn.Exec(ctx, sqlAttach, opts)
 				}
+				if err != nil && strings.Contains(err.Error(), "Code: 117") && strings.Contains(sql, "CREATE TABLE") {
+					// WARNING: error message or code may change in newer ClickHouse versions
+					c.l.V(1).M(host).F().Info("Directory for table already exists. Trying ATTACH TABLE instead")
+					sqlAttach := strings.ReplaceAll(sql, "CREATE TABLE", "ATTACH TABLE")
+					err = conn.Exec(ctx, sqlAttach, opts)
+				}
 				if err == nil || strings.Contains(err.Error(), "ALREADY_EXISTS") {
 					queries[i] = "" // Query is executed or object already exists, removing from the list
 				} else {


### PR DESCRIPTION
When multiple disks are combined into a single volume and the default disk(not in the volume, just includes metadata) becomes lost, the ClickHouse operator attempts to recover the tables. However, because the actual table data still exists intact on other disks (not on the lost default disk), ClickHouse throws the following error during the CREATE TABLE operation, and the table fails to recover properly:

```sh
<Error> executeQuery: Code: 117. DB::Exception: Data directory for table already contains data parts - probably it was unclean DROP table or manual intervention. You must either clear directory by hand or use ATTACH TABLE instead of CREATE TABLE if you need to use that parts. (INCORRECT_DATA) (version 25.6.3.116 (official build))
```

In this situation, the issue can be resolved by using the ATTACH TABLE command instead.

Since there is already existing logic that falls back to ATTACH TABLE for other error codes, we only need to add specific handling for error code 117.

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
