### PR TITLE
Support watching multiple namespaces in OLM

### DIFF
--- a/deploy/builder/templates-operatorhub/clickhouse-operator.vVERSION.clusterserviceversion-template.yaml
+++ b/deploy/builder/templates-operatorhub/clickhouse-operator.vVERSION.clusterserviceversion-template.yaml
@@ -1216,11 +1216,11 @@ spec:
   installModes:
     - supported: true
       type: OwnNamespace
-    - supported: false
+    - supported: true
       type: SingleNamespace
-    - supported: false
+    - supported: true
       type: MultiNamespace
-    - supported: false
+    - supported: true
       type: AllNamespaces
 
   install:


### PR DESCRIPTION
This PR makes OLM deployment support deploying clickhouse cluster on namespaces other than the operator's namespace.

--- 

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
