### PR TITLE
fix: correctly delete existing helm release artifacts by appending asset ID to URL

### DIFF
--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -44,7 +44,7 @@ jobs:
         if: steps.get_assets.outputs.asset_id != ''
         run: |
           curl -X DELETE -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}
+          "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets/${{ steps.get_assets.outputs.asset_id }}"
 
       - name: Upload Release Artifacts
         run: |


### PR DESCRIPTION
oh, looks like we always failed to second "release published" event
look logs https://github.com/Altinity/clickhouse-operator/actions/workflows/release_chart.yaml, and it was really dangerous cause trying delete whole repo... 
only quote " prevented us from failure

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)

