### PR TITLE
use time.Since(..) in place of time.Now().Sub(..)

### DIFF
--- a/pkg/controller/chi/worker-reconciler-chi.go
+++ b/pkg/controller/chi/worker-reconciler-chi.go
@@ -107,7 +107,7 @@ func (w *worker) reconcileCR(ctx context.Context, old, new *api.ClickHouseInstal
 		w.finalizeReconcileAndMarkCompleted(ctx, new)
 
 		metrics.CHIReconcilesCompleted(ctx, new)
-		metrics.CHIReconcilesTimings(ctx, new, time.Now().Sub(startTime).Seconds())
+		metrics.CHIReconcilesTimings(ctx, new, time.Since(startTime).Seconds())
 	}
 
 	return nil
@@ -731,7 +731,7 @@ func (w *worker) reconcileHost(ctx context.Context, host *api.Host) error {
 	})
 
 	metrics.HostReconcilesCompleted(ctx, host.GetCR())
-	metrics.HostReconcilesTimings(ctx, host.GetCR(), time.Now().Sub(startTime).Seconds())
+	metrics.HostReconcilesTimings(ctx, host.GetCR(), time.Since(startTime).Seconds())
 
 	return nil
 }

--- a/pkg/controller/chi/worker-wait-exclude-include-restart.go
+++ b/pkg/controller/chi/worker-wait-exclude-include-restart.go
@@ -61,7 +61,7 @@ func (w *worker) waitForIPAddresses(ctx context.Context, chi *api.ClickHouseInst
 			// Stop polling
 			return false
 		}
-		if time.Now().Sub(start) > timeout {
+		if time.Since(start) > timeout {
 			l.Warning("not all IP addresses are in place but time has elapsed")
 			// Stop polling
 			return false

--- a/pkg/controller/chk/worker-exclude-include-wait.go
+++ b/pkg/controller/chk/worker-exclude-include-wait.go
@@ -49,7 +49,7 @@ func (w *worker) waitForIPAddresses(ctx context.Context, chk *apiChk.ClickHouseK
 			w.a.V(1).M(c).Info("all IP addresses are in place")
 			return false
 		}
-		if time.Now().Sub(start) > 1*time.Minute {
+		if time.Since(start) > 1*time.Minute {
 			// Stop polling
 			w.a.V(1).M(c).Warning("not all IP addresses are in place but time has elapsed")
 			return false

--- a/pkg/controller/common/task.go
+++ b/pkg/controller/common/task.go
@@ -95,7 +95,7 @@ func (t *Task) WaitForConfigMapPropagation(ctx context.Context, host *api.Host) 
 
 	// How much time has elapsed since last ConfigMap update?
 	// May be there is no need to wait already
-	elapsed := time.Now().Sub(t.CmUpdate())
+	elapsed := time.Since(t.CmUpdate())
 	if elapsed >= timeout {
 		log.V(1).M(host).F().Info("No need to wait for ConfigMap propagation - already elapsed. [elapsed/timeout: %s/%s]", elapsed, timeout)
 		return false

--- a/pkg/metrics/clickhouse/exporter.go
+++ b/pkg/metrics/clickhouse/exporter.go
@@ -80,7 +80,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	log.V(1).Info("Collect started")
 	defer func() {
-		log.V(1).Infof("Collect completed [%s]", time.Now().Sub(start))
+		log.V(1).Infof("Collect completed [%s]", time.Since(start))
 	}()
 
 	// Collect should have timeout
@@ -91,7 +91,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	log.V(1).Infof("Launching host collectors [%s]", time.Now().Sub(start))
+	log.V(1).Infof("Launching host collectors [%s]", time.Since(start))
 
 	var wg = sync.WaitGroup{}
 	e.chInstallations.walk(func(chi *metrics.WatchedCR, _ *metrics.WatchedCluster, host *metrics.WatchedHost) {
@@ -213,7 +213,7 @@ func (e *Exporter) collectHostSystemMetrics(
 	log.V(1).Infof("Querying system metrics for host %s", host.Hostname)
 	start := time.Now()
 	metrics, err := fetcher.getClickHouseQueryMetrics(ctx)
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	if err == nil {
 		log.V(1).Infof("Extracted [%s] %d system metrics for host %s", elapsed, len(metrics), host.Hostname)
 		writer.WriteMetrics(metrics)
@@ -234,7 +234,7 @@ func (e *Exporter) collectHostSystemPartsMetrics(
 	log.V(1).Infof("Querying table sizes for host %s", host.Hostname)
 	start := time.Now()
 	systemPartsData, err := fetcher.getClickHouseSystemParts(ctx)
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	if err == nil {
 		log.V(1).Infof("Extracted [%s] %d table sizes for host %s", elapsed, len(systemPartsData), host.Hostname)
 		writer.WriteTableSizes(systemPartsData)
@@ -258,7 +258,7 @@ func (e *Exporter) collectHostSystemReplicasMetrics(
 	log.V(1).Infof("Querying system replicas for host %s", host.Hostname)
 	start := time.Now()
 	systemReplicas, err := fetcher.getClickHouseQuerySystemReplicas(ctx)
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	if err == nil {
 		log.V(1).Infof("Extracted [%s] %d system replicas for host %s", elapsed, len(systemReplicas), host.Hostname)
 		writer.WriteSystemReplicas(systemReplicas)
@@ -279,7 +279,7 @@ func (e *Exporter) collectHostMutationsMetrics(
 	log.V(1).Infof("Querying mutations for host %s", host.Hostname)
 	start := time.Now()
 	mutations, err := fetcher.getClickHouseQueryMutations(ctx)
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	if err == nil {
 		log.V(1).Infof("Extracted [%s] %d mutations for %s", elapsed, len(mutations), host.Hostname)
 		writer.WriteMutations(mutations)
@@ -300,7 +300,7 @@ func (e *Exporter) collectHostSystemDisksMetrics(
 	log.V(1).Infof("Querying disks for host %s", host.Hostname)
 	start := time.Now()
 	disks, err := fetcher.getClickHouseQuerySystemDisks(ctx)
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	if err == nil {
 		log.V(1).Infof("Extracted [%s] %d disks for host %s", elapsed, len(disks), host.Hostname)
 		writer.WriteSystemDisks(disks)
@@ -321,7 +321,7 @@ func (e *Exporter) collectHostDetachedPartsMetrics(
 	log.V(1).Infof("Querying detached parts for host %s", host.Hostname)
 	start := time.Now()
 	detachedParts, err := fetcher.getClickHouseQueryDetachedParts(ctx)
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	if err == nil {
 		log.V(1).Infof("Extracted [%s] %d detached parts info for host %s", elapsed, len(detachedParts), host.Hostname)
 		writer.WriteDetachedParts(detachedParts)


### PR DESCRIPTION
Tiny refactoring to use the easier to read `time.Since` utility fn

---

Please note that I couldn't find a `next-release` (`0.25.5`?) branch and so I have raised this PR against `master`. I can update this as soon as a new release branch is cut.

* [ ] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
