### PR TITLE
Fix missing ownerReferences in pvc metadata

### DIFF
--- a/pkg/model/common/creator/pvc.go
+++ b/pkg/model/common/creator/pvc.go
@@ -43,8 +43,9 @@ func (c *Creator) CreatePVC(
 			//  we are close to proper disk inheritance
 			// Right now we hit the following error:
 			// "Forbidden: updates to StatefulSet spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden"
-			Labels:      c.macro.Scope(host).Map(c.tagger.Label(interfaces.LabelNewPVC, host, false)),
-			Annotations: c.macro.Scope(host).Map(c.tagger.Annotate(interfaces.AnnotateNewPVC, host)),
+			Labels:          c.macro.Scope(host).Map(c.tagger.Label(interfaces.LabelNewPVC, host, false)),
+			Annotations:     c.macro.Scope(host).Map(c.tagger.Annotate(interfaces.AnnotateNewPVC, host)),
+			OwnerReferences: c.or.CreateOwnerReferences(c.cr),
 		},
 		// Append copy of PersistentVolumeClaimSpec
 		Spec: *spec.DeepCopy(),
@@ -65,6 +66,7 @@ func (c *Creator) AdjustPVC(
 ) *core.PersistentVolumeClaim {
 	pvc.SetLabels(c.macro.Scope(host).Map(c.tagger.Label(interfaces.LabelExistingPVC, pvc, host, template)))
 	pvc.SetAnnotations(c.macro.Scope(host).Map(c.tagger.Annotate(interfaces.AnnotateExistingPVC, pvc, host, template)))
+    pvc.SetOwnerReferences(c.or.CreateOwnerReferences(c.cr))
 	// And after the object is ready we can put version label
 	c.labeler.MakeObjectVersion(&pvc.ObjectMeta, pvc)
 	return pvc


### PR DESCRIPTION
## Problem

See issue #1799, #1843

## Root Cause

By default, the Clickhouse Helm chart deploys the Keeper StatefulSet with PVCs provisioned by the Operator ([`chk.yaml`:33](https://github.com/Altinity/helm-charts/blob/2eb731d2df689b895ee003485a557d804b39ab76/charts/clickhouse/templates/chk.yaml#L33)), but the Operator does not set `metadata.OwnerReferences` on the PVCs.

Without `metadata.OwnerReferences` correctly set, ArgoCD can't attribute the PVCs to the application installation, and will incorrectly mark the PVCs as `OutOfSync`, which leads to the following undesirable behaviors/workarounds documented in the aforementioned issue.

The cluster instance's PVCs don't encounter the same issue because the Helm chart [`chi.yaml`](https://github.com/Altinity/helm-charts/blob/2eb731d2df689b895ee003485a557d804b39ab76/charts/clickhouse/templates/chi.yaml) doesn't specify `spec.defaults.storageManagement.provisioner`, so the default `StatefulSet` provisioner is used:
https://github.com/Altinity/clickhouse-operator/blob/732a1be0d43a5b1643f076a4b7d404dc9b45b6d3/pkg/model/common/volume/volumer.go#L60-L61

Thus, ArgoCD is able to correctly map the StatefulSet-created PVCs to the CHI StatefulSet resources.

## Solution: set `metadata.OwnerReferences` on PVCs

There's already precedence with doing this on Operator-provisioned StatefulSet and Service k8s resources:
https://github.com/Altinity/clickhouse-operator/blob/732a1be0d43a5b1643f076a4b7d404dc9b45b6d3/pkg/model/common/creator/stateful-set.go#L35-L41
https://github.com/Altinity/clickhouse-operator/blob/732a1be0d43a5b1643f076a4b7d404dc9b45b6d3/pkg/model/common/creator/service.go#L81-L85

This PR makes code changes in a similar manner to the above code snippets.

## Pull Request checklist

* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)