### PR TITLE
Use replica-level dataVolumeClaimTemplate and logVolumeClaimTemplate when the shard's field is not set.

### DIFF
--- a/pkg/apis/clickhouse-keeper.altinity.com/v1/type_cluster.go
+++ b/pkg/apis/clickhouse-keeper.altinity.com/v1/type_cluster.go
@@ -163,13 +163,19 @@ func (cluster *Cluster) isShardExplicitlySpecified() bool {
 
 // isReplicaExplicitlySpecified checks whether replica is explicitly specified
 func (cluster *Cluster) isReplicaExplicitlySpecified() bool {
-	return cluster.Layout.ReplicasExplicitlySpecified && !cluster.isShardExplicitlySpecified()
+	return cluster.Layout.ReplicasExplicitlySpecified
 }
 
 // IsShardSpecified checks whether shard is explicitly specified
 func (cluster *Cluster) isShardToBeUsedToInheritSettingsFrom() bool {
 	if !cluster.isShardExplicitlySpecified() && !cluster.isReplicaExplicitlySpecified() {
 		return true
+	}
+
+	// When both shards and replicas are explicitly specified, prefer replicas
+	// since replica-level configuration is more specific than shard-level
+	if cluster.isShardExplicitlySpecified() && cluster.isReplicaExplicitlySpecified() {
+		return false
 	}
 
 	return cluster.isShardExplicitlySpecified()

--- a/pkg/apis/clickhouse-keeper.altinity.com/v1/type_cluster_test.go
+++ b/pkg/apis/clickhouse-keeper.altinity.com/v1/type_cluster_test.go
@@ -1,0 +1,133 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apiChi "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+)
+
+// Test_KeeperClusterSettingsSource_PreferReplicaOverShard tests that when both
+// shard and replica settings are explicitly specified, replica settings
+// take precedence as they are more fine-grained control points.
+func Test_KeeperClusterSettingsSource_PreferReplicaOverShard(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		shardsExplicit       bool
+		replicasExplicit     bool
+		expectShardAsSource  bool
+		description          string
+	}{
+		{
+			name:                 "neither_shards_nor_replicas_explicit",
+			shardsExplicit:       false,
+			replicasExplicit:     false,
+			expectShardAsSource:  true,
+			description:          "When neither shards nor replicas are explicitly specified, use shard as settings source",
+		},
+		{
+			name:                 "only_shards_explicit",
+			shardsExplicit:       true,
+			replicasExplicit:     false,
+			expectShardAsSource:  true,
+			description:          "When only shards are explicitly specified, use shard as settings source",
+		},
+		{
+			name:                 "only_replicas_explicit",
+			shardsExplicit:       false,
+			replicasExplicit:     true,
+			expectShardAsSource:  false,
+			description:          "When only replicas are explicitly specified, use replica as settings source",
+		},
+		{
+			name:                 "both_shards_and_replicas_explicit",
+			shardsExplicit:       true,
+			replicasExplicit:     true,
+			expectShardAsSource:  false,
+			description:          "When both shards and replicas are explicitly specified, prefer replica settings as they are more fine-grained",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			cluster := &Cluster{
+				Layout: &ChkClusterLayout{
+					ShardsExplicitlySpecified:   tc.shardsExplicit,
+					ReplicasExplicitlySpecified: tc.replicasExplicit,
+				},
+			}
+
+			// Test isShardToBeUsedToInheritSettingsFrom
+			actualShardSource := cluster.isShardToBeUsedToInheritSettingsFrom()
+			require.Equal(tt, tc.expectShardAsSource, actualShardSource,
+				"%s: isShardToBeUsedToInheritSettingsFrom() returned %v, expected %v",
+				tc.description, actualShardSource, tc.expectShardAsSource)
+
+			// Test SelectSettingsSourceFrom
+			shard := &apiChi.ChiShard{Name: "test-shard"}
+			replica := &apiChi.ChiReplica{Name: "test-replica"}
+
+			src := cluster.SelectSettingsSourceFrom(shard, replica)
+			if tc.expectShardAsSource {
+				require.Equal(tt, shard, src,
+					"%s: SelectSettingsSourceFrom() should return shard", tc.description)
+			} else {
+				require.Equal(tt, replica, src,
+					"%s: SelectSettingsSourceFrom() should return replica", tc.description)
+			}
+		})
+	}
+}
+
+// Test_KeeperClusterReplicaExplicitlySpecified tests that isReplicaExplicitlySpecified
+// returns true whenever replicas are explicitly specified, regardless of shard specification
+func Test_KeeperClusterReplicaExplicitlySpecified(t *testing.T) {
+	testCases := []struct {
+		name             string
+		shardsExplicit   bool
+		replicasExplicit bool
+		expected         bool
+	}{
+		{
+			name:             "replicas_not_explicit",
+			shardsExplicit:   false,
+			replicasExplicit: false,
+			expected:         false,
+		},
+		{
+			name:             "replicas_explicit_shards_not",
+			shardsExplicit:   false,
+			replicasExplicit: true,
+			expected:         true,
+		},
+		{
+			name:             "replicas_explicit_shards_explicit",
+			shardsExplicit:   true,
+			replicasExplicit: true,
+			expected:         true,
+		},
+		{
+			name:             "replicas_not_explicit_shards_explicit",
+			shardsExplicit:   true,
+			replicasExplicit: false,
+			expected:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			cluster := &Cluster{
+				Layout: &ChkClusterLayout{
+					ShardsExplicitlySpecified:   tc.shardsExplicit,
+					ReplicasExplicitlySpecified: tc.replicasExplicit,
+				},
+			}
+
+			actual := cluster.isReplicaExplicitlySpecified()
+			require.Equal(tt, tc.expected, actual,
+				"isReplicaExplicitlySpecified() returned %v, expected %v",
+				actual, tc.expected)
+		})
+	}
+}

--- a/pkg/apis/clickhouse.altinity.com/v1/type_cluster.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_cluster.go
@@ -172,13 +172,19 @@ func (cluster *Cluster) isShardExplicitlySpecified() bool {
 
 // isReplicaExplicitlySpecified checks whether replica is explicitly specified
 func (cluster *Cluster) isReplicaExplicitlySpecified() bool {
-	return cluster.Layout.ReplicasExplicitlySpecified && !cluster.isShardExplicitlySpecified()
+	return cluster.Layout.ReplicasExplicitlySpecified
 }
 
 // IsShardSpecified checks whether shard is explicitly specified
 func (cluster *Cluster) isShardToBeUsedToInheritSettingsFrom() bool {
 	if !cluster.isShardExplicitlySpecified() && !cluster.isReplicaExplicitlySpecified() {
 		return true
+	}
+
+	// When both shards and replicas are explicitly specified, prefer replicas
+	// since replica-level configuration is more specific than shard-level
+	if cluster.isShardExplicitlySpecified() && cluster.isReplicaExplicitlySpecified() {
+		return false
 	}
 
 	return cluster.isShardExplicitlySpecified()

--- a/pkg/apis/clickhouse.altinity.com/v1/type_cluster_test.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_cluster_test.go
@@ -1,0 +1,131 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_ClusterSettingsSource_PreferReplicaOverShard tests that when both
+// shard and replica settings are explicitly specified, replica settings
+// take precedence as they are more fine-grained control points.
+func Test_ClusterSettingsSource_PreferReplicaOverShard(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		shardsExplicit       bool
+		replicasExplicit     bool
+		expectShardAsSource  bool
+		description          string
+	}{
+		{
+			name:                 "neither_shards_nor_replicas_explicit",
+			shardsExplicit:       false,
+			replicasExplicit:     false,
+			expectShardAsSource:  true,
+			description:          "When neither shards nor replicas are explicitly specified, use shard as settings source",
+		},
+		{
+			name:                 "only_shards_explicit",
+			shardsExplicit:       true,
+			replicasExplicit:     false,
+			expectShardAsSource:  true,
+			description:          "When only shards are explicitly specified, use shard as settings source",
+		},
+		{
+			name:                 "only_replicas_explicit",
+			shardsExplicit:       false,
+			replicasExplicit:     true,
+			expectShardAsSource:  false,
+			description:          "When only replicas are explicitly specified, use replica as settings source",
+		},
+		{
+			name:                 "both_shards_and_replicas_explicit",
+			shardsExplicit:       true,
+			replicasExplicit:     true,
+			expectShardAsSource:  false,
+			description:          "When both shards and replicas are explicitly specified, prefer replica settings as they are more fine-grained",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			cluster := &Cluster{
+				Layout: &ChiClusterLayout{
+					ShardsExplicitlySpecified:   tc.shardsExplicit,
+					ReplicasExplicitlySpecified: tc.replicasExplicit,
+				},
+			}
+
+			// Test isShardToBeUsedToInheritSettingsFrom
+			actualShardSource := cluster.isShardToBeUsedToInheritSettingsFrom()
+			require.Equal(tt, tc.expectShardAsSource, actualShardSource,
+				"%s: isShardToBeUsedToInheritSettingsFrom() returned %v, expected %v",
+				tc.description, actualShardSource, tc.expectShardAsSource)
+
+			// Test SelectSettingsSourceFrom
+			shard := &ChiShard{Name: "test-shard"}
+			replica := &ChiReplica{Name: "test-replica"}
+
+			src := cluster.SelectSettingsSourceFrom(shard, replica)
+			if tc.expectShardAsSource {
+				require.Equal(tt, shard, src,
+					"%s: SelectSettingsSourceFrom() should return shard", tc.description)
+			} else {
+				require.Equal(tt, replica, src,
+					"%s: SelectSettingsSourceFrom() should return replica", tc.description)
+			}
+		})
+	}
+}
+
+// Test_ClusterReplicaExplicitlySpecified tests that isReplicaExplicitlySpecified
+// returns true whenever replicas are explicitly specified, regardless of shard specification
+func Test_ClusterReplicaExplicitlySpecified(t *testing.T) {
+	testCases := []struct {
+		name             string
+		shardsExplicit   bool
+		replicasExplicit bool
+		expected         bool
+	}{
+		{
+			name:             "replicas_not_explicit",
+			shardsExplicit:   false,
+			replicasExplicit: false,
+			expected:         false,
+		},
+		{
+			name:             "replicas_explicit_shards_not",
+			shardsExplicit:   false,
+			replicasExplicit: true,
+			expected:         true,
+		},
+		{
+			name:             "replicas_explicit_shards_explicit",
+			shardsExplicit:   true,
+			replicasExplicit: true,
+			expected:         true,
+		},
+		{
+			name:             "replicas_not_explicit_shards_explicit",
+			shardsExplicit:   true,
+			replicasExplicit: false,
+			expected:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			cluster := &Cluster{
+				Layout: &ChiClusterLayout{
+					ShardsExplicitlySpecified:   tc.shardsExplicit,
+					ReplicasExplicitlySpecified: tc.replicasExplicit,
+				},
+			}
+
+			actual := cluster.isReplicaExplicitlySpecified()
+			require.Equal(tt, tc.expected, actual,
+				"isReplicaExplicitlySpecified() returned %v, expected %v",
+				actual, tc.expected)
+		})
+	}
+}

--- a/pkg/apis/clickhouse.altinity.com/v1/type_status_test.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_status_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
+
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
 )
 
 var normalizedChiA = &ClickHouseInstallation{}
@@ -158,12 +160,14 @@ func Test_ChiStatus_BasicOperations_SingleStatus_ConcurrencyTest(t *testing.T) {
 			name: "CopyFrom",
 			goRoutineA: func(s *Status) {
 				s.PushAction("always-present-action") // CopyFrom preserves existing actions (does not clobber)
-				s.CopyFrom(copyTestStatusFrom, CopyStatusOptions{
-					Actions:           true,
-					Errors:            true,
-					MainFields:        true,
-					WholeStatus:       true,
-					InheritableFields: true,
+				s.CopyFrom(copyTestStatusFrom, types.CopyStatusOptions{
+					CopyStatusFieldGroup: types.CopyStatusFieldGroup{
+						FieldGroupActions:     true,
+						FieldGroupErrors:      true,
+						FieldGroupMain:        true,
+						FieldGroupWholeStatus: true,
+						FieldGroupInheritable: true,
+					},
 				})
 			},
 			goRoutineB: func(s *Status) {
@@ -171,7 +175,6 @@ func Test_ChiStatus_BasicOperations_SingleStatus_ConcurrencyTest(t *testing.T) {
 			},
 			postConditionsVerification: func(tt *testing.T, s *Status) {
 				if len(s.GetActions()) == len(copyTestStatusFrom.GetActions())+2 {
-					require.Equal(tt, copyTestStatusFrom.GetActions(), s.GetActions())
 					require.Contains(tt, s.GetActions(), "always-present-action")
 					require.Contains(tt, s.GetActions(), "additional-action")
 					for _, action := range copyTestStatusFrom.GetActions() {
@@ -179,7 +182,7 @@ func Test_ChiStatus_BasicOperations_SingleStatus_ConcurrencyTest(t *testing.T) {
 					}
 				} else {
 					require.Equal(tt, len(copyTestStatusFrom.GetActions())+1, len(s.GetActions()))
-					require.Contains(tt, s.GetActions(), "additional-action")
+					require.Contains(tt, s.GetActions(), "always-present-action")
 					for _, action := range copyTestStatusFrom.GetActions() {
 						require.Contains(tt, s.GetActions(), action)
 					}


### PR DESCRIPTION
in the case where replicas override `dataVolumeClaimTemplates/logVolumeClaimTemplates` but the shard does not set it,  the replica-level overrides are ignored. This fix prefers the replica settings always as they are more fine grained control points.

I found this while attempting to do something a little bit out of the box: attempting to leverage the operator to migrate a clickhouse cluster from an old storageclass to a new one by leveraging the replica level template overrides.

So I'm going from this type of spec, which uses the `defaults` for each shard and replica:
```
spec:
  configuration:
    clusters:
    - layout:
        replicasCount: 3
        shardsCount: 1
    defaults:
      templates:
        dataVolumeClaimTemplate: original-template
```

And I'd like to migrate to this, which should have the effect of (re)creating the 3 existing replicas using their existing PVs, and adding a new replica to the shard which uses the new storageclass via the `logVolumeClaimTemplate + dataVolumeClaimTemplate` fields.

```
spec:
  configuration:
    clusters:
    - layout:
        shards:
        - replicas:
          - name: 0-0
          - name: 0-1
          - name: 0-2
          - name: 0-3
             templates:
              dataVolumeClaimTemplate: some-different-template
              logVolumeClaimTemplate: some-different-template
    defaults:
      templates:
        dataVolumeClaimTemplate: original-template
```
What happens though, is that the new replica `0-4` is created using the default dataVolumeClaim instead of the one that is specified in the replica-level field of the spec.

While trying to get this to work, I noticed that the replica level `dataVolumeClaimTemplate` field is ignored if it is not also set in the shard. This PR removes the shard-level check in favour of the replica-level field which allows for finer grained control of the logVolumeClaimTemplates and dataVolumeClaimTemplates.

NOTE: I believe this to be a bug fix since replica level `logVolumeClaimTemplate + dataVolumeClaimTemplate` configurations are ignored when both shard and replica were set, but it will change behaviour for users:
```
  - Old behavior: When both shard-level and replica-level volume claim templates (or other settings) were specified, shard-level settings took precedence
  - New behavior: When both are specified, replica-level settings now take precedence
```

Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
