### PR TITLE
fix CI/CD failures New curl static changed from moparisthebest/static-curl to stunnel/static-curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ tests/image/cache
 
 # agents
 .aider*
+CLAUDE.md
+AGENTS.md
+.claude

--- a/dockerfile/metrics-exporter/Dockerfile
+++ b/dockerfile/metrics-exporter/Dockerfile
@@ -19,9 +19,12 @@ RUN wget -O /usr/bin/yq --progress=bar:force:noscroll "https://github.com/mikefa
 RUN PLATFORM="x86_64" && if [ "${TARGETARCH}" = "arm64" ]; then PLATFORM="aarch64"; fi && \
     wget -O /tmp/bash --progress=bar:force:noscroll "https://github.com/robxu9/bash-static/releases/latest/download/bash-linux-${PLATFORM}" && \
     chmod +x /tmp/bash
-RUN PLATFORM="amd64" && if [ "${TARGETARCH}" = "arm64" ]; then PLATFORM="aarch64"; fi && \
-    wget -O /tmp/curl --progress=bar:force:noscroll "https://github.com/moparisthebest/static-curl/releases/latest/download/curl-${PLATFORM}" && \
-    chmod +x /tmp/curl
+RUN PLATFORM="x86_64" && if [ "${TARGETARCH}" = "arm64" ]; then PLATFORM="aarch64"; fi && \
+    CURL_VERSION=$(wget -qO- https://github.com/stunnel/static-curl/releases/latest 2>&1 | grep -oE 'tag/[0-9.]+' | head -n1 | cut -d'/' -f2) && \
+    wget -O /tmp/curl.tar.xz --progress=bar:force:noscroll "https://github.com/stunnel/static-curl/releases/download/${CURL_VERSION}/curl-linux-${PLATFORM}-glibc-${CURL_VERSION}.tar.xz" && \
+    tar -xf /tmp/curl.tar.xz -C /tmp/ && \
+    chmod +x /tmp/curl && \
+    rm -f /tmp/curl.tar.xz
 
 # Reconstruct source tree inside docker
 WORKDIR /clickhouse-operator

--- a/dockerfile/operator/Dockerfile
+++ b/dockerfile/operator/Dockerfile
@@ -19,9 +19,12 @@ RUN wget -O /usr/bin/yq --progress=bar:force:noscroll "https://github.com/mikefa
 RUN PLATFORM="x86_64" && if [ "${TARGETARCH}" = "arm64" ]; then PLATFORM="aarch64"; fi && \
     wget -O /tmp/bash --progress=bar:force:noscroll "https://github.com/robxu9/bash-static/releases/latest/download/bash-linux-${PLATFORM}" && \
     chmod +x /tmp/bash
-RUN PLATFORM="amd64" && if [ "${TARGETARCH}" = "arm64" ]; then PLATFORM="aarch64"; fi && \
-    wget -O /tmp/curl --progress=bar:force:noscroll "https://github.com/moparisthebest/static-curl/releases/latest/download/curl-${PLATFORM}" && \
-    chmod +x /tmp/curl
+RUN PLATFORM="x86_64" && if [ "${TARGETARCH}" = "arm64" ]; then PLATFORM="aarch64"; fi && \
+    CURL_VERSION=$(wget -qO- https://github.com/stunnel/static-curl/releases/latest 2>&1 | grep -oE 'tag/[0-9.]+' | head -n1 | cut -d'/' -f2) && \
+    wget -O /tmp/curl.tar.xz --progress=bar:force:noscroll "https://github.com/stunnel/static-curl/releases/download/${CURL_VERSION}/curl-linux-${PLATFORM}-glibc-${CURL_VERSION}.tar.xz" && \
+    tar -xf /tmp/curl.tar.xz -C /tmp/ && \
+    chmod +x /tmp/curl && \
+    rm -f /tmp/curl.tar.xz
 
 # Reconstruct source tree inside docker
 WORKDIR /clickhouse-operator


### PR DESCRIPTION
workaround for https://github.com/moparisthebest/static-curl/issues/19

* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)