### PR TITLE
Enhance CHK reconciliation and normalization features

### DIFF
--- a/pkg/apis/clickhouse-keeper.altinity.com/v1/type_cluster.go
+++ b/pkg/apis/clickhouse-keeper.altinity.com/v1/type_cluster.go
@@ -224,6 +224,15 @@ func (cluster *Cluster) GetAncestor() apiChi.ICluster {
 	return (*Cluster)(nil)
 }
 
+// InheritClusterReconcileFrom inherits reconcile settings from CHK CR
+func (cluster *Cluster) InheritClusterReconcileFrom(chk *ClickHouseKeeperInstallation) {
+	if chk.Spec.Reconcile == nil {
+		return
+	}
+	cluster.Reconcile.Runtime = cluster.Reconcile.Runtime.MergeFrom(chk.Spec.Reconcile.Runtime, apiChi.MergeTypeFillEmptyValues)
+	cluster.Reconcile.Host = cluster.Reconcile.Host.MergeFrom(chk.Spec.Reconcile.Host)
+}
+
 // GetShard gets shard with specified index
 func (cluster *Cluster) GetShard(shard int) *ChkShard {
 	return cluster.Layout.Shards[shard]

--- a/pkg/controller/common/poller/domain/poller-host-objects.go
+++ b/pkg/controller/common/poller/domain/poller-host-objects.go
@@ -99,7 +99,9 @@ func (p *HostObjectsPoller) WaitHostStatefulSetReady(ctx context.Context, host *
 			if sts == nil {
 				return false
 			}
-			_ = p.readyMarkDeleter.DeleteReadyMarkOnPodAndService(_ctx, host)
+			if p.readyMarkDeleter != nil {
+				_ = p.readyMarkDeleter.DeleteReadyMarkOnPodAndService(_ctx, host)
+			}
 			return k8s.IsStatefulSetReconcileCompleted(sts)
 		},
 	)

--- a/pkg/model/chk/normalizer/normalizer.go
+++ b/pkg/model/chk/normalizer/normalizer.go
@@ -340,8 +340,14 @@ func (n *Normalizer) normalizeReconcile(reconcile *chi.ChiReconcile) *chi.ChiRec
 	// No normalization yet
 
 	// Host
-	// No normalization yet
+	reconcile.Host = n.normalizeReconcileHost(reconcile.Host)
 	return reconcile
+}
+
+func (n *Normalizer) normalizeReconcileHost(rh chi.ReconcileHost) chi.ReconcileHost {
+	// Normalize
+	rh = rh.Normalize()
+	return rh
 }
 
 func (n *Normalizer) normalizeReconcileCleanup(cleanup *chi.Cleanup) *chi.Cleanup {
@@ -519,6 +525,9 @@ func (n *Normalizer) normalizeClusterStage1(cluster *chk.Cluster) *chk.Cluster {
 
 	// Runtime has to be prepared first
 	cluster.GetRuntime().SetCR(n.req.GetTarget())
+
+	// Inherit reconcile settings from CR
+	cluster.InheritClusterReconcileFrom(n.req.GetTarget())
 
 	n.normalizeClusterLayout(cluster)
 

--- a/pkg/model/common/macro/engine.go
+++ b/pkg/model/common/macro/engine.go
@@ -17,6 +17,7 @@ package macro
 import (
 	"strconv"
 
+	apiChk "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse-keeper.altinity.com/v1"
 	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
 	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
 	"github.com/altinity/clickhouse-operator/pkg/interfaces"
@@ -68,6 +69,8 @@ func (e *Engine) Replacer() *util.Replacer {
 		return e.newReplacerCR(t)
 	case api.ICluster:
 		return e.newReplacerCluster(t)
+	case *apiChk.Cluster:
+		return e.newReplacerCHKCluster(t)
 	case api.IShard:
 		return e.newReplacerShard(t)
 	case api.IReplica:
@@ -97,6 +100,16 @@ func (e *Engine) newReplacerCR(cr api.ICustomResource) *util.Replacer {
 
 // newReplacerCluster
 func (e *Engine) newReplacerCluster(cluster api.ICluster) *util.Replacer {
+	return util.NewReplacer(map[string]string{
+		e.Get(MacrosNamespace):    e.namer.Name(short.Namespace, cluster),
+		e.Get(MacrosCRName):       e.namer.Name(short.CRName, cluster),
+		e.Get(MacrosClusterName):  e.namer.Name(short.ClusterName, cluster),
+		e.Get(MacrosClusterIndex): strconv.Itoa(cluster.GetRuntime().GetAddress().GetClusterIndex()),
+	})
+}
+
+// newReplacerCHKCluster
+func (e *Engine) newReplacerCHKCluster(cluster *apiChk.Cluster) *util.Replacer {
 	return util.NewReplacer(map[string]string{
 		e.Get(MacrosNamespace):    e.namer.Name(short.Namespace, cluster),
 		e.Get(MacrosCRName):       e.namer.Name(short.CRName, cluster),

--- a/pkg/model/common/namer/short/namer.go
+++ b/pkg/model/common/namer/short/namer.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	apiChk "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse-keeper.altinity.com/v1"
 	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
 	"github.com/altinity/clickhouse-operator/pkg/util"
 )
@@ -132,6 +133,9 @@ func (n *Namer) getNamePartNamespace(obj interface{}) string {
 	case api.ICluster:
 		cluster := obj.(api.ICluster)
 		return n.namePartCRName(cluster.GetRuntime().GetAddress().GetNamespace())
+	case *apiChk.Cluster:
+		cluster := obj.(*apiChk.Cluster)
+		return n.namePartCRName(cluster.GetRuntime().GetAddress().GetNamespace())
 	case api.IShard:
 		shard := obj.(api.IShard)
 		return n.namePartCRName(shard.GetRuntime().GetAddress().GetNamespace())
@@ -152,6 +156,9 @@ func (n *Namer) getNamePartCRName(obj interface{}) string {
 	case api.ICluster:
 		cluster := obj.(api.ICluster)
 		return n.namePartCRName(cluster.GetRuntime().GetAddress().GetCRName())
+	case *apiChk.Cluster:
+		cluster := obj.(*apiChk.Cluster)
+		return n.namePartCRName(cluster.GetRuntime().GetAddress().GetCRName())
 	case api.IShard:
 		shard := obj.(api.IShard)
 		return n.namePartCRName(shard.GetRuntime().GetAddress().GetCRName())
@@ -168,6 +175,9 @@ func (n *Namer) getNamePartClusterName(obj interface{}) string {
 	switch obj.(type) {
 	case api.ICluster:
 		cluster := obj.(api.ICluster)
+		return n.namePartClusterName(cluster.GetRuntime().GetAddress().GetClusterName())
+	case *apiChk.Cluster:
+		cluster := obj.(*apiChk.Cluster)
 		return n.namePartClusterName(cluster.GetRuntime().GetAddress().GetClusterName())
 	case api.IShard:
 		shard := obj.(api.IShard)


### PR DESCRIPTION
This pull request introduces enhancements to the ClickHouse Keeper (CHK) controller logic, focusing on better inheritance and normalization of reconcile settings, improved handling of StatefulSet reconciliation, and extended macro/namer support for CHK clusters. The changes improve the maintainability and configurability of cluster reconciliation, ensuring CHK clusters inherit correct settings and are properly identified throughout the codebase.

**Reconcile settings inheritance and normalization:**
* Added `Cluster.InheritClusterReconcileFrom` to allow CHK clusters to inherit reconcile settings from the parent CR, ensuring consistent runtime and host reconciliation behavior. [[1]](diffhunk://#diff-da5cac11f3a497d3702ed270681cbb39a0e4af49103209096479316715f262ecR227-R235) [[2]](diffhunk://#diff-4b5636f18383224d6eee43acb0e64b9ffba3e904ccb10ba068e0b609c6163762R529-R531)
* Updated the normalizer to apply normalization to the host reconcile section (`normalizeReconcileHost`), improving the reliability of host-specific settings.

**StatefulSet reconciliation improvements:**
* Introduced `prepareStsReconcileOptsWaitSection`, enabling conditional setting of `WaitUntilStarted` and `WaitUntilReady` options for StatefulSet reconciliation based on probe readiness, with appropriate logging.
* Ensured that readiness marks are deleted on pods and services when waiting for StatefulSet readiness, increasing robustness of readiness checks.

**Macro and namer support for CHK clusters:**
* Extended macro engine and short namer to recognize and generate names for `*apiChk.Cluster` objects, supporting namespace, CR name, and cluster name resolution for CHK clusters. [[1]](diffhunk://#diff-c53a99df1e9900cdca6786ab1ef6ff7090316ff9a024ec32664c1e48daf98928R20) [[2]](diffhunk://#diff-c53a99df1e9900cdca6786ab1ef6ff7090316ff9a024ec32664c1e48daf98928R72-R73) [[3]](diffhunk://#diff-c53a99df1e9900cdca6786ab1ef6ff7090316ff9a024ec32664c1e48daf98928R111-R120) [[4]](diffhunk://#diff-cd439ab508ec22814c5ddca73da4ca985923e216a854484907466e732ab91a75R21) [[5]](diffhunk://#diff-cd439ab508ec22814c5ddca73da4ca985923e216a854484907466e732ab91a75R136-R138) [[6]](diffhunk://#diff-cd439ab508ec22814c5ddca73da4ca985923e216a854484907466e732ab91a75R159-R161) [[7]](diffhunk://#diff-cd439ab508ec22814c5ddca73da4ca985923e216a854484907466e732ab91a75R179-R181)

Fixes #1796 