### PR TITLE
sort keys in Settings.Keys() method for consistent order (fix manifest reconcile issue)

### DIFF
--- a/pkg/apis/clickhouse.altinity.com/v1/type_settings.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_settings.go
@@ -300,11 +300,15 @@ func (s *Settings) SetScalarsFromMap(m map[string]string) *Settings {
 	return s
 }
 
-// Keys gets keys of the settings
+// Keys gets keys of the settings in alphabetical order
 func (s *Settings) Keys() (keys []string) {
 	s.WalkKeys(func(key string, setting *Setting) {
 		keys = append(keys, key)
 	})
+
+	// Sort keys to ensure deterministic ordering for Kubernetes manifest stability.
+	// Consistent ordering prevents unnecessary resource updates during reconciliation.
+	sort.Strings(keys)
 	return keys
 }
 


### PR DESCRIPTION
This pull request introduces a minor improvement to the `Keys` method in the `Settings` struct by ensuring the returned list of keys is sorted alphabetically.

This is to correct an issue we found where pods are re-created by the stateful set for (possibly) every reconcile due to the generated volume mounts getting re-ordered (e.g., using a secret for TLS key/cert as documented [here](https://github.com/Altinity/clickhouse-operator/blob/master/docs/security_hardening.md)) and possibly others. 

The value of `.Keys()` is used in a few different places; notably by `WalkKeysSafe`, used by `WalkSafe`, and finally `normalizeConfigurationFiles`. Since Go map iterations are random otherwise, sorting them here means the `WalkSafe` method will "walk" in alphabetical order, making the generated mounts/volume order stable.

```go
// normalizeConfigurationFiles normalizes .spec.configuration.files
func (n *Normalizer) normalizeConfigurationFiles(files *chi.Settings, scope any) *chi.Settings {
	if files == nil {
		return nil
	}
	files.Normalize(n.settingsNormalizerOptions(replacerFiles, scope))

	files.WalkSafe(func(key string, setting *chi.Setting) {
		subst.ReplaceSettingsFieldWithMountedFile(n.req, files, key)
	})

	return files
}
```

<img width="1904" height="520" alt="image" src="https://github.com/user-attachments/assets/b611d1e2-0b95-4a7b-9daa-65e8f6820016" />


---


Thanks for taking the time to contribute to `clickhouse-operator`!

Please, read carefully [instructions on how to make a Pull Request](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#intro).

This will help a lot for maintainers to adopt your Pull Request. 

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
