### PR TITLE
Fix installer to default template URL to OPERATOR_VERSION

### DIFF
--- a/deploy/operator-web-installer/clickhouse-operator-install.sh
+++ b/deploy/operator-web-installer/clickhouse-operator-install.sh
@@ -141,9 +141,6 @@ check_envsubst_available
 
 # Manifest is expected to be ready-to-use manifest file
 MANIFEST="${MANIFEST:-""}"
-# Template can have params to substitute
-DEFAULT_TEMPLATE="https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/operator/clickhouse-operator-install-template.yaml"
-TEMPLATE="${TEMPLATE:-"${DEFAULT_TEMPLATE}"}"
 # Namespace to install operator
 OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-"kube-system"}"
 METRICS_EXPORTER_NAMESPACE="${OPERATOR_NAMESPACE}"
@@ -153,6 +150,9 @@ if [[ -z "${OPERATOR_VERSION}" ]]; then
     RELEASE_VERSION=$(get_file https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/release)
 fi
 OPERATOR_VERSION="${OPERATOR_VERSION:-"${RELEASE_VERSION}"}"
+# Template can have params to substitute
+DEFAULT_TEMPLATE="https://raw.githubusercontent.com/Altinity/clickhouse-operator/${OPERATOR_VERSION:-master}/deploy/operator/clickhouse-operator-install-template.yaml"
+TEMPLATE="${TEMPLATE:-"${DEFAULT_TEMPLATE}"}"
 OPERATOR_IMAGE="${OPERATOR_IMAGE:-"altinity/clickhouse-operator:${OPERATOR_VERSION}"}"
 OPERATOR_IMAGE_PULL_POLICY="${OPERATOR_IMAGE_PULL_POLICY:-"Always"}"
 METRICS_EXPORTER_IMAGE="${METRICS_EXPORTER_IMAGE:-"altinity/metrics-exporter:${OPERATOR_VERSION}"}"


### PR DESCRIPTION
The web installer hard‑coded the install template URL to master, so
running it with ie OPERATOR_VERSION=0.24.1 installed a 0.24.1 operator
image but master CRDs/config/configmaps, creating version skew.

Signed-off-by: Maciej Bąk <realyota@gmail.com>

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
