### PR TITLE
fix(helm): propagate configs.watch.namespaces to operator ConfigMap

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/_helpers.tpl
+++ b/deploy/helm/clickhouse-operator/templates/_helpers.tpl
@@ -122,3 +122,27 @@ null
 {{- tpl (toYaml (dict $k $v)) $root }}
 {{ end }}
 {{- end }}
+
+{{/*
+altinity-clickhouse-operator.operatorFilesData returns configs.files with
+configs.watch merged into configs.files.config.yaml.watch so that the
+user-facing configs.watch.namespaces value actually takes effect.
+
+Without this, configs.watch.namespaces is silently ignored because the
+ConfigMap template renders configs.files directly, which contains a
+hardcoded watch.namespaces: [] in the config.yaml blob.
+
+See: https://github.com/Altinity/clickhouse-operator/issues/1919
+*/}}
+{{- define "altinity-clickhouse-operator.operatorFilesData" -}}
+{{- $files := deepCopy .Values.configs.files -}}
+{{- if and .Values.configs.watch .Values.configs.watch.namespaces -}}
+  {{- if index $files "config.yaml" -}}
+    {{- $configYaml := index $files "config.yaml" -}}
+    {{- if kindIs "map" $configYaml -}}
+      {{- $_ := set $configYaml "watch" (deepCopy .Values.configs.watch) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- toJson $files -}}
+{{- end -}}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
@@ -11,4 +11,4 @@ metadata:
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
-data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.files) | nindent 2 }}
+data: {{ include "altinity-clickhouse-operator.configmap-data" (list . (include "altinity-clickhouse-operator.operatorFilesData" . | fromJson)) | nindent 2 }}


### PR DESCRIPTION
## Summary

- Fixes `configs.watch.namespaces` being silently ignored in the Helm chart — the operator ConfigMap always rendered `watch.namespaces: []` regardless of user-provided values
- Adds an `operatorFilesData` helper that merges `configs.watch` into `configs.files.config.yaml.watch` before rendering the ConfigMap
- Updates both the generator script (`dev/generate_helm_chart.sh`) and the generated output
- 3-file change, fully backwards-compatible

## Problem

The `values.yaml` has two separate paths that both define `watch.namespaces`:

1. **`configs.watch.namespaces`** — the user-facing value, but never read by any template
2. **`configs.files.config.yaml.watch.namespaces`** — hardcoded to `[]` inside the `config.yaml` blob, and this is what the ConfigMap template actually renders

When users set `configs.watch.namespaces: [clickhouse]`, the operator still only watches its own namespace because the ConfigMap template reads from `configs.files` directly.

## Fix

**`templates/_helpers.tpl`** — New `operatorFilesData` helper:
1. Deep-copies `configs.files`
2. If `configs.watch.namespaces` is non-empty, merges it into `config.yaml.watch`
3. Returns the merged data for the ConfigMap template to render

**`templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml`** — Uses `operatorFilesData` instead of `configs.files` directly

**`dev/generate_helm_chart.sh`** — Updated `update_configmap_resource()` so that re-running the generator produces the same output (special-cases `etc-clickhouse-operator-files` to use the new helper)

## Testing

Tested on a local kind cluster:

| Test | Expected | Actual |
|---|---|---|
| `--set configs.watch.namespaces[0]=clickhouse --set configs.watch.namespaces[1]=my-other-ns` | `namespaces: [clickhouse, my-other-ns]` | `namespaces: [clickhouse, my-other-ns]` |
| No override (default) | `namespaces: []` | `namespaces: []` |

```bash
# With override
helm install test-operator deploy/helm/clickhouse-operator/ \
  -n clickhouse-operator --create-namespace \
  --set 'configs.watch.namespaces[0]=clickhouse'
kubectl -n clickhouse-operator get configmap test-operator-altinity-clickhouse-operator-files \
  -o jsonpath='{.data.config\.yaml}' | grep -A3 'watch:'
# Output:
# watch:
#   namespaces:
#   - clickhouse

# Without override (default, backwards-compatible)
helm install test-operator deploy/helm/clickhouse-operator/ \
  -n clickhouse-operator --create-namespace
kubectl -n clickhouse-operator get configmap test-operator-altinity-clickhouse-operator-files \
  -o jsonpath='{.data.config\.yaml}' | grep -A3 'watch:'
# Output:
# watch:
#   namespaces: []
```

`helm lint` passes in both cases.

Fixes #1919