### PR TITLE
fix(helm): propagate configs.watch.namespaces to operator ConfigMap

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/_helpers.tpl
+++ b/deploy/helm/clickhouse-operator/templates/_helpers.tpl
@@ -122,3 +122,27 @@ null
 {{- tpl (toYaml (dict $k $v)) $root }}
 {{ end }}
 {{- end }}
+
+{{/*
+altinity-clickhouse-operator.operatorFilesData returns configs.files with
+configs.watch merged into configs.files.config.yaml.watch so that the
+user-facing configs.watch.namespaces value actually takes effect.
+
+Without this, configs.watch.namespaces is silently ignored because the
+ConfigMap template renders configs.files directly, which contains a
+hardcoded watch.namespaces: [] in the config.yaml blob.
+
+See: https://github.com/Altinity/clickhouse-operator/issues/1919
+*/}}
+{{- define "altinity-clickhouse-operator.operatorFilesData" -}}
+{{- $files := deepCopy .Values.configs.files -}}
+{{- if and .Values.configs.watch .Values.configs.watch.namespaces -}}
+  {{- if index $files "config.yaml" -}}
+    {{- $configYaml := index $files "config.yaml" -}}
+    {{- if kindIs "map" $configYaml -}}
+      {{- $_ := set $configYaml "watch" (deepCopy .Values.configs.watch) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- toJson $files -}}
+{{- end -}}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
@@ -11,4 +11,4 @@ metadata:
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
-data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.files) | nindent 2 }}
+data: {{ include "altinity-clickhouse-operator.configmap-data" (list . (include "altinity-clickhouse-operator.operatorFilesData" . | fromJson)) | nindent 2 }}

--- a/dev/generate_helm_chart.sh
+++ b/dev/generate_helm_chart.sh
@@ -273,7 +273,15 @@ function update_configmap_resource() {
   yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
   yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
-  yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-data\" (list . .Values.configs.'"${camel_cased_name}"') | nindent 2 }}"' "${file}"
+  # For the operator files ConfigMap, use the operatorFilesData helper which
+  # merges configs.watch into configs.files.config.yaml.watch so the user-facing
+  # configs.watch.namespaces value actually takes effect.
+  # See: https://github.com/Altinity/clickhouse-operator/issues/1919
+  if [ "${name}" = "etc-clickhouse-operator-files" ]; then
+    yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-data\" (list . (include \"altinity-clickhouse-operator.operatorFilesData\" . | fromJson)) | nindent 2 }}"' "${file}"
+  else
+    yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-data\" (list . .Values.configs.'"${camel_cased_name}"') | nindent 2 }}"' "${file}"
+  fi
 
   if [ -z "${data}" ]; then
     yq e -i '.configs.'"${camel_cased_name}"' |= null' "${values_yaml}"


### PR DESCRIPTION
## Summary

- Fixes `configs.watch.namespaces` being silently ignored in the Helm chart — the operator ConfigMap always rendered `watch.namespaces: []` regardless of user-provided values
- Adds an `operatorFilesData` helper that merges `configs.watch` into `configs.files.config.yaml.watch` before rendering the ConfigMap
- Updates both the generator script (`dev/generate_helm_chart.sh`) and the generated output
- 3-file change, fully backwards-compatible

## Problem

The `values.yaml` has two separate paths that both define `watch.namespaces`:

1. **`configs.watch.namespaces`** — the user-facing value, but never read by any template
2. **`configs.files.config.yaml.watch.namespaces`** — hardcoded to `[]` inside the `config.yaml` blob, and this is what the ConfigMap template actually renders

When users set `configs.watch.namespaces: [clickhouse]`, the operator still only watches its own namespace because the ConfigMap template reads from `configs.files` directly.

## Fix

**`templates/_helpers.tpl`** — New `operatorFilesData` helper:
1. Deep-copies `configs.files`
2. If `configs.watch.namespaces` is non-empty, merges it into `config.yaml.watch`
3. Returns the merged data for the ConfigMap template to render

**`templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml`** — Uses `operatorFilesData` instead of `configs.files` directly

**`dev/generate_helm_chart.sh`** — Updated `update_configmap_resource()` so that re-running the generator produces the same output (special-cases `etc-clickhouse-operator-files` to use the new helper)

## Testing

Tested on a local kind cluster — installed the **official v0.25.6 chart** to confirm the bug, then installed with the fix to verify.

### Official chart v0.25.6 (bug confirmed)

```bash
$ helm install official-operator altinity/altinity-clickhouse-operator \
    --version 0.25.6 -n clickhouse-operator --create-namespace \
    --set 'configs.watch.namespaces[0]=clickhouse' \
    --set 'configs.watch.namespaces[1]=my-other-ns'

$ kubectl -n clickhouse-operator get configmap \
    official-operator-altinity-clickhouse-operator-files -o json \
    | python3 -c "import json,sys,yaml; print(yaml.dump({'watch': yaml.safe_load(json.load(sys.stdin)['data']['config.yaml'])['watch']}))"

watch:
  namespaces: []       # <-- BUG: user-provided values silently ignored
```

### With this fix

```bash
$ helm install test-operator deploy/helm/clickhouse-operator/ \
    -n clickhouse-operator --create-namespace \
    --set 'configs.watch.namespaces[0]=clickhouse' \
    --set 'configs.watch.namespaces[1]=my-other-ns'

$ kubectl -n clickhouse-operator get configmap \
    test-operator-altinity-clickhouse-operator-files -o json \
    | python3 -c "import json,sys,yaml; print(yaml.dump({'watch': yaml.safe_load(json.load(sys.stdin)['data']['config.yaml'])['watch']}))"

watch:
  namespaces:
  - clickhouse
  - my-other-ns       # <-- FIXED: values correctly propagated
```

### Default (no override — backwards compatibility)

```bash
$ helm install test-operator deploy/helm/clickhouse-operator/ \
    -n clickhouse-operator --create-namespace

watch:
  namespaces: []       # <-- Default preserved, backwards-compatible
```

### Summary

| Chart | `configs.watch.namespaces` set to | ConfigMap actual | Result |
|---|---|---|---|
| Official v0.25.6 (unpatched) | `[clickhouse, my-other-ns]` | `[]` | BUG |
| This fix | `[clickhouse, my-other-ns]` | `[clickhouse, my-other-ns]` | PASS |
| This fix (no override) | *(default)* | `[]` | PASS |

`helm lint` passes in all cases.

Fixes #1919