### PR TITLE
Fix distributed_ddl replicas_path mismatch causing ON CLUSTER DDL to hang

### DIFF
--- a/pkg/model/chi/config/generator.go
+++ b/pkg/model/chi/config/generator.go
@@ -33,6 +33,9 @@ const (
 	// Pattern for string path used in <distributed_ddl><path>XXX</path></distributed_ddl>
 	DistributedDDLPathPattern = "/clickhouse/%s/task_queue/ddl"
 
+	// Pattern for string path used in <distributed_ddl><replicas_path>XXX</replicas_path></distributed_ddl>
+	DistributedDDLReplicasPathPattern = "/clickhouse/%s/task_queue/replicas"
+
 	// Special auto-generated clusters. Each of these clusters lay over all replicas in CHI
 	// 1. Cluster with one shard and all replicas. Used to duplicate data over all replicas.
 	// 2. Cluster with all shards (1 replica). Used to gather/scatter data over all replicas.
@@ -178,6 +181,7 @@ func (c *Generator) getHostZookeeper(host *chi.Host) string {
 	//      <profile>X</profile>
 	util.Iline(b, 4, "<distributed_ddl>")
 	util.Iline(b, 4, "    <path>%s</path>", c.getDistributedDDLPath())
+	util.Iline(b, 4, "    <replicas_path>%s</replicas_path>", c.getDistributedDDLReplicasPath())
 	if c.opts.DistributedDDL.HasProfile() {
 		util.Iline(b, 4, "    <profile>%s</profile>", c.opts.DistributedDDL.GetProfile())
 	}
@@ -543,6 +547,11 @@ func (c *Generator) getHostHostnameAndPorts(host *chi.Host) string {
 // getDistributedDDLPath returns string path used in <distributed_ddl><path>XXX</path></distributed_ddl>
 func (c *Generator) getDistributedDDLPath() string {
 	return fmt.Sprintf(DistributedDDLPathPattern, c.cr.GetName())
+}
+
+// getDistributedDDLReplicasPath returns string path used in <distributed_ddl><replicas_path>XXX</replicas_path></distributed_ddl>
+func (c *Generator) getDistributedDDLReplicasPath() string {
+	return fmt.Sprintf(DistributedDDLReplicasPathPattern, c.cr.GetName())
 }
 
 // getRemoteServersReplicaHostname returns hostname (podhostname + service or FQDN) for "remote_servers.xml"


### PR DESCRIPTION
The operator generates a custom <distributed_ddl><path> per CHI (e.g. /clickhouse/{chi-name}/task_queue/ddl) but does not set <replicas_path>. ClickHouse 25.8+ falls back to the default replicas_path from config.xml (/clickhouse/task_queue/replicas), which is in a different subtree. This causes the DDL workers to never pick up tasks, making any CREATE TABLE ... ON CLUSTER hang indefinitely.

Add <replicas_path> alongside <path> so both use the same per-CHI subtree in ZooKeeper/Keeper.


## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [ ] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
