### PR TITLE
Document custom service template behaviour for CHK

### DIFF
--- a/docs/custom_resource_explained.md
+++ b/docs/custom_resource_explained.md
@@ -507,6 +507,8 @@ Another example with selectively described replicas. Note - `replicasCount` spec
 with additional sections, such as:
 1. `generateName`
 
+**Important:** `serviceTemplates[].spec` is not merged with operator defaults; for ClickHouseKeeperInstallation replica host Services (`replicaServiceTemplate`), include `spec.publishNotReadyAddresses: true` when overriding `spec`.
+
 **`generateName`** is used to explicitly specify service name to be created. `generateName` provides the following macro substitutions:
 1. `{chi}` - ClickHouseInstallation name
 2. `{chiID}` - short hashed ClickHouseInstallation name (BEWARE, this is an experimental feature)


### PR DESCRIPTION
Added an Important note in custom_resource_explained.md to clarify that `serviceTemplates[].spec` is not merged with operator defaults.

For ClickHouseKeeperInstallation replica host services (replicaServiceTemplate), `spec.publishNotReadyAddresses: true` must be set when overriding `spec`; otherwise Kubernetes won’t publish DNS for not-ready Keeper pods, and Keeper peers can’t discover each other during initial Raft bootstrap, which can lead to quorum/readiness deadlock and startup failures.

Signed-off-by: Maciej Bąk <realyota@gmail.com>