### PR TITLE
helm: fix configmap too long

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/hooks/crd-install-configmap.yaml
+++ b/deploy/helm/clickhouse-operator/templates/hooks/crd-install-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "altinity-clickhouse-operator.fullname" . }}-crds
+  name: {{ include "altinity-clickhouse-operator.fullname" . }}-crds-1
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels:
     {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
@@ -21,6 +21,23 @@ data:
 {{ .Files.Get "crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml" | indent 4 }}
   clickhousekeeperinstallations.yaml: |
 {{ .Files.Get "crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml" | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "altinity-clickhouse-operator.fullname" . }}-crds-2
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
+  labels:
+    {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-install-hook
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-7"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.crdHook.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
   clickhouseoperatorconfigurations.yaml: |
 {{ .Files.Get "crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml" | indent 4 }}
 {{- end }}

--- a/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
+++ b/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
@@ -50,21 +50,27 @@ spec:
         - |
           set -e
           echo "Installing/Updating ClickHouse Operator CRDs..."
-          for crd_file in /crds/*.yaml; do
+          for crd_file in /crds/*/*.yaml; do
             echo "Applying $(basename $crd_file)..."
             kubectl apply --server-side=true --force-conflicts -f "$crd_file"
           done
           echo "CRD installation completed successfully"
         volumeMounts:
-        - name: crds
-          mountPath: /crds
+        - name: crds-1
+          mountPath: /crds/1
+          readOnly: true
+        - name: crds-2
+          mountPath: /crds/2
           readOnly: true
         {{- with .Values.crdHook.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       volumes:
-      - name: crds
+      - name: crds-1
         configMap:
-          name: {{ include "altinity-clickhouse-operator.fullname" . }}-crds
+          name: {{ include "altinity-clickhouse-operator.fullname" . }}-crds-1
+      - name: crds-2
+        configMap:
+          name: {{ include "altinity-clickhouse-operator.fullname" . }}-crds-2
 {{- end }}


### PR DESCRIPTION
Fix the helm deployment error:

    Failed sync attempt to ####: one or more objects failed to apply, reason:
    ConfigMap "altinity-clickhouse-operator-crds" is invalid:
    metadata.annotations: Too long: may not be more than 262144 bytes.

Solves [#1911](https://github.com/Altinity/clickhouse-operator/issues/1911)

Signed-off-by: Davide Madrisan <d.madrisan@proton.me>