### PR TITLE
Add security context for crdHook to enable security policy compliance

### DIFF
--- a/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
+++ b/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
@@ -63,6 +63,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.crdHook.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: crds
         configMap:

--- a/deploy/helm/clickhouse-operator/values.schema.json
+++ b/deploy/helm/clickhouse-operator/values.schema.json
@@ -635,6 +635,49 @@
                 }
             }
         },
+        "crdHook": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "affinity": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "containerSecurityContext": {
+                    "type": "object"
+                }
+            }
+        },
         "dashboards": {
             "type": "object",
             "properties": {

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -38,6 +38,16 @@ crdHook:
   affinity: {}
   # crdHook.annotations -- additional annotations for CRD installation job
   annotations: {}
+  # crdHook.containerSecurityContext -- container security context for CRD installation job
+  # check `kubectl explain pod.spec.containers.securityContext` for details
+  containerSecurityContext: {}
+  #  allowPrivilegeEscalation: false
+  #  capabilities:
+  #    drop:
+  #      - ALL
+  #  runAsNonRoot: true
+  #  seccompProfile:
+  #    type: RuntimeDefault
 operator:
   image:
     # operator.image.registry -- optional image registry prefix (e.g. 1234567890.dkr.ecr.us-east-1.amazonaws.com)


### PR DESCRIPTION
Adds crdHook.containerSecurityContext option to configure container security context for the CRD installation job, enabling compliance with security policies (e.g., Kyverno).

Changes
  - values.yaml: Added crdHook.containerSecurityContext configuration option
  - templates/hooks/crd-install-job.yaml: Template now applies the security context to the container
  - values.schema.json: Added missing crdHook section with all its properties

Example usage

```yaml
  crdHook:
    containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - ALL
      runAsNonRoot: true
      seccompProfile:
        type: RuntimeDefault
```