### PR TITLE
Watch ClickHouseOperatorConfiguration in operator namespace

### DIFF
--- a/cmd/operator/app/thread_chi.go
+++ b/cmd/operator/app/thread_chi.go
@@ -81,6 +81,11 @@ func initClickHouse(ctx context.Context) {
 		chopInformerFactoryResyncPeriod,
 		chopinformers.WithNamespace(chop.Config().GetInformerNamespace()),
 	)
+	chopConfigInformerFactory := chopinformers.NewSharedInformerFactoryWithOptions(
+		chopClient,
+		chopInformerFactoryResyncPeriod,
+		chopinformers.WithNamespace(chop.Config().Runtime.Namespace),
+	)
 
 	// Create Controller
 	chiController = chi.NewController(
@@ -88,6 +93,7 @@ func initClickHouse(ctx context.Context) {
 		extClient,
 		kubeClient,
 		dynamicClient,
+		chopConfigInformerFactory,
 		chopInformerFactory,
 		kubeInformerFactory,
 	)
@@ -98,6 +104,7 @@ func initClickHouse(ctx context.Context) {
 	// Start Informers
 	kubeInformerFactory.Start(ctx.Done())
 	chopInformerFactory.Start(ctx.Done())
+	chopConfigInformerFactory.Start(ctx.Done())
 }
 
 // runClickHouse is an entry point of the application

--- a/pkg/controller/chi/controller.go
+++ b/pkg/controller/chi/controller.go
@@ -90,6 +90,7 @@ func NewController(
 	extClient apiExtensions.Interface,
 	kubeClient kube.Interface,
 	dynamicClient dynamic.Interface,
+	chopConfigInformerFactory chopInformers.SharedInformerFactory,
 	chopInformerFactory chopInformers.SharedInformerFactory,
 	kubeInformerFactory kubeInformers.SharedInformerFactory,
 ) *Controller {
@@ -128,7 +129,7 @@ func NewController(
 		pvcDeleter:    volume.NewPVCDeleter(managers.NewNameManager(managers.NameManagerTypeClickHouse)),
 	}
 	controller.initQueues()
-	controller.addEventHandlers(chopInformerFactory, kubeInformerFactory)
+	controller.addEventHandlers(chopConfigInformerFactory, chopInformerFactory, kubeInformerFactory)
 
 	return controller
 }
@@ -218,32 +219,22 @@ func (c *Controller) addEventHandlersCHIT(
 }
 
 func (c *Controller) addEventHandlersChopConfig(
-	chopInformerFactory chopInformers.SharedInformerFactory,
+	chopConfigInformerFactory chopInformers.SharedInformerFactory,
 ) {
-	chopInformerFactory.Clickhouse().V1().ClickHouseOperatorConfigurations().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	chopConfigInformerFactory.Clickhouse().V1().ClickHouseOperatorConfigurations().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			chopConfig := obj.(*api.ClickHouseOperatorConfiguration)
-			if !chop.Config().IsNamespaceWatched(chopConfig.Namespace) {
-				log.V(2).M(chopConfig).Info("chopInformer: skip event, namespace '%s' is not watched or is in deny list", chopConfig.Namespace)
-				return
-			}
 			log.V(3).M(chopConfig).Info("chopInformer.AddFunc")
 			c.enqueueObject(cmd_queue.NewReconcileChopConfig(cmd_queue.ReconcileAdd, nil, chopConfig))
 		},
 		UpdateFunc: func(old, new interface{}) {
 			newChopConfig := new.(*api.ClickHouseOperatorConfiguration)
 			oldChopConfig := old.(*api.ClickHouseOperatorConfiguration)
-			if !chop.Config().IsNamespaceWatched(newChopConfig.Namespace) {
-				return
-			}
 			log.V(3).M(newChopConfig).Info("chopInformer.UpdateFunc")
 			c.enqueueObject(cmd_queue.NewReconcileChopConfig(cmd_queue.ReconcileUpdate, oldChopConfig, newChopConfig))
 		},
 		DeleteFunc: func(obj interface{}) {
 			chopConfig := obj.(*api.ClickHouseOperatorConfiguration)
-			if !chop.Config().IsNamespaceWatched(chopConfig.Namespace) {
-				return
-			}
 			log.V(3).M(chopConfig).Info("chopInformer.DeleteFunc")
 			c.enqueueObject(cmd_queue.NewReconcileChopConfig(cmd_queue.ReconcileDelete, chopConfig, nil))
 		},
@@ -537,12 +528,13 @@ func (c *Controller) addEventHandlersPod(
 
 // addEventHandlers
 func (c *Controller) addEventHandlers(
+	chopConfigInformerFactory chopInformers.SharedInformerFactory,
 	chopInformerFactory chopInformers.SharedInformerFactory,
 	kubeInformerFactory kubeInformers.SharedInformerFactory,
 ) {
+	c.addEventHandlersChopConfig(chopConfigInformerFactory)
 	c.addEventHandlersCHI(chopInformerFactory)
 	c.addEventHandlersCHIT(chopInformerFactory)
-	c.addEventHandlersChopConfig(chopInformerFactory)
 	c.addEventHandlersService(kubeInformerFactory)
 	//c.addEventHandlersEndpoints(kubeInformerFactory)
 	c.addEventHandlersEndpointSlice(kubeInformerFactory)


### PR DESCRIPTION
## Summary
- create a dedicated informer factory for ClickHouseOperatorConfiguration scoped to the operator namespace
- keep CHI and CHIT informers scoped by the configured watch namespace settings
- register all event handlers in one place while wiring CHOP config handlers to the dedicated informer factory