### PR TITLE
Restart operator on operator configuration change

### DIFF
--- a/cmd/operator/app/thread_chi.go
+++ b/cmd/operator/app/thread_chi.go
@@ -62,7 +62,7 @@ func initClickHouse(ctx context.Context) {
 	chop.New(kubeClient, chopClient, chopConfigFile)
 	log.V(1).F().Info("Config parsed:")
 	log.Info("\n" + chop.Config().String(true))
-	if chop.Config().Restart.OnOperatorConfigurationChange {
+	if chop.Config().RestartOnOperatorConfigurationChange() {
 		log.Info("Auto-restart on ClickHouseOperatorConfiguration change is enabled")
 	} else {
 		log.Info("Auto-restart on ClickHouseOperatorConfiguration change is disabled")

--- a/cmd/operator/app/thread_chi.go
+++ b/cmd/operator/app/thread_chi.go
@@ -62,6 +62,11 @@ func initClickHouse(ctx context.Context) {
 	chop.New(kubeClient, chopClient, chopConfigFile)
 	log.V(1).F().Info("Config parsed:")
 	log.Info("\n" + chop.Config().String(true))
+	if chop.Config().Restart.OnOperatorConfigurationChange {
+		log.Info("Auto-restart on ClickHouseOperatorConfiguration change is enabled")
+	} else {
+		log.Info("Auto-restart on ClickHouseOperatorConfiguration change is disabled")
+	}
 
 	// Log namespace deny list configuration
 	if chop.Config().Watch.Namespaces.Exclude.Len() > 0 {

--- a/config/config-dev.yaml
+++ b/config/config-dev.yaml
@@ -27,9 +27,9 @@ watch:
     include: [dev, test]
     exclude: []
 
-# Restart operator when ClickHouseOperatorConfiguration changes.
-restart:
-  onOperatorConfigurationChange: true
+  # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+  configuration:
+    onChange: restart
 
 clickhouse:
   configuration:

--- a/config/config-dev.yaml
+++ b/config/config-dev.yaml
@@ -27,6 +27,10 @@ watch:
     include: [dev, test]
     exclude: []
 
+# Restart operator when ClickHouseOperatorConfiguration changes.
+restart:
+  onOperatorConfigurationChange: true
+
 clickhouse:
   configuration:
     ################################################

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,9 +25,9 @@ watch:
   # Regexp is applicable.
   namespaces: []
 
-# Restart operator when ClickHouseOperatorConfiguration changes.
-restart:
-  onOperatorConfigurationChange: true
+  # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+  configuration:
+    onChange: restart
 
 clickhouse:
   configuration:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,6 +25,10 @@ watch:
   # Regexp is applicable.
   namespaces: []
 
+# Restart operator when ClickHouseOperatorConfiguration changes.
+restart:
+  onOperatorConfigurationChange: true
+
 clickhouse:
   configuration:
     ################################################

--- a/deploy/builder/templates-config/config.yaml
+++ b/deploy/builder/templates-config/config.yaml
@@ -19,9 +19,9 @@ watch:
   # Regexp is applicable.
   namespaces: [${WATCH_NAMESPACES}]
 
-# Restart operator when ClickHouseOperatorConfiguration changes.
-restart:
-  onOperatorConfigurationChange: true
+  # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+  configuration:
+    onChange: restart
 
 clickhouse:
   configuration:

--- a/deploy/builder/templates-config/config.yaml
+++ b/deploy/builder/templates-config/config.yaml
@@ -19,6 +19,10 @@ watch:
   # Regexp is applicable.
   namespaces: [${WATCH_NAMESPACES}]
 
+# Restart operator when ClickHouseOperatorConfiguration changes.
+restart:
+  onOperatorConfigurationChange: true
+
 clickhouse:
   configuration:
     ################################################

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
@@ -56,6 +56,13 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                restart:
+                  type: object
+                  description: "Parameters which control operator restart behavior"
+                  properties:
+                    onOperatorConfigurationChange:
+                      type: boolean
+                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
@@ -56,13 +56,16 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
-                restart:
-                  type: object
-                  description: "Parameters which control operator restart behavior"
-                  properties:
-                    onOperatorConfigurationChange:
-                      type: boolean
-                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - restart
+                          description: "none — ignore; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -56,6 +56,13 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                restart:
+                  type: object
+                  description: "Parameters which control operator restart behavior"
+                  properties:
+                    onOperatorConfigurationChange:
+                      type: boolean
+                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -56,13 +56,16 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
-                restart:
-                  type: object
-                  description: "Parameters which control operator restart behavior"
-                  properties:
-                    onOperatorConfigurationChange:
-                      type: boolean
-                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - restart
+                          description: "none — ignore; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/helm/clickhouse-operator/values.schema.json
+++ b/deploy/helm/clickhouse-operator/values.schema.json
@@ -569,7 +569,16 @@
                                     "type": "object",
                                     "properties": {
                                         "namespaces": {
-                                            "type": "array"
+                                            "type": ["array", "object"]
+                                        },
+                                        "configuration": {
+                                            "type": "object",
+                                            "properties": {
+                                                "onChange": {
+                                                    "type": "string",
+                                                    "enum": ["none", "restart"]
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -279,6 +279,10 @@ configs:
         # IMPORTANT
         # Regexp is applicable.
         namespaces: []
+
+        # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+        configuration:
+          onChange: restart
       clickhouse:
         configuration:
           ################################################

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -5080,6 +5080,10 @@ data:
       # Regexp is applicable.
       namespaces: [{{ namespace }}]
     
+    # Restart operator when ClickHouseOperatorConfiguration changes.
+    restart:
+      onOperatorConfigurationChange: true
+    
     clickhouse:
       configuration:
         ################################################

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -3283,6 +3283,13 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                restart:
+                  type: object
+                  description: "Parameters which control operator restart behavior"
+                  properties:
+                    onOperatorConfigurationChange:
+                      type: boolean
+                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -3283,13 +3283,16 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
-                restart:
-                  type: object
-                  description: "Parameters which control operator restart behavior"
-                  properties:
-                    onOperatorConfigurationChange:
-                      type: boolean
-                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - restart
+                          description: "none — ignore; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"
@@ -5079,10 +5082,10 @@ data:
       # IMPORTANT
       # Regexp is applicable.
       namespaces: [{{ namespace }}]
-    
-    # Restart operator when ClickHouseOperatorConfiguration changes.
-    restart:
-      onOperatorConfigurationChange: true
+
+      # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+      configuration:
+        onChange: restart
     
     clickhouse:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -3250,6 +3250,13 @@ spec:
                   type: object
                   description: "List of namespaces where clickhouse-operator watches for events."
                   x-kubernetes-preserve-unknown-fields: true
+            restart:
+              type: object
+              description: "Parameters which control operator restart behavior"
+              properties:
+                onOperatorConfigurationChange:
+                  type: boolean
+                  description: "Restart operator when ClickHouseOperatorConfiguration changes"
             clickhouse:
               type: object
               description: "Clickhouse related parameters used by clickhouse-operator"
@@ -4722,7 +4729,6 @@ metadata:
   namespace: kube-system
   labels:
     clickhouse.altinity.com/chop: 0.27.0
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -4975,7 +4981,6 @@ subjects:
   - kind: ServiceAccount
     name: clickhouse-operator
     namespace: kube-system
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -5271,6 +5276,10 @@ data:
       # IMPORTANT
       # Regexp is applicable.
       namespaces: []
+
+    # Restart operator when ClickHouseOperatorConfiguration changes.
+    restart:
+      onOperatorConfigurationChange: true
 
     clickhouse:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -3250,13 +3250,16 @@ spec:
                   type: object
                   description: "List of namespaces where clickhouse-operator watches for events."
                   x-kubernetes-preserve-unknown-fields: true
-            restart:
-              type: object
-              description: "Parameters which control operator restart behavior"
-              properties:
-                onOperatorConfigurationChange:
-                  type: boolean
-                  description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                configuration:
+                  type: object
+                  description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                  properties:
+                    onChange:
+                      type: string
+                      enum:
+                        - none
+                        - restart
+                      description: "none — ignore; restart — exit process so the operator pod restarts"
             clickhouse:
               type: object
               description: "Clickhouse related parameters used by clickhouse-operator"
@@ -5277,9 +5280,9 @@ data:
       # Regexp is applicable.
       namespaces: []
 
-    # Restart operator when ClickHouseOperatorConfiguration changes.
-    restart:
-      onOperatorConfigurationChange: true
+      # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+      configuration:
+        onChange: restart
 
     clickhouse:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -5339,6 +5339,10 @@ data:
       # Regexp is applicable.
       namespaces: []
     
+    # Restart operator when ClickHouseOperatorConfiguration changes.
+    restart:
+      onOperatorConfigurationChange: true
+    
     clickhouse:
       configuration:
         ################################################

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -3276,13 +3276,16 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
-                restart:
-                  type: object
-                  description: "Parameters which control operator restart behavior"
-                  properties:
-                    onOperatorConfigurationChange:
-                      type: boolean
-                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - restart
+                          description: "none — ignore; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"
@@ -5338,10 +5341,10 @@ data:
       # IMPORTANT
       # Regexp is applicable.
       namespaces: []
-    
-    # Restart operator when ClickHouseOperatorConfiguration changes.
-    restart:
-      onOperatorConfigurationChange: true
+
+      # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+      configuration:
+        onChange: restart
     
     clickhouse:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -3276,6 +3276,13 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                restart:
+                  type: object
+                  description: "Parameters which control operator restart behavior"
+                  properties:
+                    onOperatorConfigurationChange:
+                      type: boolean
+                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -3250,6 +3250,13 @@ spec:
                   type: object
                   description: "List of namespaces where clickhouse-operator watches for events."
                   x-kubernetes-preserve-unknown-fields: true
+            restart:
+              type: object
+              description: "Parameters which control operator restart behavior"
+              properties:
+                onOperatorConfigurationChange:
+                  type: boolean
+                  description: "Restart operator when ClickHouseOperatorConfiguration changes"
             clickhouse:
               type: object
               description: "Clickhouse related parameters used by clickhouse-operator"
@@ -4722,7 +4729,6 @@ metadata:
   namespace: ${OPERATOR_NAMESPACE}
   labels:
     clickhouse.altinity.com/chop: 0.27.0
-
 # Template Parameters:
 #
 # NAMESPACE=${OPERATOR_NAMESPACE}
@@ -5018,6 +5024,10 @@ data:
       # IMPORTANT
       # Regexp is applicable.
       namespaces: []
+
+    # Restart operator when ClickHouseOperatorConfiguration changes.
+    restart:
+      onOperatorConfigurationChange: true
 
     clickhouse:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -3250,13 +3250,16 @@ spec:
                   type: object
                   description: "List of namespaces where clickhouse-operator watches for events."
                   x-kubernetes-preserve-unknown-fields: true
-            restart:
-              type: object
-              description: "Parameters which control operator restart behavior"
-              properties:
-                onOperatorConfigurationChange:
-                  type: boolean
-                  description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                configuration:
+                  type: object
+                  description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                  properties:
+                    onChange:
+                      type: string
+                      enum:
+                        - none
+                        - restart
+                      description: "none — ignore; restart — exit process so the operator pod restarts"
             clickhouse:
               type: object
               description: "Clickhouse related parameters used by clickhouse-operator"
@@ -5025,9 +5028,9 @@ data:
       # Regexp is applicable.
       namespaces: []
 
-    # Restart operator when ClickHouseOperatorConfiguration changes.
-    restart:
-      onOperatorConfigurationChange: true
+      # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+      configuration:
+        onChange: restart
 
     clickhouse:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -3276,13 +3276,16 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
-                restart:
-                  type: object
-                  description: "Parameters which control operator restart behavior"
-                  properties:
-                    onOperatorConfigurationChange:
-                      type: boolean
-                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - restart
+                          description: "none — ignore; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"
@@ -5072,10 +5075,10 @@ data:
       # IMPORTANT
       # Regexp is applicable.
       namespaces: []
-    
-    # Restart operator when ClickHouseOperatorConfiguration changes.
-    restart:
-      onOperatorConfigurationChange: true
+
+      # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+      configuration:
+        onChange: restart
     
     clickhouse:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -5073,6 +5073,10 @@ data:
       # Regexp is applicable.
       namespaces: []
     
+    # Restart operator when ClickHouseOperatorConfiguration changes.
+    restart:
+      onOperatorConfigurationChange: true
+    
     clickhouse:
       configuration:
         ################################################

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -3276,6 +3276,13 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                restart:
+                  type: object
+                  description: "Parameters which control operator restart behavior"
+                  properties:
+                    onOperatorConfigurationChange:
+                      type: boolean
+                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -5080,6 +5080,10 @@ data:
       # Regexp is applicable.
       namespaces: [${namespace}]
     
+    # Restart operator when ClickHouseOperatorConfiguration changes.
+    restart:
+      onOperatorConfigurationChange: true
+    
     clickhouse:
       configuration:
         ################################################

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -3283,6 +3283,13 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                restart:
+                  type: object
+                  description: "Parameters which control operator restart behavior"
+                  properties:
+                    onOperatorConfigurationChange:
+                      type: boolean
+                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -3283,13 +3283,16 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
-                restart:
-                  type: object
-                  description: "Parameters which control operator restart behavior"
-                  properties:
-                    onOperatorConfigurationChange:
-                      type: boolean
-                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - restart
+                          description: "none — ignore; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"
@@ -5079,10 +5082,10 @@ data:
       # IMPORTANT
       # Regexp is applicable.
       namespaces: [${namespace}]
-    
-    # Restart operator when ClickHouseOperatorConfiguration changes.
-    restart:
-      onOperatorConfigurationChange: true
+
+      # Behavior when ClickHouseOperatorConfiguration changes: none | restart
+      configuration:
+        onChange: restart
     
     clickhouse:
       configuration:

--- a/deploy/operator/parts/crd.yaml
+++ b/deploy/operator/parts/crd.yaml
@@ -8224,6 +8224,13 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                restart:
+                  type: object
+                  description: "Parameters which control operator restart behavior"
+                  properties:
+                    onOperatorConfigurationChange:
+                      type: boolean
+                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/deploy/operator/parts/crd.yaml
+++ b/deploy/operator/parts/crd.yaml
@@ -8224,13 +8224,16 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
-                restart:
-                  type: object
-                  description: "Parameters which control operator restart behavior"
-                  properties:
-                    onOperatorConfigurationChange:
-                      type: boolean
-                      description: "Restart operator when ClickHouseOperatorConfiguration changes"
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - restart
+                          description: "none — ignore; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"

--- a/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
@@ -197,6 +197,15 @@ type OperatorConfigRuntime struct {
 type OperatorConfigWatch struct {
 	// Namespaces where operator watches for events
 	Namespaces OperatorConfigWatchNamespaces `json:"namespaces" yaml:"namespaces"`
+
+	// Configuration specifies behavior related to ClickHouseOperatorConfiguration watches
+	Configuration OperatorConfigWatchConfiguration `json:"configuration,omitempty" yaml:"configuration,omitempty"`
+}
+
+// OperatorConfigWatchConfiguration specifies behavior when operator-wide configuration changes.
+type OperatorConfigWatchConfiguration struct {
+	// OnChange controls reaction to ClickHouseOperatorConfiguration changes: "none" or "restart".
+	OnChange string `json:"onChange,omitempty" yaml:"onChange,omitempty"`
 }
 
 type OperatorConfigWatchNamespaces struct {
@@ -733,10 +742,6 @@ type OperatorConfigStatusFields struct {
 	Errors  *types.StringBool `json:"errors,omitempty"  yaml:"errors,omitempty"`
 }
 
-type OperatorConfigRestart struct {
-	OnOperatorConfigurationChange bool `json:"onOperatorConfigurationChange" yaml:"onOperatorConfigurationChange"`
-}
-
 type ConfigCRSource struct {
 	Namespace string
 	Name      string
@@ -754,7 +759,6 @@ type OperatorConfig struct {
 	Label       OperatorConfigLabel      `json:"label"      yaml:"label"`
 	Metrics     OperatorConfigMetrics    `json:"metrics"    yaml:"metrics"`
 	Status      OperatorConfigStatus     `json:"status"     yaml:"status"`
-	Restart     OperatorConfigRestart    `json:"restart"    yaml:"restart"`
 	StatefulSet struct {
 		// Revision history limit
 		RevisionHistoryLimit int `json:"revisionHistoryLimit" yaml:"revisionHistoryLimit"`
@@ -1410,6 +1414,12 @@ func (c *OperatorConfig) copyWithHiddenCredentials() *OperatorConfig {
 	conf.CHPassword = PasswordReplacer
 
 	return conf
+}
+
+// RestartOnOperatorConfigurationChange reports whether the operator process should exit when
+// ClickHouseOperatorConfiguration changes (so the pod restarts).
+func (c *OperatorConfig) RestartOnOperatorConfigurationChange() bool {
+	return strings.ToLower(c.Watch.Configuration.OnChange) == "restart"
 }
 
 // IsNamespaceWatched returns whether specified namespace is in a list of watched

--- a/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
@@ -733,6 +733,10 @@ type OperatorConfigStatusFields struct {
 	Errors  *types.StringBool `json:"errors,omitempty"  yaml:"errors,omitempty"`
 }
 
+type OperatorConfigRestart struct {
+	OnOperatorConfigurationChange bool `json:"onOperatorConfigurationChange" yaml:"onOperatorConfigurationChange"`
+}
+
 type ConfigCRSource struct {
 	Namespace string
 	Name      string
@@ -750,6 +754,7 @@ type OperatorConfig struct {
 	Label       OperatorConfigLabel      `json:"label"      yaml:"label"`
 	Metrics     OperatorConfigMetrics    `json:"metrics"    yaml:"metrics"`
 	Status      OperatorConfigStatus     `json:"status"     yaml:"status"`
+	Restart     OperatorConfigRestart    `json:"restart"    yaml:"restart"`
 	StatefulSet struct {
 		// Revision history limit
 		RevisionHistoryLimit int `json:"revisionHistoryLimit" yaml:"revisionHistoryLimit"`

--- a/pkg/controller/chi/controller.go
+++ b/pkg/controller/chi/controller.go
@@ -782,7 +782,7 @@ func (c *Controller) deleteChopConfig(chopConfig *api.ClickHouseOperatorConfigur
 }
 
 func (c *Controller) restartOperatorOnConfigChange(reason string) {
-	if !chop.Config().Restart.OnOperatorConfigurationChange {
+	if !chop.Config().RestartOnOperatorConfigurationChange() {
 		log.V(1).Info("Operator restart on configuration change is disabled")
 		return
 	}

--- a/pkg/controller/chi/controller.go
+++ b/pkg/controller/chi/controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -751,10 +752,8 @@ func (c *Controller) addChopConfig(chopConfig *api.ClickHouseOperatorConfigurati
 	if chop.Get().ConfigManager.IsConfigListed(chopConfig) {
 		log.V(1).M(chopConfig).F().Info("already known config - do nothing")
 	} else {
-		log.V(1).M(chopConfig).F().Info("new, previously unknown config, need to apply")
-		// TODO
-		// NEED REFACTORING
-		// os.Exit(0)
+		log.V(1).M(chopConfig).F().Info("new, previously unknown config")
+		c.restartOperatorOnConfigChange("ClickHouseOperatorConfiguration added")
 	}
 
 	return nil
@@ -769,9 +768,7 @@ func (c *Controller) updateChopConfig(old, new *api.ClickHouseOperatorConfigurat
 	}
 
 	log.V(2).M(new).F().Info("ResourceVersion change: %s to %s", old.GetObjectMeta().GetResourceVersion(), new.GetObjectMeta().GetResourceVersion())
-	// TODO
-	// NEED REFACTORING
-	//os.Exit(0)
+	c.restartOperatorOnConfigChange("ClickHouseOperatorConfiguration updated")
 
 	return nil
 }
@@ -779,11 +776,19 @@ func (c *Controller) updateChopConfig(old, new *api.ClickHouseOperatorConfigurat
 // deleteChit deletes CHIT
 func (c *Controller) deleteChopConfig(chopConfig *api.ClickHouseOperatorConfiguration) error {
 	log.V(2).M(chopConfig).F().P()
-	// TODO
-	// NEED REFACTORING
-	//os.Exit(0)
+	c.restartOperatorOnConfigChange("ClickHouseOperatorConfiguration deleted")
 
 	return nil
+}
+
+func (c *Controller) restartOperatorOnConfigChange(reason string) {
+	if !chop.Config().Restart.OnOperatorConfigurationChange {
+		log.V(1).Info("Operator restart on configuration change is disabled")
+		return
+	}
+
+	log.Info("Operator restart requested: %s", reason)
+	os.Exit(0)
 }
 
 type patchFinalizers struct {

--- a/tests/e2e/manifests/chopconf/test-033-auto-restart.yaml
+++ b/tests/e2e/manifests/chopconf/test-033-auto-restart.yaml
@@ -1,0 +1,9 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseOperatorConfiguration"
+metadata:
+  name: "test-033-auto-restart"
+spec:
+  reconcile:
+    statefulSet:
+      update:
+        timeout: 61

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -303,6 +303,57 @@ def check_operator_restart(chi, wait_objects, pod, shell=None):
             assert start_time == new_start_time
 
 
+def _operator_pod_container_restart_total(pod_name, ns=None, shell=None, ok_to_fail=False):
+    """Sum of .status.containerStatuses[*].restartCount (detect in-place container restarts)."""
+    if not pod_name:
+        return 0
+    pod = kubectl.get("pod", pod_name, ns=ns, ok_to_fail=ok_to_fail, shell=shell)
+    if not pod:
+        return 0
+    statuses = (pod.get("status") or {}).get("containerStatuses") or []
+    return sum(int(cs.get("restartCount") or 0) for cs in statuses)
+
+
+def wait_for_operator_pod_restart(old_pod_name, ns=None, timeout=180, shell=None):
+    if ns is None:
+        ns = current().context.operator_namespace
+
+    initial_restart_total = _operator_pod_container_restart_total(
+        old_pod_name, ns=ns, shell=shell, ok_to_fail=False
+    )
+
+    with Then("Operator pod should be restarted automatically (new pod or container restart)"):
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            new_pod_name = kubectl.get_operator_pod(ns=ns, shell=shell)
+            if not new_pod_name:
+                time.sleep(1)
+                continue
+
+            if new_pod_name != old_pod_name:
+                kubectl.wait_pod_status(new_pod_name, "Running", ns=ns, shell=shell)
+                print(f"old operator pod: {old_pod_name}")
+                print(f"new operator pod: {new_pod_name}")
+                return new_pod_name
+
+            current_restart_total = _operator_pod_container_restart_total(
+                new_pod_name, ns=ns, shell=shell, ok_to_fail=True
+            )
+            if current_restart_total > initial_restart_total:
+                kubectl.wait_pod_status(new_pod_name, "Running", ns=ns, shell=shell)
+                print(f"operator pod (unchanged name): {new_pod_name}")
+                print(
+                    f"container restart total: {initial_restart_total} -> {current_restart_total}"
+                )
+                return new_pod_name
+
+            time.sleep(1)
+
+        assert False, error(
+            f"operator was not restarted (no new pod, no container restart) within {timeout} seconds"
+        )
+
+
 @TestCheck
 def test_operator_restart(self, manifest, service, version=None):
     if version is None:
@@ -3636,6 +3687,34 @@ def test_010032(self):
     # with Then("I recreate shell"):
     #    shell = get_shell()
     #    self.context.shell = shell
+
+    with Finally("I clean up"):
+        delete_test_namespace()
+
+
+@TestScenario
+@Requirements(RQ_SRS_026_ClickHouseOperator_Settings_ClickHouseOperatorConfiguration_Changes("1.0"))
+@Name("test_010033. Restart operator automatically on ClickHouseOperatorConfiguration change")
+def test_010033(self):
+    create_shell_namespace_clickhouse_template()
+
+    chopconf_file = "manifests/chopconf/test-033-auto-restart.yaml"
+    operator_namespace = current().context.operator_namespace
+
+    with Given(f"operator pod before applying {chopconf_file}"):
+        operator_pod = kubectl.get_operator_pod(ns=operator_namespace)
+
+    with When("Apply ClickHouseOperatorConfiguration"):
+        kubectl.apply(util.get_full_path(chopconf_file, lookup_in_host=False), operator_namespace)
+
+        with Then("Operator should restart automatically after configuration is applied"):
+            operator_pod = wait_for_operator_pod_restart(operator_pod, ns=operator_namespace)
+
+    with Then("Deleting ClickHouseOperatorConfiguration"):
+        kubectl.delete(util.get_full_path(chopconf_file, lookup_in_host=False), operator_namespace)
+
+        with Then("Operator should restart back after cleanup"):
+            wait_for_operator_pod_restart(operator_pod, ns=operator_namespace)
 
     with Finally("I clean up"):
         delete_test_namespace()


### PR DESCRIPTION
Add operator config option to control if operator needs to be restarted on config changes or not. Enabled by default.

```
watch
  configuration:
    onChange: restart
```

Closes #1930