### PR TITLE
chk probe crashloop fix

### DIFF
--- a/pkg/model/chk/creator/probe.go
+++ b/pkg/model/chk/creator/probe.go
@@ -50,7 +50,7 @@ func (m *ProbeManager) createDefaultStartupProbe(_ *api.Host) *core.Probe {
 	return &core.Probe{
 		ProbeHandler: core.ProbeHandler{
 			Exec: &core.ExecAction{
-				Command: []string{"pgrep", "clickhouse-keeper"},
+				Command: []string{"pgrep", "-f","clickhouse-keeper"},
 			},
 		},
 		InitialDelaySeconds: 1,
@@ -66,7 +66,7 @@ func (m *ProbeManager) createDefaultLivenessProbe(_ *api.Host) *core.Probe {
 	return &core.Probe{
 		ProbeHandler: core.ProbeHandler{
 			Exec: &core.ExecAction{
-				Command: []string{"pgrep", "clickhouse-keeper"},
+				Command: []string{"pgrep", "-f","clickhouse-keeper"},
 			},
 		},
 		InitialDelaySeconds: 5,


### PR DESCRIPTION
* probe runs pgrep clickhouse-keeper, but the Linux process name is truncated to 15 characters (clickhouse-keep), causing the probe to always fail. Keeper pods enter a persistent CrashLoopBackOff after ~65 seconds.  pgrep -f will  match full name

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
    
Signed-off-by: Hanan Ben Shmouel <hananbs158@gmail.com>
