### PR TITLE
fix(chk): prevent nil pointer panic in poll when CR Get fails

### DIFF
--- a/pkg/controller/chk/controller.go
+++ b/pkg/controller/chk/controller.go
@@ -143,7 +143,20 @@ func (c *Controller) poll(ctx context.Context, cr api.ICustomResource, f func(c 
 
 	for {
 		cur, err := c.kube.CR().Get(ctx, namespace, name)
-		if f(cur.(*apiChk.ClickHouseKeeperInstallation), err) {
+		chk, ok := cur.(*apiChk.ClickHouseKeeperInstallation)
+		if !ok || chk == nil {
+			if apiErrors.IsNotFound(err) {
+				return
+			}
+			log.V(1).Info("poll Get error for %s: %v", cr.GetName(), err)
+			if util.IsContextDone(ctx) {
+				log.V(1).Info("Poll is aborted. Cr: %s ", cr.GetName())
+				return
+			}
+			time.Sleep(15 * time.Second)
+			continue
+		}
+		if f(chk, err) {
 			// Continue polling
 			if util.IsContextDone(ctx) {
 				log.V(1).Info("Poll is aborted. Cr: %s ", cr.GetName())


### PR DESCRIPTION
Fixes https://github.com/Altinity/clickhouse-operator/issues/1972

## What this PR fixes

The `poll` function in the ClickHouseKeeperInstallation controller panics when `c.kube.CR().Get()` returns an error because `cur` is nil, and the code performs an unchecked type assertion:

```go
cur, err := c.kube.CR().Get(ctx, namespace, name)
if f(cur.(*apiChk.ClickHouseKeeperInstallation), err) {  // ← panics when cur is nil
```

This causes the operator to crashloop with:
```
panic: interface conversion: v1.ICustomResource is nil, not *v1.ClickHouseKeeperInstallation
```

## Changes

- Added a type assertion with ok-check in `pkg/controller/chk/controller.go` `poll()` function
- If the CR cannot be fetched:
  - **NotFound**: return immediately (CR was deleted, no point polling)
  - **Other error**: log and continue polling with 15s backoff
- Only call the callback `f()` when `chk` is valid

This follows the same safe pattern already used in `statusUpdateProcess()` in `pkg/controller/chk/kube/cr.go`.