### PR TITLE
excludeMetricsRegexp -- filter out noisy metrics, e,g CPU and OS

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -252,6 +252,10 @@ clickhouse:
     # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
     # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
     tablesRegexp: "^(metrics|custom_metrics)$"
+    # List of regexps to match ClickHouse metrics to exclude from export.
+    # Regexps match internal metric names before Prometheus normalization and prefixing.
+    excludeMetricsRegexp:
+      - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
 
 keeper:
   configuration:

--- a/deploy/builder/templates-config/config.yaml
+++ b/deploy/builder/templates-config/config.yaml
@@ -246,6 +246,10 @@ clickhouse:
     # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
     # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
     tablesRegexp: "^(metrics|custom_metrics)$"
+    # List of regexps to match ClickHouse metrics to exclude from export.
+    # Regexps match internal metric names before Prometheus normalization and prefixing.
+    excludeMetricsRegexp:
+      - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
 
 keeper:
   configuration:

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
@@ -260,6 +260,13 @@ spec:
                             Regexp to match tables in system database to fetch metrics from.
                             Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                             Default is "^(metrics|custom_metrics)$".
+                        excludeMetricsRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -260,6 +260,13 @@ spec:
                             Regexp to match tables in system database to fetch metrics from.
                             Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                             Default is "^(metrics|custom_metrics)$".
+                        excludeMetricsRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"

--- a/deploy/helm/clickhouse-operator/values.schema.json
+++ b/deploy/helm/clickhouse-operator/values.schema.json
@@ -319,6 +319,15 @@
                                         "metrics": {
                                             "type": "object",
                                             "properties": {
+                                                "excludeMetricsRegexp": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "tablesRegexp": {
+                                                    "type": "string"
+                                                },
                                                 "timeouts": {
                                                     "type": "object",
                                                     "properties": {

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -491,6 +491,10 @@ configs:
           # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
           # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
           tablesRegexp: "^(metrics|custom_metrics)$"
+          # List of regexps to match ClickHouse metrics to exclude from export.
+          # Regexps match internal metric names before Prometheus normalization and prefixing.
+          excludeMetricsRegexp:
+            - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
       keeper:
         configuration:
           ################################################

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -3487,6 +3487,13 @@ spec:
                             Regexp to match tables in system database to fetch metrics from.
                             Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                             Default is "^(metrics|custom_metrics)$".
+                        excludeMetricsRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -5338,6 +5345,10 @@ data:
         # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
         # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
         tablesRegexp: "^(metrics|custom_metrics)$"
+        # List of regexps to match ClickHouse metrics to exclude from export.
+        # Regexps match internal metric names before Prometheus normalization and prefixing.
+        excludeMetricsRegexp:
+          - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
     
     keeper:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -3454,6 +3454,13 @@ spec:
                         Regexp to match tables in system database to fetch metrics from.
                         Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                         Default is "^(metrics|custom_metrics)$".
+                    excludeMetricsRegexp:
+                      type: array
+                      items:
+                        type: string
+                      description: |
+                        List of regexps to match ClickHouse metrics to exclude from export.
+                        Regexps match internal metric names before Prometheus normalization and prefixing.
             template:
               type: object
               description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -4760,7 +4767,6 @@ metadata:
   namespace: kube-system
   labels:
     clickhouse.altinity.com/chop: 0.27.0
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -5013,7 +5019,6 @@ subjects:
   - kind: ServiceAccount
     name: clickhouse-operator
     namespace: kube-system
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -5537,6 +5542,10 @@ data:
         # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
         # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
         tablesRegexp: "^(metrics|custom_metrics)$"
+        # List of regexps to match ClickHouse metrics to exclude from export.
+        # Regexps match internal metric names before Prometheus normalization and prefixing.
+        excludeMetricsRegexp:
+          - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
 
     keeper:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -3480,6 +3480,13 @@ spec:
                             Regexp to match tables in system database to fetch metrics from.
                             Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                             Default is "^(metrics|custom_metrics)$".
+                        excludeMetricsRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -5597,6 +5604,10 @@ data:
         # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
         # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
         tablesRegexp: "^(metrics|custom_metrics)$"
+        # List of regexps to match ClickHouse metrics to exclude from export.
+        # Regexps match internal metric names before Prometheus normalization and prefixing.
+        excludeMetricsRegexp:
+          - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
     
     keeper:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -3454,6 +3454,13 @@ spec:
                         Regexp to match tables in system database to fetch metrics from.
                         Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                         Default is "^(metrics|custom_metrics)$".
+                    excludeMetricsRegexp:
+                      type: array
+                      items:
+                        type: string
+                      description: |
+                        List of regexps to match ClickHouse metrics to exclude from export.
+                        Regexps match internal metric names before Prometheus normalization and prefixing.
             template:
               type: object
               description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -4760,7 +4767,6 @@ metadata:
   namespace: ${OPERATOR_NAMESPACE}
   labels:
     clickhouse.altinity.com/chop: 0.27.0
-
 # Template Parameters:
 #
 # NAMESPACE=${OPERATOR_NAMESPACE}
@@ -5284,6 +5290,10 @@ data:
         # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
         # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
         tablesRegexp: "^(metrics|custom_metrics)$"
+        # List of regexps to match ClickHouse metrics to exclude from export.
+        # Regexps match internal metric names before Prometheus normalization and prefixing.
+        excludeMetricsRegexp:
+          - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
 
     keeper:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -3480,6 +3480,13 @@ spec:
                             Regexp to match tables in system database to fetch metrics from.
                             Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                             Default is "^(metrics|custom_metrics)$".
+                        excludeMetricsRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -5331,6 +5338,10 @@ data:
         # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
         # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
         tablesRegexp: "^(metrics|custom_metrics)$"
+        # List of regexps to match ClickHouse metrics to exclude from export.
+        # Regexps match internal metric names before Prometheus normalization and prefixing.
+        excludeMetricsRegexp:
+          - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
     
     keeper:
       configuration:

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -3487,6 +3487,13 @@ spec:
                             Regexp to match tables in system database to fetch metrics from.
                             Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                             Default is "^(metrics|custom_metrics)$".
+                        excludeMetricsRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -5338,6 +5345,10 @@ data:
         # Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
         # Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
         tablesRegexp: "^(metrics|custom_metrics)$"
+        # List of regexps to match ClickHouse metrics to exclude from export.
+        # Regexps match internal metric names before Prometheus normalization and prefixing.
+        excludeMetricsRegexp:
+          - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
     
     keeper:
       configuration:

--- a/deploy/operator/parts/crd.yaml
+++ b/deploy/operator/parts/crd.yaml
@@ -8428,6 +8428,13 @@ spec:
                             Regexp to match tables in system database to fetch metrics from.
                             Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
                             Default is "^(metrics|custom_metrics)$".
+                        excludeMetricsRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"

--- a/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -416,6 +417,9 @@ type OperatorConfigClickHouse struct {
 		// Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
 		// Default is "^(metrics|custom_metrics)$" which fetches from both system.metrics and system.custom_metrics.
 		TablesRegexp string `json:"tablesRegexp" yaml:"tablesRegexp"`
+		// ExcludeMetricsRegexp specifies a list of regexps to match ClickHouse metric names to exclude.
+		// Regexps are matched against internal metric names before Prometheus normalization and prefixing.
+		ExcludeMetricsRegexp []string `json:"excludeMetricsRegexp,omitempty" yaml:"excludeMetricsRegexp,omitempty"`
 	} `json:"metrics" yaml:"metrics"`
 }
 
@@ -930,8 +934,15 @@ func (c *OperatorConfig) MergeFrom(from *OperatorConfig) error {
 		return nil
 	}
 
+	excludeMetricsRegexp := from.ClickHouse.Metrics.ExcludeMetricsRegexp
 	if err := mergo.Merge(c, *from, mergo.WithAppendSlice, mergo.WithOverride); err != nil {
 		return fmt.Errorf("FAIL merge config Error: %q", err)
+	}
+
+	// Unlike additive label/template lists, metric exclusion regexps are a complete filter set.
+	// Preserve the distinction between omitted (nil) and explicitly empty ([]) CHOPCONF values.
+	if excludeMetricsRegexp != nil {
+		c.ClickHouse.Metrics.ExcludeMetricsRegexp = slices.Clone(excludeMetricsRegexp)
 	}
 
 	return nil

--- a/pkg/apis/clickhouse.altinity.com/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/zz_generated.deepcopy.go
@@ -1708,6 +1708,11 @@ func (in *OperatorConfigClickHouse) DeepCopyInto(out *OperatorConfigClickHouse) 
 	out.Access = in.Access
 	in.Addons.DeepCopyInto(&out.Addons)
 	out.Metrics = in.Metrics
+	if in.Metrics.ExcludeMetricsRegexp != nil {
+		in, out := &in.Metrics.ExcludeMetricsRegexp, &out.Metrics.ExcludeMetricsRegexp
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/metrics/clickhouse/clickhouse_metrics_fetcher.go
+++ b/pkg/metrics/clickhouse/clickhouse_metrics_fetcher.go
@@ -142,16 +142,19 @@ const (
 type MetricsFetcher struct {
 	connectionParams *clickhouse.EndpointConnectionParams
 	tablesRegexp     string
+	metricFilter     *metricRegexpFilter
 }
 
 // NewMetricsFetcher creates new clickhouse fetcher object
 func NewMetricsFetcher(
 	endpointConnectionParams *clickhouse.EndpointConnectionParams,
 	tablesRegexp string,
+	metricFilter *metricRegexpFilter,
 ) *MetricsFetcher {
 	return &MetricsFetcher{
 		connectionParams: endpointConnectionParams,
 		tablesRegexp:     tablesRegexp,
+		metricFilter:     metricFilter,
 	}
 }
 
@@ -169,12 +172,24 @@ func (f *MetricsFetcher) buildMetricsTableSource() string {
 	return fmt.Sprintf("merge('system','%s')", f.tablesRegexp)
 }
 
+func (f *MetricsFetcher) buildMetricsSQL() string {
+	metricsSQL := fmt.Sprintf(queryMetricsSQLTemplate, f.buildMetricsTableSource())
+	if !f.metricFilter.hasPatterns() {
+		return metricsSQL
+	}
+
+	return fmt.Sprintf(`
+		SELECT metric, value, description, type
+		FROM (%s)
+		WHERE NOT (%s)
+	`, metricsSQL, f.metricFilter.buildExcludeMetricsWhere())
+}
+
 // getClickHouseQueryMetrics requests metrics data from ClickHouse
 func (f *MetricsFetcher) getClickHouseQueryMetrics(ctx context.Context) (Table, error) {
-	metricsSQL := fmt.Sprintf(queryMetricsSQLTemplate, f.buildMetricsTableSource())
 	return f.clickHouseQueryScanRows(
 		ctx,
-		metricsSQL,
+		f.buildMetricsSQL(),
 		func(rows *sql.Rows, data *Table) error {
 			var metric, value, description, _type string
 			if err := rows.Scan(&metric, &value, &description, &_type); err == nil {

--- a/pkg/metrics/clickhouse/exporter.go
+++ b/pkg/metrics/clickhouse/exporter.go
@@ -40,6 +40,7 @@ import (
 type Exporter struct {
 	collectorTimeout time.Duration
 	registry         *CRRegistry
+	metricFilter     *metricRegexpFilter
 }
 
 // Type compatibility
@@ -50,6 +51,7 @@ func NewExporter(registry *CRRegistry, collectorTimeout time.Duration) *Exporter
 	return &Exporter{
 		registry:         registry,
 		collectorTimeout: collectorTimeout,
+		metricFilter:     newMetricRegexpFilter(chop.Config().ClickHouse.Metrics.ExcludeMetricsRegexp),
 	}
 }
 
@@ -93,7 +95,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 func (e *Exporter) collectHostMetrics(ctx context.Context, chi *metrics.WatchedCR, host *metrics.WatchedHost, c chan<- prometheus.Metric) {
 	collector := NewCollector(
 		e.newHostFetcher(host),
-		NewCHIPrometheusWriter(c, chi, host),
+		NewCHIPrometheusWriter(c, chi, host, e.metricFilter),
 	)
 	collector.CollectHostMetrics(ctx, host)
 }
@@ -122,6 +124,7 @@ func (e *Exporter) newHostFetcher(host *metrics.WatchedHost) *MetricsFetcher {
 	return NewMetricsFetcher(
 		clusterConnectionParams.NewEndpointConnectionParams(host.Hostname),
 		chop.Config().ClickHouse.Metrics.TablesRegexp,
+		e.metricFilter,
 	)
 }
 

--- a/pkg/metrics/clickhouse/metric_filter.go
+++ b/pkg/metrics/clickhouse/metric_filter.go
@@ -1,0 +1,82 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clickhouse
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	log "github.com/golang/glog"
+)
+
+type metricRegexpFilter struct {
+	patterns []string
+	regexps  []*regexp.Regexp
+}
+
+func newMetricRegexpFilter(patterns []string) *metricRegexpFilter {
+	filter := &metricRegexpFilter{}
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			log.Warningf("Ignore invalid ClickHouse metric exclusion regexp %q: %v", pattern, err)
+			continue
+		}
+		filter.patterns = append(filter.patterns, pattern)
+		filter.regexps = append(filter.regexps, re)
+	}
+	return filter
+}
+
+func (f *metricRegexpFilter) hasPatterns() bool {
+	return f != nil && len(f.patterns) > 0
+}
+
+func (f *metricRegexpFilter) validPatterns() []string {
+	if f == nil {
+		return nil
+	}
+	return f.patterns
+}
+
+func (f *metricRegexpFilter) isExcluded(name string) bool {
+	if f == nil {
+		return false
+	}
+	for _, re := range f.regexps {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *metricRegexpFilter) buildExcludeMetricsWhere() string {
+	conditions := make([]string, 0, len(f.validPatterns()))
+	for _, pattern := range f.validPatterns() {
+		conditions = append(conditions, fmt.Sprintf("match(metric, '%s')", escapeClickHouseString(pattern)))
+	}
+	return strings.Join(conditions, " OR ")
+}
+
+func escapeClickHouseString(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `'`, `\'`)
+	return value
+}

--- a/pkg/metrics/clickhouse/metric_filter_test.go
+++ b/pkg/metrics/clickhouse/metric_filter_test.go
@@ -1,0 +1,103 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clickhouse
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestMetricRegexpFilter(t *testing.T) {
+	filter := newMetricRegexpFilter([]string{
+		`^metric\.OS.*CPU[0-9]+$`,
+		`^table_parts$`,
+		`[`,
+		``,
+	})
+
+	if !filter.isExcluded("metric.OSUserTimeCPU12") {
+		t.Fatal("expected CPU metric to be excluded")
+	}
+	if !filter.isExcluded("table_parts") {
+		t.Fatal("expected table_parts metric to be excluded")
+	}
+	if filter.isExcluded("metric.OSUserTime") {
+		t.Fatal("expected non-CPU metric to be included")
+	}
+	if len(filter.validPatterns()) != 2 {
+		t.Fatalf("expected 2 valid patterns, got %d", len(filter.validPatterns()))
+	}
+}
+
+func TestMetricsSQLWithoutFilterIsBackwardCompatible(t *testing.T) {
+	fetcher := NewMetricsFetcher(nil, "^(metrics|custom_metrics)$", nil)
+	expected := fmt.Sprintf(queryMetricsSQLTemplate, "merge('system','^(metrics|custom_metrics)$')")
+
+	if got := fetcher.buildMetricsSQL(); got != expected {
+		t.Fatalf("expected unfiltered SQL to match previous template\nexpected:\n%s\ngot:\n%s", expected, got)
+	}
+}
+
+func TestMetricsSQLWithFilter(t *testing.T) {
+	fetcher := NewMetricsFetcher(
+		nil,
+		"metrics",
+		newMetricRegexpFilter([]string{`^metric\.OS.*CPU[0-9]+$`, `^table_parts$`}),
+	)
+	sql := fetcher.buildMetricsSQL()
+
+	assertContains(t, sql, "FROM (")
+	assertContains(t, sql, "WHERE NOT (")
+	assertContains(t, sql, `match(metric, '^metric\\.OS.*CPU[0-9]+$')`)
+	assertContains(t, sql, `match(metric, '^table_parts$')`)
+}
+
+func TestEscapeClickHouseString(t *testing.T) {
+	got := escapeClickHouseString(`^metric\.Foo'Bar\\Baz$`)
+	expected := `^metric\\.Foo\'Bar\\\\Baz$`
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestPrometheusWriterSkipsExcludedMetric(t *testing.T) {
+	out := make(chan prometheus.Metric, 1)
+	writer := &CHIPrometheusWriter{
+		out:          out,
+		metricFilter: newMetricRegexpFilter([]string{`^metric\.OS.*CPU[0-9]+$`}),
+	}
+
+	writer.writeSingleMetricToPrometheus(
+		"metric.OSUserTimeCPU12",
+		"",
+		prometheus.GaugeValue,
+		"1",
+		nil,
+	)
+
+	if len(out) != 0 {
+		t.Fatal("expected excluded metric not to be written")
+	}
+}
+
+func assertContains(t *testing.T, s string, substr string) {
+	t.Helper()
+	if !strings.Contains(s, substr) {
+		t.Fatalf("expected SQL to contain %q\nSQL:\n%s", substr, s)
+	}
+}

--- a/pkg/metrics/clickhouse/prometheus_writer.go
+++ b/pkg/metrics/clickhouse/prometheus_writer.go
@@ -41,9 +41,10 @@ const (
 
 // CHIPrometheusWriter specifies writer to prometheus
 type CHIPrometheusWriter struct {
-	out  chan<- prometheus.Metric
-	chi  *metrics.WatchedCR
-	host *metrics.WatchedHost
+	out          chan<- prometheus.Metric
+	chi          *metrics.WatchedCR
+	host         *metrics.WatchedHost
+	metricFilter *metricRegexpFilter
 }
 
 // NewCHIPrometheusWriter creates new CHI prometheus writer
@@ -51,11 +52,13 @@ func NewCHIPrometheusWriter(
 	out chan<- prometheus.Metric,
 	chi *metrics.WatchedCR,
 	host *metrics.WatchedHost,
+	metricFilter *metricRegexpFilter,
 ) *CHIPrometheusWriter {
 	return &CHIPrometheusWriter{
-		out:  out,
-		chi:  chi,
-		host: host,
+		out:          out,
+		chi:          chi,
+		host:         host,
+		metricFilter: metricFilter,
 	}
 }
 
@@ -256,6 +259,10 @@ func (w *CHIPrometheusWriter) writeSingleMetricToPrometheus(
 	value string,
 	metricLabels map[string]string,
 ) {
+	if w.metricFilter.isExcluded(name) {
+		return
+	}
+
 	// Prepare metrics labels
 	labelNames, labelValues := w.prepareLabels(metricLabels)
 	// Prepare metrics value

--- a/tests/e2e/manifests/chi/test-051-metrics-exclusion.yaml
+++ b/tests/e2e/manifests/chi/test-051-metrics-exclusion.yaml
@@ -1,0 +1,10 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseInstallation"
+metadata:
+  name: test-051
+spec:
+  useTemplates:
+    - name: clickhouse-version
+  configuration:
+    clusters:
+      - name: default

--- a/tests/e2e/manifests/chopconf/test-051-chopconf.yaml
+++ b/tests/e2e/manifests/chopconf/test-051-chopconf.yaml
@@ -1,0 +1,8 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseOperatorConfiguration"
+metadata:
+  name: "test-051-chopconf"
+spec:
+  clickhouse:
+    metrics:
+      excludeMetricsRegexp: []

--- a/tests/e2e/steps.py
+++ b/tests/e2e/steps.py
@@ -165,11 +165,7 @@ def check_metrics_monitoring(
     with Then(f"metrics-exporter /metrics endpoint result should contain {expect_pattern}{expect_metric}"):
         expected_pattern_found = False
         for i in range(1, max_retries):
-            url_cmd = util.make_http_get_request("127.0.0.1", port, "/metrics")
-            out = kubectl.launch(
-                f"exec {operator_pod} -c {container} -- {url_cmd}",
-                ns=operator_namespace,
-            )
+            out = util.get_metrics(operator_pod, operator_namespace, container=container, port=port)
             if expect_metric != "":
                 lines = [m for m in out.splitlines() if m.startswith(expect_metric) and expect_labels in m]
                 if len(lines) > 0:

--- a/tests/e2e/test_metrics_exporter.py
+++ b/tests/e2e/test_metrics_exporter.py
@@ -29,11 +29,7 @@ def test_metrics_exporter_chi(self):
         with Then(f"metrics-exporter /chi endpoint result should return {expect_result}"):
             for i in range(1, max_retries):
                 # check /metrics for try to refresh monitored instances
-                url_cmd = util.make_http_get_request("127.0.0.1", "8888", "/metrics")
-                kubectl.launch(
-                    f"exec {operator_pod} -c metrics-exporter -- {url_cmd}",
-                    ns=operator_namespace,
-                )
+                util.get_metrics(operator_pod, operator_namespace)
                 # check /chi after refresh monitored instances
                 url_cmd = util.make_http_get_request("127.0.0.1", "8888", "/chi")
                 out = kubectl.launch(
@@ -53,11 +49,7 @@ def test_metrics_exporter_chi(self):
         with Then(f"metrics-exporter /metrics endpoint result should match with {expect_result}"):
             found = 0
             for i in range(1, max_retries):
-                url_cmd = util.make_http_get_request("127.0.0.1", "8888", "/metrics")
-                out = kubectl.launch(
-                    f"exec {operator_pod} -c metrics-exporter -- {url_cmd}",
-                    ns=operator_namespace,
-                )
+                out = util.get_metrics(operator_pod, operator_namespace)
                 found = 0
                 for string, exists in expect_result.items():
                     if exists == (string in out):

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -5198,6 +5198,77 @@ def test_010050(self):
         delete_test_namespace()
 
 
+@TestScenario
+@Name("test_010051. Test ClickHouse metrics exclusion")
+def test_010051(self):
+    create_shell_namespace_clickhouse_template()
+
+    chi_manifest = "manifests/chi/test-051-metrics-exclusion.yaml"
+    chopconf_file = "manifests/chopconf/test-051-chopconf.yaml"
+    chi = yaml_manifest.get_name(util.get_full_path(chi_manifest))
+    operator_namespace = current().context.operator_namespace
+
+    def wait_metrics_state(description, present_patterns=None, absent_patterns=None, max_retries=12):
+        present_patterns = present_patterns or []
+        absent_patterns = absent_patterns or []
+        with Then(description):
+            present_rx = [re.compile(pattern, re.MULTILINE) for pattern in present_patterns]
+            absent_rx = [re.compile(pattern, re.MULTILINE) for pattern in absent_patterns]
+            out = ""
+            for i in range(1, max_retries):
+                operator_pod = kubectl.get_operator_pod()
+                out = util.get_metrics(operator_pod, operator_namespace)
+
+                present = all(rx.search(out) is not None for rx in present_rx)
+                absent  = all(rx.search(out) is None for rx in absent_rx)
+
+                print(f"{present_patterns} present is {present}")
+                print(f"{absent_patterns} absent is {absent}")
+
+                if present and absent:
+                    return out
+
+                retry_sleep(i, 5, "Metrics are not ready")
+            assert False, error("Metrics do not match present/absent patterns")
+
+    with Given("Operator configuration with disabled metric exclusions is installed"):
+        util.apply_operator_config(chopconf_file)
+
+    with Given("CHI is installed"):
+        kubectl.create_and_check(
+            manifest=chi_manifest,
+            check={
+                "pod_count": 1,
+                "apply_templates": {
+                    current().context.clickhouse_template,
+                },
+                "pod_count": 1,
+                "do_not_delete": 1,
+            },
+        )
+
+    cpu_metric_pattern = r"^chi_clickhouse_metric_(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)\{"
+    version_metric_pattern = r"^chi_clickhouse_metric_VersionInteger.*"
+
+    wait_metrics_state(
+        "CPU-related and VersionInteger ClickHouse metrics should exist when exclusions are disabled",
+        present_patterns=[cpu_metric_pattern, version_metric_pattern],
+    )
+
+    with When("CHOP configuration is deleted to restore default metric exclusions"):
+        kubectl.delete(util.get_full_path(chopconf_file, lookup_in_host=False), operator_namespace)
+        util.restart_operator()
+
+    wait_metrics_state(
+        "CPU-related ClickHouse metrics should disappear while VersionInteger remains when exclusions are enabled",
+        present_patterns=[version_metric_pattern],
+        absent_patterns=[cpu_metric_pattern],
+    )
+
+    with Finally("I clean up"):
+        delete_test_namespace()
+
+
 def check_replication(chi, replicas, token, table = ''):
         cluster = clickhouse.query(chi, "select substitution from system.macros where macro = 'cluster'")
         if table == '':

--- a/tests/e2e/util.py
+++ b/tests/e2e/util.py
@@ -261,6 +261,17 @@ def make_http_get_request(host, port, path):
     return f"bash -c '{cmd}'"
 
 
+def get_metrics(operator_pod, operator_namespace=None, container="metrics-exporter", port="8888"):
+    if operator_namespace is None:
+        operator_namespace = current().context.operator_namespace
+
+    url_cmd = make_http_get_request("127.0.0.1", port, "/metrics")
+    return kubectl.launch(
+        f"exec {operator_pod} -c {container} -- {url_cmd}",
+        ns=operator_namespace,
+    )
+
+
 def install_operator_if_not_exist(
     reinstall=False,
     manifest=None,


### PR DESCRIPTION
Added operator config setting to exclude noise metrics from export. By default, CPU and OS metrics are excluded, those are reported by thread and rarely used. 

Closes https://github.com/Altinity/clickhouse-operator/issues/1876

```
    excludeMetricsRegexp:
      - "^metric\\.(OS.*CPU[0-9]+|CPUFrequencyMHz_[0-9]+)$"
```