### PR TITLE
fix: use plain errors for clickhouse model messages

### DIFF
--- a/pkg/model/clickhouse/cluster.go
+++ b/pkg/model/clickhouse/cluster.go
@@ -16,6 +16,7 @@ package clickhouse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -93,7 +94,7 @@ func (c *Cluster) QueryAny(ctx context.Context, sql string) (*QueryResult, error
 
 	str := fmt.Sprintf("FAILED to run query on all hosts %v", c.Hosts)
 	c.l.V(1).F().Error(str)
-	return nil, fmt.Errorf(str)
+	return nil, errors.New(str)
 }
 
 // ExecAll runs set of SQL queries on all endpoints of the cluster.

--- a/pkg/model/clickhouse/connection.go
+++ b/pkg/model/clickhouse/connection.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	goch "github.com/mailru/go-clickhouse/v2"
 
@@ -195,7 +196,7 @@ func (c *Connection) QueryContext(ctx context.Context, sql string) (*QueryResult
 	if !c.ensureConnected(ctx) {
 		s := fmt.Sprintf("FAILED connect(%s) for SQL: %s", c.params.GetDSNWithHiddenCredentials(), sql)
 		c.l.V(1).F().Error(s)
-		return nil, fmt.Errorf(s)
+		return nil, errors.New(s)
 	}
 
 	if util.IsContextDone(ctx) {
@@ -251,7 +252,7 @@ func (c *Connection) Exec(_ctx context.Context, sql string, opts *QueryOptions) 
 		cancel()
 		s := fmt.Sprintf("FAILED connect(%s) for SQL: %s", c.params.GetDSNWithHiddenCredentials(), sql)
 		c.l.V(1).F().Error(s)
-		return fmt.Errorf(s)
+		return errors.New(s)
 	}
 
 	db := c.dbPrimary


### PR DESCRIPTION
Tiny vet cleanup in the ClickHouse model package.

Go 1.26 flags `fmt.Errorf(s)` when `s` is already a built string. No formatting needed here, so `errors.New(s)` is the straight shot. same behavior, less noise.

Repro before:
```sh
go test ./pkg/model/clickhouse
```

It failed with:
```text
non-constant format string in call to fmt.Errorf
```

After:
```sh
go test ./pkg/model/clickhouse
```

passes
