### PR TITLE
Update default port names to Istio friendly names

### DIFF
--- a/pkg/apis/clickhouse.altinity.com/v1/type_host.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_host.go
@@ -577,13 +577,13 @@ func (host *Host) HasDesiredStatefulSet() bool {
 }
 
 const (
-	ChDefaultPortName   = "port"
+	ChDefaultPortName   = "tcp-port"
 	ChDefaultPortNumber = int32(9000)
 
 	// ClickHouse open ports names and values
 	ChDefaultTCPPortName               = "tcp"
 	ChDefaultTCPPortNumber             = int32(9000)
-	ChDefaultTLSPortName               = "secureclient"
+	ChDefaultTLSPortName               = "tls-secureclient"
 	ChDefaultTLSPortNumber             = int32(9440)
 	ChDefaultHTTPPortName              = "http"
 	ChDefaultHTTPPortNumber            = int32(8123)
@@ -593,11 +593,11 @@ const (
 	ChDefaultInterserverHTTPPortNumber = int32(9009)
 
 	// Keeper open ports names and values
-	KpDefaultZKPortName         = "zk"
+	KpDefaultZKPortName         = "tcp-zk"
 	KpDefaultZKPortNumber       = int32(2181)
-	KpDefaultZKSecurePortName   = "zk-secure"
+	KpDefaultZKSecurePortName   = "tls-zk-secure"
 	KpDefaultZKSecurePortNumber = int32(2281)
-	KpDefaultRaftPortName       = "raft"
+	KpDefaultRaftPortName       = "tcp-raft"
 	KpDefaultRaftPortNumber     = int32(9444)
 )
 


### PR DESCRIPTION
Update default port names to more Istio friendly names indicating the app protocol.

Note I did not update the "interserver" port name as there appears to be indirectly linked references (within the operator) using that name - I had a local deployment fail when updating this name to "http-interserver".  Also, istio's app protocol auto-detection seems to work fine for this interserver connection.
