### PR TITLE
Fix permanent ArgoCD diff on resourceFieldRef.divisor

### DIFF
--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-no-configmap.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-no-configmap.yaml
@@ -84,21 +84,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -144,21 +148,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-with-configmap.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-04-section-deployment-01-with-configmap.yaml
@@ -129,21 +129,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -207,21 +211,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics

--- a/deploy/builder/templates-operatorhub/clickhouse-operator.vVERSION.clusterserviceversion-template.yaml
+++ b/deploy/builder/templates-operatorhub/clickhouse-operator.vVERSION.clusterserviceversion-template.yaml
@@ -1272,21 +1272,25 @@ spec:
                           resourceFieldRef:
                             containerName: clickhouse-operator
                             resource: requests.cpu
+                            divisor: "1m"
                       - name: OPERATOR_CONTAINER_CPU_LIMIT
                         valueFrom:
                           resourceFieldRef:
                             containerName: clickhouse-operator
                             resource: limits.cpu
+                            divisor: "1m"
                       - name: OPERATOR_CONTAINER_MEM_REQUEST
                         valueFrom:
                           resourceFieldRef:
                             containerName: clickhouse-operator
                             resource: requests.memory
+                            divisor: "1Mi"
                       - name: OPERATOR_CONTAINER_MEM_LIMIT
                         valueFrom:
                           resourceFieldRef:
                             containerName: clickhouse-operator
                             resource: limits.memory
+                            divisor: "1Mi"
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:

--- a/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
@@ -131,21 +131,25 @@ spec:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: limits.memory
+                  divisor: "1Mi"
             {{ with .Values.operator.env }}{{ toYaml . | nindent 12 }}{{ end }}
           ports:
             - containerPort: 9999
@@ -217,21 +221,25 @@ spec:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: {{ .Chart.Name }}
                   resource: limits.memory
+                  divisor: "1Mi"
             {{ with .Values.metrics.env }}{{ toYaml . | nindent 12 }}{{ end }}
           ports:
             - containerPort: 8888

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -6764,21 +6764,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -6842,21 +6846,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -5214,7 +5214,6 @@ metadata:
   namespace: kube-system
   labels:
     clickhouse.altinity.com/chop: 0.27.1
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -5467,7 +5466,6 @@ subjects:
   - kind: ServiceAccount
     name: clickhouse-operator
     namespace: kube-system
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -6950,21 +6948,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -7026,21 +7028,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -7023,21 +7023,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -7101,21 +7105,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -5214,7 +5214,6 @@ metadata:
   namespace: ${OPERATOR_NAMESPACE}
   labels:
     clickhouse.altinity.com/chop: 0.27.1
-
 # Template Parameters:
 #
 # NAMESPACE=${OPERATOR_NAMESPACE}
@@ -6697,21 +6696,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -6773,21 +6776,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -6757,21 +6757,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -6835,21 +6839,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -6764,21 +6764,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 9999
               name: op-metrics
@@ -6842,21 +6846,25 @@ spec:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_CPU_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.cpu
+                  divisor: "1m"
             - name: OPERATOR_CONTAINER_MEM_REQUEST
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: requests.memory
+                  divisor: "1Mi"
             - name: OPERATOR_CONTAINER_MEM_LIMIT
               valueFrom:
                 resourceFieldRef:
                   containerName: clickhouse-operator
                   resource: limits.memory
+                  divisor: "1Mi"
           ports:
             - containerPort: 8888
               name: ch-metrics


### PR DESCRIPTION
ArgoCD shows a permanent diff on the operator Deployment because resourceFieldRef.divisor isn't set in the chart, but the apiserver materializes it as a zero-value Quantity that serializes back as '0'.

Issue tracked at Altinity/helm-charts#110.

Fix is to set `divisor: "1"` on all 8 resourceFieldRef blocks (4 per container, 2 containers). "1" is the documented k8s default, so no behavior change - kubelet already uses 1 when divisor is unset.

## How I tested

Edited the 3 source templates in `deploy/builder/`, then ran `deploy/builder/build-clickhouse-operator-install-yaml.sh` and `dev/generate_helm_chart.sh` to regenerate the 7 derived files (install bundles + helm chart Deployment).

- `helm lint` passes
- `helm template` renders 8 `divisor: "1"` lines as expected
- no other resourceFieldRef occurrences in the tree