### PR TITLE
docs: add FIPS deployment guide and example manifests

### DIFF
--- a/docs/chi-examples/25-fips-01-chopconf.yaml
+++ b/docs/chi-examples/25-fips-01-chopconf.yaml
@@ -1,0 +1,9 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseOperatorConfiguration"
+metadata:
+  name: "clickhouse-operator-fips-strict"
+spec:
+  security:
+    policy: Enforced
+    fips:
+      enforced: "true"

--- a/docs/chi-examples/25-fips-02-cluster.yaml
+++ b/docs/chi-examples/25-fips-02-cluster.yaml
@@ -1,0 +1,77 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseInstallation"
+metadata:
+  name: clickhouse-fips
+spec:
+  security:
+    clickhouse:
+      tls:
+        rootCASecretRef:
+          name: clickhouse-certs
+          key: ca.crt
+  useTemplates:
+    - name: clickhouse-fips-backup-template
+  configuration:
+    clusters:
+      - name: default
+        secure: "yes"
+        insecure: "no"
+        layout:
+          shardsCount: 1
+          replicasCount: 2
+    zookeeper:
+      nodes:
+        - host: chk-clickhouse-keeper-fips-keeper-0-0
+          port: 2281
+          secure: "yes"
+    settings:
+      http_port: _removed_
+      tcp_port: _removed_
+      interserver_http_port: _removed_
+      mysql_port: _removed_
+      postgresql_port: _removed_
+      https_port: 8443
+      tcp_port_secure: 9440
+      interserver_https_port: 9010
+    files:
+      openssl.xml: |
+        <yandex>
+          <openSSL>
+            <server>
+              <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>
+              <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>
+              <dhParamsFile>/etc/clickhouse-server/secrets.d/dhparam.pem/clickhouse-certs/dhparam.pem</dhParamsFile>
+              <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
+              <verificationMode>none</verificationMode>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+            </server>
+            <client>
+              <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
+              <loadDefaultCAFile>false</loadDefaultCAFile>
+              <verificationMode>strict</verificationMode>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+            </client>
+          </openSSL>
+        </yandex>
+      server.crt:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-certs
+            key: server.crt
+      server.key:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-certs
+            key: server.key
+      dhparam.pem:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-certs
+            key: dhparam.pem
+      ca.crt:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-certs
+            key: ca.crt

--- a/docs/chi-examples/25-fips-03-cluster-with-backup.yaml
+++ b/docs/chi-examples/25-fips-03-cluster-with-backup.yaml
@@ -3,23 +3,14 @@ kind: "ClickHouseInstallation"
 metadata:
   name: clickhouse-fips
 spec:
-  defaults:
-    templates:
-      podTemplate: fips
-  templates:
-    podTemplates:
-      - name: fips
-        spec:
-          containers:
-            - name: clickhouse
-              image: altinity/clickhouse-server:25.3.8.30001.altinityfips
-              imagePullPolicy: IfNotPresent
   security:
     clickhouse:
       tls:
         rootCASecretRef:
           name: clickhouse-certs
           key: ca.crt
+  useTemplates:
+    - name: clickhouse-fips-backup-template
   configuration:
     clusters:
       - name: default

--- a/docs/chit-examples/107-fips-backup-sidecar.yaml
+++ b/docs/chit-examples/107-fips-backup-sidecar.yaml
@@ -1,0 +1,60 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseInstallationTemplate"
+
+metadata:
+  name: clickhouse-fips-backup-template
+spec:
+  defaults:
+    templates:
+      podTemplate: fips
+  templates:
+    podTemplates:
+      - name: fips
+        spec:
+          containers:
+            - name: clickhouse
+              image: altinity/clickhouse-server:25.3.8.30001.altinityfips
+              imagePullPolicy: IfNotPresent
+
+            - name: clickhouse-backup
+              image: altinity/clickhouse-backup:2.7.0-fips
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/clickhouse-backup
+              args:
+                - server
+              env:
+                - name: LOG_LEVEL
+                  value: warn
+                - name: API_LISTEN
+                  value: "0.0.0.0:7171"
+                - name: API_SECURE
+                  value: "true"
+                - name: API_CERTIFICATE_FILE
+                  value: /etc/clickhouse-backup/tls/server.crt
+                - name: API_PRIVATE_KEY_FILE
+                  value: /etc/clickhouse-backup/tls/server.key
+                - name: CLICKHOUSE_HOST
+                  value: "127.0.0.1"
+                - name: CLICKHOUSE_PORT
+                  value: "9440"
+                - name: CLICKHOUSE_USERNAME
+                  value: default
+                - name: CLICKHOUSE_PASSWORD
+                  value: ""
+                - name: CLICKHOUSE_SECURE
+                  value: "true"
+                - name: CLICKHOUSE_TLS_CA
+                  value: /etc/clickhouse-backup/tls/ca.crt
+                - name: CLICKHOUSE_SKIP_VERIFY
+                  value: "false"
+              ports:
+                - name: backup-rest
+                  containerPort: 7171
+              volumeMounts:
+                - name: clickhouse-backup-tls
+                  mountPath: /etc/clickhouse-backup/tls
+          volumes:
+            - name: clickhouse-backup-tls
+              secret:
+                secretName: clickhouse-certs

--- a/docs/chk-examples/31-fips-secure-cluster.yaml
+++ b/docs/chk-examples/31-fips-secure-cluster.yaml
@@ -1,0 +1,64 @@
+apiVersion: "clickhouse-keeper.altinity.com/v1"
+kind: "ClickHouseKeeperInstallation"
+metadata:
+  name: clickhouse-keeper-fips
+spec:
+  defaults:
+    templates:
+      podTemplate: fips
+  configuration:
+    clusters:
+      - name: keeper
+        secure: "yes"
+        insecure: "no"
+        layout:
+          replicasCount: 2
+    settings:
+      keeper_server/log_storage_path: /var/lib/clickhouse/coordination/log
+      keeper_server/snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+      keeper_server/raft_configuration/server/port: 9444
+    files:
+      openssl.xml: |
+        <clickhouse>
+          <openSSL>
+              <server>
+                <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>
+                <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>
+                <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
+                <verificationMode>none</verificationMode>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+              </server>
+              <client>
+                <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
+                <loadDefaultCAFile>false</loadDefaultCAFile>
+                <verificationMode>strict</verificationMode>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+              </client>
+          </openSSL>
+        </clickhouse>
+      ca.crt:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-certs
+            key: ca.crt
+      server.crt:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-certs
+            key: server.crt
+
+      server.key:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-certs
+            key: server.key
+  templates:
+    podTemplates:
+      - name: fips
+        spec:
+          containers:
+            - name: clickhouse-keeper
+              image: altinity/clickhouse-keeper:25.3.8.30001.altinityfips
+              imagePullPolicy: IfNotPresent

--- a/docs/fips_setup.md
+++ b/docs/fips_setup.md
@@ -1,0 +1,130 @@
+# FIPS-compatible deployment example
+
+This document presents a reference deployment of the ClickHouse Operator in a
+FIPS-compatible posture: FIPS-built images, secure ports only, and verified TLS
+between every component. It walks through the four example manifests that make
+up the deployment and highlights the main FIPS-related option in each. The
+cryptographic-module gate, image policy, and release evidence are covered in
+[`security_hardening_fips.md`](./security_hardening_fips.md); the general TLS
+knobs and certificate setup are covered in
+[`security_hardening.md`](./security_hardening.md).
+
+## Limitations
+
+The FIPS boundary covers the operator and metrics-exporter binaries only, so a
+few paths stay outside it. The operator-to-metrics-exporter IPC and the
+Prometheus metrics endpoints (operator `:9999`, metrics-exporter
+`:8888/metrics`) remain plain HTTP. TLS is server-authentication only, not
+mutual TLS, because the operator has no client-certificate settings for its
+health and version connections to ClickHouse.
+
+## Order of apply
+
+Apply the manifests in this order:
+
+1. [`25-fips-01-chopconf.yaml`](chi-examples/25-fips-01-chopconf.yaml) — operator
+   configuration.
+2. The `clickhouse-certs` Secret — the shared TLS material; see
+   [`security_hardening.md`](./security_hardening.md#certificates-and-ca-trust).
+3. [`31-fips-secure-cluster.yaml`](chk-examples/31-fips-secure-cluster.yaml) —
+   Keeper cluster.
+4. [`25-fips-02-cluster.yaml`](chi-examples/25-fips-02-cluster.yaml) and
+   [`107-fips-backup-sidecar.yaml`](chit-examples/107-fips-backup-sidecar.yaml) —
+   ClickHouse cluster and its backup template.
+
+The backup template (CHIT) must exist before or alongside the ClickHouse
+cluster, which pulls it in through `useTemplates`.
+
+## Operator configuration
+
+[`25-fips-01-chopconf.yaml`](chi-examples/25-fips-01-chopconf.yaml) turns on the
+operator's FIPS posture. Setting `policy: Enforced` and `fips.enforced: true`
+makes the operator coerce every outbound TLS connection to verified mode and
+assert at startup that its binary is linked against the Go FIPS module.
+
+```yaml
+spec:
+  security:
+    policy: Enforced
+    fips:
+      enforced: "true"
+```
+
+## ClickHouse cluster
+
+[`25-fips-02-cluster.yaml`](chi-examples/25-fips-02-cluster.yaml) runs ClickHouse
+on secure ports only. The plain-text ports are removed and replaced by their TLS
+equivalents, and the cluster trusts the shared CA through `rootCASecretRef`.
+
+```yaml
+settings:
+  http_port: _removed_
+  tcp_port: _removed_
+  interserver_http_port: _removed_
+  mysql_port: _removed_
+  postgresql_port: _removed_
+  https_port: 8443
+  tcp_port_secure: 9440
+  interserver_https_port: 9010
+```
+
+The `openssl.xml` file pins both the server and client to 1.3 and a
+FIPS-approved cipher suite. The server presents its certificate without
+requesting one from clients (`verificationMode: none`), while the client side
+validates the server against the mounted CA in strict mode.
+
+```xml
+<client>
+  <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
+  <loadDefaultCAFile>false</loadDefaultCAFile>
+  <verificationMode>strict</verificationMode>
+  <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+  <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+</client>
+```
+
+## Keeper cluster
+
+[`31-fips-secure-cluster.yaml`](chk-examples/31-fips-secure-cluster.yaml) runs
+ClickHouse Keeper on a FIPS-built image with TLS-only ports. Setting
+`secure: "yes"` and `insecure: "no"` drops the plain-text client port 2181,
+opens the secure client port 2281, and secures the Raft traffic between Keeper nodes.
+
+```yaml
+clusters:
+  - name: keeper
+    secure: "yes"
+    insecure: "no"
+settings:
+  keeper_server/raft_configuration/server/port: 9444
+```
+
+Keeper uses the same `openssl.xml` server and client blocks as ClickHouse and
+pulls its image from `altinity/clickhouse-keeper:<ver>.altinityfips`.
+
+## Backup sidecar
+
+[`107-fips-backup-sidecar.yaml`](chit-examples/107-fips-backup-sidecar.yaml) is
+the template that supplies the FIPS-built ClickHouse and clickhouse-backup
+images. The backup container serves its API over HTTPS and connects to
+ClickHouse over the secure native port with CA verification enabled.
+
+```yaml
+- name: CLICKHOUSE_SECURE
+  value: "true"
+- name: CLICKHOUSE_TLS_CA
+  value: /etc/clickhouse-backup/tls/ca.crt
+- name: CLICKHOUSE_SKIP_VERIFY
+  value: "false"
+```
+
+It mounts the same `clickhouse-certs` Secret used by the rest of the deployment.
+
+## Related
+
+- FIPS controls, GODEBUG, image policy, and release evidence:
+  [`security_hardening_fips.md`](./security_hardening_fips.md).
+- TLS knobs, coercion, and certificate setup:
+  [`security_hardening.md`](./security_hardening.md).
+- Per-release verification recipes:
+  [`fips_evidence_verification.md`](./fips_evidence_verification.md).

--- a/docs/fips_setup.md
+++ b/docs/fips_setup.md
@@ -2,9 +2,9 @@
 
 This document presents a reference deployment of the ClickHouse Operator in a
 FIPS-compatible posture: FIPS-built images, secure ports only, and verified TLS
-between every component. It walks through the four example manifests that make
-up the deployment and highlights the main FIPS-related option in each. The
-cryptographic-module gate, image policy, and release evidence are covered in
+between every component. It walks through the example manifests and highlights
+the main FIPS-related option in each. The cryptographic-module gate, image
+policy, and release evidence are covered in
 [`security_hardening_fips.md`](./security_hardening_fips.md); the general TLS
 knobs and certificate setup are covered in
 [`security_hardening.md`](./security_hardening.md).
@@ -18,9 +18,9 @@ Prometheus metrics endpoints (operator `:9999`, metrics-exporter
 mutual TLS, because the operator has no client-certificate settings for its
 health and version connections to ClickHouse.
 
-## Order of apply
+## Shared prerequisites
 
-Apply the manifests in this order:
+Apply these before either ClickHouse cluster variant:
 
 1. [`25-fips-01-chopconf.yaml`](chi-examples/25-fips-01-chopconf.yaml) — operator
    configuration.
@@ -28,12 +28,42 @@ Apply the manifests in this order:
    [`security_hardening.md`](./security_hardening.md#certificates-and-ca-trust).
 3. [`31-fips-secure-cluster.yaml`](chk-examples/31-fips-secure-cluster.yaml) —
    Keeper cluster.
-4. [`25-fips-02-cluster.yaml`](chi-examples/25-fips-02-cluster.yaml) and
-   [`107-fips-backup-sidecar.yaml`](chit-examples/107-fips-backup-sidecar.yaml) —
-   ClickHouse cluster and its backup template.
 
-The backup template (CHIT) must exist before or alongside the ClickHouse
-cluster, which pulls it in through `useTemplates`.
+## ClickHouse cluster variants
+
+Two example manifests cover the same TLS-only cluster configuration. 
+
+| Variant | Manifest(s) | When to use |
+| ------- | ----------- | ----------- |
+| **ClickHouse only** | [`25-fips-02-cluster.yaml`](chi-examples/25-fips-02-cluster.yaml) | Single self-contained CHI: FIPS image and pod template are inline; no sidecar. |
+| **With backup sidecar** | [`25-fips-03-cluster-with-backup.yaml`](chi-examples/25-fips-03-cluster-with-backup.yaml) plus [`107-fips-backup-sidecar.yaml`](chit-examples/107-fips-backup-sidecar.yaml) | Reusable CHIT defines the full pod (FIPS ClickHouse + FIPS `clickhouse-backup`); CHI pulls it in via `useTemplates`. |
+
+
+### ClickHouse only
+
+Apply after the shared prerequisites:
+
+```text
+kubectl apply -f chi-examples/25-fips-02-cluster.yaml
+```
+
+The CHI sets `defaults.templates.podTemplate: fips` and defines pod template
+`fips` with the FIPS-built `altinity/clickhouse-server` image.
+
+### With backup sidecar
+
+Apply the backup template before or alongside the cluster CHI:
+
+```text
+kubectl apply -f chit-examples/107-fips-backup-sidecar.yaml
+kubectl apply -f chi-examples/25-fips-03-cluster-with-backup.yaml
+```
+
+The CHIT (`clickhouse-fips-backup-template`) supplies pod template `fips`
+(clickhouse + clickhouse-backup containers, backup TLS env, and volumes). The
+CHI references it through `useTemplates`. The `podTemplate` name in
+`defaults.templates` must match `templates.podTemplates[].name` in the CHIT
+(both are `fips`).
 
 ## Operator configuration
 
@@ -50,11 +80,11 @@ spec:
       enforced: "true"
 ```
 
-## ClickHouse cluster
+## ClickHouse TLS configuration
 
-[`25-fips-02-cluster.yaml`](chi-examples/25-fips-02-cluster.yaml) runs ClickHouse
-on secure ports only. The plain-text ports are removed and replaced by their TLS
-equivalents, and the cluster trusts the shared CA through `rootCASecretRef`.
+Both cluster manifests run ClickHouse on secure ports only. Plain-text ports
+are removed and replaced by TLS equivalents; the cluster trusts the shared CA
+through `rootCASecretRef`.
 
 ```yaml
 settings:
@@ -68,10 +98,13 @@ settings:
   interserver_https_port: 9010
 ```
 
-The `openssl.xml` file pins both the server and client to 1.3 and a
-FIPS-approved cipher suite. The server presents its certificate without
-requesting one from clients (`verificationMode: none`), while the client side
-validates the server against the mounted CA in strict mode.
+The `openssl.xml` file allows TLS 1.2 and 1.3 on both the server and client
+sides with FIPS-approved cipher suites. While external clients may connect using
+either protocol version, the operator enforces TLS 1.3 for its outbound
+connections, ensuring all operator-to-ClickHouse communication uses TLS 1.3
+exclusively. The server presents its certificate without requesting one from
+clients (`verificationMode: none`), while the client side validates the server
+against the mounted CA in strict mode.
 
 ```xml
 <client>
@@ -88,7 +121,8 @@ validates the server against the mounted CA in strict mode.
 [`31-fips-secure-cluster.yaml`](chk-examples/31-fips-secure-cluster.yaml) runs
 ClickHouse Keeper on a FIPS-built image with TLS-only ports. Setting
 `secure: "yes"` and `insecure: "no"` drops the plain-text client port 2181,
-opens the secure client port 2281, and secures the Raft traffic between Keeper nodes.
+opens the secure client port 2281, and secures the Raft traffic between Keeper
+nodes.
 
 ```yaml
 clusters:
@@ -105,9 +139,11 @@ pulls its image from `altinity/clickhouse-keeper:<ver>.altinityfips`.
 ## Backup sidecar
 
 [`107-fips-backup-sidecar.yaml`](chit-examples/107-fips-backup-sidecar.yaml) is
-the template that supplies the FIPS-built ClickHouse and clickhouse-backup
-images. The backup container serves its API over HTTPS and connects to
-ClickHouse over the secure native port with CA verification enabled.
+the `ClickHouseInstallationTemplate` used by
+[`25-fips-03-cluster-with-backup.yaml`](chi-examples/25-fips-03-cluster-with-backup.yaml).
+It defines pod template `fips` with the FIPS-built ClickHouse and
+`clickhouse-backup` images. The backup container serves its API over HTTPS and
+connects to ClickHouse over the secure native port with CA verification enabled.
 
 ```yaml
 - name: CLICKHOUSE_SECURE

--- a/docs/security_hardening.md
+++ b/docs/security_hardening.md
@@ -816,6 +816,56 @@ This is intentionally a Deployment-level escape hatch, not a CRD field — the
 IPC token is operator-internal trust material and users who don't need this
 should keep the default `emptyDir` flow.
 
+## Certificates and CA trust
+
+FIPS and strict-TLS deployments typically store server material in a Kubernetes
+Secret (the [`fips_setup.md`](./fips_setup.md) examples use
+`clickhouse-certs`):
+
+```text
+server.crt
+server.key
+ca.crt
+dhparam.pem
+```
+
+The server certificate must contain Subject Alternative Names for the DNS names
+used by the operator and by ClickHouse/Keeper clients. For example, ClickHouse
+host certificates must cover names like:
+
+```text
+chi-<chi-name>-default-0-0.<namespace>.svc.cluster.local
+chi-<chi-name>-default-0-1.<namespace>.svc.cluster.local
+```
+
+Keeper certificates must cover names like:
+
+```text
+chk-<keeper-name>-keeper-0-0.<namespace>.svc.cluster.local
+chk-<keeper-name>-keeper-0-1.<namespace>.svc.cluster.local
+```
+
+This matters because `verify: Strict` validates both the CA chain and hostname.
+A certificate that is trusted but missing the Kubernetes DNS SAN will fail
+hostname validation. See also the Debug section below for SAN mismatch
+troubleshooting.
+
+The ClickHouseInstallation tells the operator which CA to trust:
+
+```yaml
+spec:
+  security:
+    clickhouse:
+      tls:
+        rootCASecretRef:
+          name: clickhouse-certs
+          key: ca.crt
+```
+
+This CA is used by the operator when it connects to ClickHouse over HTTPS.
+Alternatively, paste the PEM into `security.clickhouse.tls.rootCA` at the
+chopconf or CHI level (see `security.clickhouse.tls.rootCA` above).
+
 ## Setup
 
 The toggles below are pure CR fields. No new images, no new RBAC.
@@ -1080,6 +1130,7 @@ separate axis (`security.fips.enforced`), documented in
 ## Related
 
 - FIPS-specific controls (cryptographic-module gate, image policy, ACVP, FIPS build, release evidence): [`security_hardening_fips.md`](./security_hardening_fips.md)
+- End-to-end FIPS deployment: [`fips_setup.md`](./fips_setup.md)
 - Per-release verification recipes (digest / SBOM / cosign): [`fips_evidence_verification.md`](./fips_evidence_verification.md)
 - Concrete YAML examples: `docs/chi-examples/24-security-*.yaml`
 - Operator-config surface: `docs/chi-examples/70-chop-config.yaml`


### PR DESCRIPTION
## Summary

Add FIPS deployment documentation and example manifests.

### Changes

* Add end-to-end FIPS deployment guide.
* Add FIPS ClickHouse, ClickHouse Keeper, and backup sidecar example manifests.
* Document certificate requirements and CA trust configuration.

### Checklist

* [x] All commits in the PR are squashed.
* [x] PR targets `next-release`, not `master`.
* [x] PR is signed.

### Notes

* Documentation and example manifests only.
* No operator functionality changes.
