### PR TITLE
fix: backup sidecar doc example, add: backup create/restore scenario over TLS 

### DIFF
--- a/docs/chit-examples/107-fips-backup-sidecar.yaml
+++ b/docs/chit-examples/107-fips-backup-sidecar.yaml
@@ -2,7 +2,7 @@ apiVersion: "clickhouse.altinity.com/v1"
 kind: "ClickHouseInstallationTemplate"
 
 metadata:
-  name: clickhouse-fips-backup-template
+  name: test-030003-backup-template
 spec:
   defaults:
     templates:
@@ -15,6 +15,9 @@ spec:
             - name: clickhouse
               image: altinity/clickhouse-server:25.3.8.30001.altinityfips
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: clickhouse-data
+                  mountPath: /var/lib/clickhouse
 
             - name: clickhouse-backup
               image: altinity/clickhouse-backup:2.7.0-fips
@@ -54,7 +57,11 @@ spec:
               volumeMounts:
                 - name: clickhouse-backup-tls
                   mountPath: /etc/clickhouse-backup/tls
+                - name: clickhouse-data
+                  mountPath: /var/lib/clickhouse
           volumes:
             - name: clickhouse-backup-tls
               secret:
                 secretName: clickhouse-certs
+            - name: clickhouse-data
+              emptyDir: {}

--- a/docs/chit-examples/107-fips-backup-sidecar.yaml
+++ b/docs/chit-examples/107-fips-backup-sidecar.yaml
@@ -2,7 +2,7 @@ apiVersion: "clickhouse.altinity.com/v1"
 kind: "ClickHouseInstallationTemplate"
 
 metadata:
-  name: test-030003-backup-template
+  name: clickhouse-fips-backup-template
 spec:
   defaults:
     templates:

--- a/tests/e2e/manifests/chit/test-030003-backup-template.yaml
+++ b/tests/e2e/manifests/chit/test-030003-backup-template.yaml
@@ -15,6 +15,9 @@ spec:
             - name: clickhouse
               image: altinity/clickhouse-server:25.3.8.30001.altinityfips
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: clickhouse-data
+                  mountPath: /var/lib/clickhouse
 
             - name: clickhouse-backup
               image: altinity/clickhouse-backup:2.7.0-fips
@@ -54,7 +57,11 @@ spec:
               volumeMounts:
                 - name: clickhouse-backup-tls
                   mountPath: /etc/clickhouse-backup/tls
+                - name: clickhouse-data
+                  mountPath: /var/lib/clickhouse
           volumes:
             - name: clickhouse-backup-tls
               secret:
                 secretName: clickhouse-certs
+            - name: clickhouse-data
+              emptyDir: {}

--- a/tests/e2e/steps_fips.py
+++ b/tests/e2e/steps_fips.py
@@ -1163,3 +1163,138 @@ def fips_assert_chk_tls_rejected(
         workload=f"chk/{chk}",
         min_version=min_version,
     )
+
+@TestStep(Then)
+def check_clickhouse_backup_clickhouse_tls_config(self, pod, ns=None):
+    """Verify clickhouse-backup container is configured to reach ClickHouse via TLS native port."""
+    ns = ns or self.context.test_namespace
+
+    out = kubectl.launch(
+        f"exec {pod} -c clickhouse-backup -- "
+        "sh -c '"
+        "echo PORT:$CLICKHOUSE_PORT; "
+        "echo SECURE:$CLICKHOUSE_SECURE; "
+        "echo TLS_CA:$CLICKHOUSE_TLS_CA; "
+        "echo SKIP_VERIFY:$CLICKHOUSE_SKIP_VERIFY"
+        "'",
+        ns=ns,
+    )
+
+    assert "PORT:9440" in out, error(out)
+    assert "SECURE:true" in out, error(out)
+    assert "TLS_CA:/etc/clickhouse-backup/tls/ca.crt" in out, error(out)
+    assert "SKIP_VERIFY:false" in out, error(out)
+
+
+@TestStep(Then)
+def check_clickhouse_backup_can_list_tables_over_clickhouse_tls(self, pod, ns=None):
+    """Use backup API to prove backup can talk to ClickHouse using its configured TLS path."""
+    ns = ns or self.context.test_namespace
+
+    out = kubectl.launch(
+        f"exec {pod} -c clickhouse-backup -- "
+        "curl -sS "
+        "--cacert /etc/clickhouse-backup/tls/ca.crt "
+        "-o /tmp/backup_tables.out "
+        "-w 'HTTP:%{http_code}' "
+        "https://127.0.0.1:7171/backup/tables",
+        ns=ns,
+    )
+
+    assert out == "HTTP:200", error(out)
+
+@TestStep(Then)
+def check_clickhouse_backup_restore_roundtrip_https(
+    self,
+    pod,
+    table="fips_backup_roundtrip",
+    ns=None,
+):
+    """Create data, backup via HTTPS API, drop data, restore via HTTPS API, verify data."""
+    ns = ns or self.context.test_namespace
+    backup_name = f"{table}_backup"
+
+    def api(method, path):
+        return kubectl.launch(
+            f"exec {pod} -c clickhouse-backup -- "
+            "sh -c "
+            f"\"curl -sS -X {method} "
+            "--cacert /etc/clickhouse-backup/tls/ca.crt "
+            "-o /tmp/backup_api.out "
+            "-w 'HTTP:%{http_code}' "
+            f"'https://127.0.0.1:7171{path}'\"",
+            ns=ns,
+        ).strip()
+
+    with Given("test table exists with data"):
+        fips_ch_external_secure_query(
+            pod=pod,
+            sql=f"DROP TABLE IF EXISTS {table} SYNC",
+        )
+        fips_wait_table_removed_from_dropped_tables(pod=pod, table=table)
+
+        fips_ch_external_secure_query(
+            pod=pod,
+            sql=f"CREATE TABLE {table} (n UInt64) ENGINE = MergeTree ORDER BY n",
+        )
+        fips_ch_external_secure_query(
+            pod=pod,
+            sql=f"INSERT INTO {table} SELECT number FROM numbers(10)",
+        )
+
+    with When("backup is created through HTTPS API"):
+        out = api(
+            "POST",
+            f"/backup/create?name={backup_name}&table=default.{table}",
+        )
+        assert out.startswith("HTTP:2"), error(out)
+
+    with And("table is dropped"):
+        fips_ch_external_secure_query(
+            pod=pod,
+            sql=f"DROP TABLE IF EXISTS {table} SYNC",
+        )
+        fips_wait_table_removed_from_dropped_tables(pod=pod, table=table)
+
+    with And("backup is restored through HTTPS API"):
+        out = api(
+            "POST",
+            f"/backup/restore/{backup_name}?table=default.{table}",
+        )
+        assert out.startswith("HTTP:2"), error(out)
+
+    with Then("restored data is visible through strict TLS ClickHouse client"):
+        fips_poll_secure_scalar(
+            pod=pod,
+            sql=f"SELECT count() FROM {table}",
+            expected=10,
+        )
+@TestStep(Then)
+def fips_wait_table_removed_from_dropped_tables(
+    self,
+    pod,
+    table,
+    database="default",
+    timeout=60,
+):
+    """Wait until Atomic database dropped-table metadata no longer reserves the table UUID."""
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        out = fips_ch_external_secure_query(
+            pod=pod,
+            sql=(
+                "SELECT count() "
+                "FROM system.dropped_tables "
+                f"WHERE database = '{database}' AND table = '{table}'"
+            ),
+        )
+
+        if out.strip() == "0":
+            return
+
+        time.sleep(1)
+
+    assert False, error(
+        f"{database}.{table} still present in system.dropped_tables after {timeout}s"
+    )

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -8648,6 +8648,68 @@ def test_030010(self):
         )
         util.restart_operator()
 
+@TestScenario
+@Name("test_030012. FIPS backup: ClickHouse over TLS and HTTPS restore round-trip")
+@Requirements(
+    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_ClickHouseOverTLS("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_RestoreRoundTrip("1.0"),
+)
+@Tags("NO_PARALLEL")
+def test_030012(self):
+    """Verify clickhouse-backup uses TLS to ClickHouse and restore works via HTTPS API."""
+
+    chopconf = "manifests/chopconf/test-030002-chopconf.yaml"
+    chi_manifest = "manifests/chi/test-030003.yaml"
+    chk_manifest = "manifests/chk/test-030003.yaml"
+    backup_template = "manifests/chit/test-030003-backup-template.yaml"
+
+    fips_create_shell_namespace_clickhouse_template()
+
+    chi = yaml_manifest.get_name(util.get_full_path(chi_manifest))
+    chk = yaml_manifest.get_name(util.get_full_path(chk_manifest))
+
+    with Given("strict FIPS operator configuration is applied"):
+        util.apply_operator_config(chopconf)
+
+    with And("test TLS secret is installed"):
+        create_tls_secret_for_fips_hosts(chi=chi, chk=chk)
+
+    with And("external ClickHouse client container is started"):
+        start_external_ch_container()
+
+    with And("FIPS Keeper is deployed"):
+        fips_apply_manifest(
+            manifest_path=chk_manifest,
+            expected_pod_count=2,
+            kind="chk",
+        )
+
+    with And("FIPS ClickHouse with backup sidecar is deployed"):
+        fips_apply_manifest(
+            manifest_path=chi_manifest,
+            expected_pod_count=2,
+            kind="chi",
+            apply_templates=[backup_template],
+        )
+
+    with Given("FIPS ClickHouse cluster is healthy"):
+        chi_pods = fips_assert_replicas_healthy(
+            workload=chi,
+            expected_count=2,
+            kind="chi",
+        )
+
+        pod = chi_pods[0]
+
+    with Then("backup sidecar reaches ClickHouse through secure native TCP"):
+        check_clickhouse_backup_clickhouse_tls_config(pod=pod)
+        check_clickhouse_backup_can_list_tables_over_clickhouse_tls(pod=pod)
+
+    with Then("backup and restore succeeds through HTTPS API"):
+        check_clickhouse_backup_restore_roundtrip_https(pod=pod)
+
+    with Finally("external ClickHouse client container is removed"):
+        stop_external_ch_container()
 
 def cleanup_chis(self):
     with Given("Cleanup CHIs"):


### PR DESCRIPTION
## Summary

Added missing volume mounts to the backups sidecar example that was denying backup restore. Also added following test which checks TLS communication during backup create and restore.


## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed.
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch.
* [x] The PR is signed.