### PR TITLE
fix(helm): wire watchNamespaces value into operator ConfigMap

### DIFF
--- a/deploy/helm/clickhouse-operator/README.md
+++ b/deploy/helm/clickhouse-operator/README.md
@@ -138,4 +138,5 @@ crdHook:
 | serviceMonitor.operatorMetrics.scrapeTimeout | string | `""` |  |
 | tolerations | list | `[]` | tolerations for scheduler pod assignment, check `kubectl explain pod.spec.tolerations` for details |
 | topologySpreadConstraints | list | `[]` |  |
+| watchNamespaces | list | `[]` | namespaces where the operator watches for ClickHouseInstallation resources. If empty, the operator watches only its own namespace (or all namespaces when running in kube-system). Use [".*"] to watch all namespaces. Example: watchNamespaces: ["clickhouse", "my-other-namespace"] |
 

--- a/deploy/helm/clickhouse-operator/templates/_helpers.tpl
+++ b/deploy/helm/clickhouse-operator/templates/_helpers.tpl
@@ -122,3 +122,25 @@ null
 {{- tpl (toYaml (dict $k $v)) $root }}
 {{ end }}
 {{- end }}
+
+{{/*
+altinity-clickhouse-operator.configmap-files merges watchNamespaces into the
+operator config before rendering the ConfigMap data block.
+
+This exists because configs.files.config.yaml.watch.namespaces.include is
+deep inside a nested structure — Helm's values merge cannot target it
+directly. Instead we deepCopy the files map, patch the nested value in-place,
+and pass the result to configmap-data.
+
+Arguments (list): root context, configs.files, watchNamespaces list
+*/}}
+{{- define "altinity-clickhouse-operator.configmap-files" -}}
+{{- $root := index . 0 -}}
+{{- $files := deepCopy (index . 1) -}}
+{{- $watchNamespaces := index . 2 -}}
+{{- if $watchNamespaces -}}
+  {{- $namespaces := index (index (index $files "config.yaml") "watch") "namespaces" -}}
+  {{- $_ := set $namespaces "include" $watchNamespaces -}}
+{{- end -}}
+{{- include "altinity-clickhouse-operator.configmap-data" (list $root $files) -}}
+{{- end -}}

--- a/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
@@ -11,4 +11,4 @@ metadata:
   namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
-data: {{ include "altinity-clickhouse-operator.configmap-data" (list . .Values.configs.files) | nindent 2 }}
+data: {{ include "altinity-clickhouse-operator.configmap-files" (list . .Values.configs.files .Values.watchNamespaces) | nindent 2 }}

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -147,6 +147,11 @@ podAnnotations:
   prometheus.io/scrape: 'true'
   clickhouse-operator-metrics/port: '9999'
   clickhouse-operator-metrics/scrape: 'true'
+# watchNamespaces -- namespaces where the operator watches for ClickHouseInstallation resources.
+# If empty, the operator watches only its own namespace (or all namespaces when running in kube-system).
+# Use [".*"] to watch all namespaces.
+# Example: watchNamespaces: ["clickhouse", "my-other-namespace"]
+watchNamespaces: []
 # nameOverride -- override name of the chart
 nameOverride: ""
 # fullnameOverride -- full name of the chart.

--- a/dev/generate_helm_chart.sh
+++ b/dev/generate_helm_chart.sh
@@ -290,7 +290,14 @@ function update_configmap_resource() {
   yq e -i '.metadata.namespace |= "{{ include \"altinity-clickhouse-operator.namespace\" . }}"' "${file}"
   yq e -i '.metadata.labels |= "{{ include \"altinity-clickhouse-operator.labels\" . | nindent 4 }}"' "${file}"
   yq e -i '.metadata.annotations |= "{{ include \"altinity-clickhouse-operator.annotations\" . | nindent 4 }}"' "${file}"
-  yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-data\" (list . .Values.configs.'"${camel_cased_name}"') | nindent 2 }}"' "${file}"
+  if [ "${name}" = "etc-clickhouse-operator-files" ]; then
+    # The operator config ConfigMap needs watchNamespaces wired in. Use the
+    # configmap-files helper (which patches watch.namespaces.include from the
+    # top-level watchNamespaces value) instead of the generic configmap-data.
+    yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-files\" (list . .Values.configs.files .Values.watchNamespaces) | nindent 2 }}"' "${file}"
+  else
+    yq e -i '.data |= "{{ include \"altinity-clickhouse-operator.configmap-data\" (list . .Values.configs.'"${camel_cased_name}"') | nindent 2 }}"' "${file}"
+  fi
 
   if [ -z "${data}" ]; then
     yq e -i '.configs.'"${camel_cased_name}"' |= null' "${values_yaml}"


### PR DESCRIPTION
## Problem

Closes #1919.

`configs.files.config.yaml.watch.namespaces.include` is hardcoded to `[]` in `values.yaml` and the ConfigMap template renders it directly — there is no way to override it via a top-level Helm value. Users who need the operator to watch multiple namespaces must manually patch the ConfigMap after install, which is fragile and breaks on upgrades.

## Solution

This PR introduces:

1. A top-level `watchNamespaces` value in `values.yaml` (empty by default — preserves existing behavior):

```yaml
# watchNamespaces -- namespaces where the operator watches for ClickHouseInstallation resources.
# If empty, the operator watches only its own namespace (or all namespaces when running in kube-system).
# Use [".*"] to watch all namespaces.
watchNamespaces: []
```

2. A new `altinity-clickhouse-operator.configmap-files` helper in `_helpers.tpl` that deep-copies `configs.files`, patches `watch.namespaces.include` in-place, and delegates to the existing `configmap-data` helper for rendering.

3. The ConfigMap template updated to call the new helper instead of `configmap-data` directly.

## Usage

```yaml
# values.yaml
watchNamespaces:
  - clickhouse-system
  - my-app-namespace
```

Or via `--set`:

```bash
helm install clickhouse-operator altinity/altinity-clickhouse-operator \
  --set "watchNamespaces={clickhouse-system,my-app-namespace}"
```

## Behavior

- `watchNamespaces: []` (default) — no change, operator watches its own namespace
- `watchNamespaces: [".*"]` — watch all namespaces
- Any non-empty list — operator watches exactly those namespaces

## Testing

```bash
# Default — include stays []
helm template test deploy/helm/clickhouse-operator \
  --show-only templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml | grep -A5 'watch:'

# With namespaces set
helm template test deploy/helm/clickhouse-operator \
  --set 'watchNamespaces={clickhouse-system,everest-dev}' \
  --show-only templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml | grep -A8 'watch:'
```