### PR TITLE
feat(helm): add podSecurityContext and podAnnotations to crdHook Job

### DIFF
--- a/deploy/helm/clickhouse-operator/README.md
+++ b/deploy/helm/clickhouse-operator/README.md
@@ -83,6 +83,8 @@ crdHook:
 | crdHook.image.tag | string | `"latest"` | image tag for CRD installation job |
 | crdHook.imagePullSecrets | list | `[]` | image pull secrets for CRD installation job possible value format `[{"name":"your-secret-name"}]`, check `kubectl explain pod.spec.imagePullSecrets` for details |
 | crdHook.nodeSelector | object | `{}` | node selector for CRD installation job |
+| crdHook.podAnnotations | object | `{}` | additional annotations for CRD installation job pod template useful to opt out of service mesh injection, e.g. `sidecar.istio.io/inject: "false"` |
+| crdHook.podSecurityContext | object | `{}` | pod-level security context for CRD installation job required by some admission policies (e.g. Kyverno `restrict-seccomp-strict`) check `kubectl explain pod.spec.securityContext` for details |
 | crdHook.resources | object | `{}` | resource limits and requests for CRD installation job |
 | crdHook.tolerations | list | `[]` | tolerations for CRD installation job |
 | dashboards.additionalLabels | object | `{"grafana_dashboard":""}` | labels to add to a secret with dashboards |

--- a/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
+++ b/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
@@ -21,9 +21,17 @@ spec:
       labels:
         {{- include "altinity-clickhouse-operator.labels" . | nindent 8 }}
         app.kubernetes.io/component: crd-install-hook
+      {{- with .Values.crdHook.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "altinity-clickhouse-operator.fullname" . }}-crd-install
       restartPolicy: OnFailure
+      {{- with .Values.crdHook.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.crdHook.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/clickhouse-operator/values.schema.json
+++ b/deploy/helm/clickhouse-operator/values.schema.json
@@ -710,6 +710,12 @@
                 "annotations": {
                     "type": "object"
                 },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
                 "containerSecurityContext": {
                     "type": "object"
                 }

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -38,6 +38,17 @@ crdHook:
   affinity: {}
   # crdHook.annotations -- additional annotations for CRD installation job
   annotations: {}
+  # crdHook.podAnnotations -- additional annotations for CRD installation job pod template
+  # useful to opt out of service mesh injection, e.g. `sidecar.istio.io/inject: "false"`
+  podAnnotations: {}
+  # crdHook.podSecurityContext -- pod-level security context for CRD installation job
+  # required by some admission policies (e.g. Kyverno `restrict-seccomp-strict`)
+  # check `kubectl explain pod.spec.securityContext` for details
+  podSecurityContext: {}
+  #  runAsNonRoot: true
+  #  runAsUser: 1000
+  #  seccompProfile:
+  #    type: RuntimeDefault
   # crdHook.containerSecurityContext -- container security context for CRD installation job
   # check `kubectl explain pod.spec.containers.securityContext` for details
   containerSecurityContext: {}


### PR DESCRIPTION
Follow-up to #1950, which added `crdHook.containerSecurityContext`.

## Summary

The `crd-install` Helm hook Job currently exposes only container-level `securityContext`. There is no way to set pod-level `securityContext` nor pod-template annotations. This blocks two real-world deployments:

- **Kyverno `restrict-seccomp-strict`** rejects the Job because the pod spec lacks a pod-level `seccompProfile`. Container-level seccomp is not sufficient under the strict variant of this policy. https://kyverno.io/policies/pod-security/restricted/restrict-seccomp-strict/
- **Istio sidecar auto-injection** adds an `istio-init` initContainer at admission time. That initContainer has no `seccompProfile`, again tripping Kyverno strict. The canonical opt-out is the pod-template annotation `sidecar.istio.io/inject: "false"`, but the chart had no field to set it.

This PR adds two new value keys:

| Key | Renders to |
|---|---|
| `crdHook.podSecurityContext` | `spec.template.spec.securityContext` |
| `crdHook.podAnnotations`     | `spec.template.metadata.annotations` |

Both default to `{}` and render under `{{- with }}`, so the output is byte-identical when unset.

## Changes

- `templates/hooks/crd-install-job.yaml` — render the two new blocks
- `values.yaml` — documented under `crdHook:` with commented-out examples
- `values.schema.json` — declared both as `type: object`
- `README.md` — two new rows in the values table

## Backward compatibility

Defaults unchanged. With no overrides, the rendered Job is identical to the pre-PR chart (verified via `diff` of `helm template` output).
