### PR TITLE
Align FIPS test plan, requirements, and e2e FIPS coverage

### DIFF
--- a/tests/e2e/steps_fips.py
+++ b/tests/e2e/steps_fips.py
@@ -33,6 +33,8 @@ from testflows.core import *
 import e2e.kubectl as kubectl
 
 
+FAKE_OPENSSL_SERVER = "fake-openssl-server"
+
 # ---------------------------------------------------------------------------
 # Build verification
 # ---------------------------------------------------------------------------
@@ -268,8 +270,6 @@ def fips_assert_fips_enforced_coercion_in_logs(self, logs):
             "FIPS strict: coerced security.ipc.mode: Plain → Secure",
         ),
     )
-
-
 
 
 @TestStep(Given)
@@ -571,6 +571,10 @@ def start_external_ch_container(self, ns=None, cipher_suites=None):
     note(f"external ClickHouse client container started: {container}")
     self.context.external_chi_container = container
 
+    yield
+
+    with Finally("stop external ClickHouse client container"):
+        stop_external_ch_container()
 
 @TestStep(Finally)
 def stop_external_ch_container(self):
@@ -592,7 +596,7 @@ def fips_ch_external_secure_query(self, pod, sql, ns=None):
     """
     ns = ns or self.context.test_namespace
     container = self.context.external_chi_container
-    local_port = "9440"
+    local_port = _free_local_port()
 
     pf = subprocess.Popen(
         [
@@ -668,7 +672,7 @@ def fips_ch_external_secure_query(self, pod, sql, ns=None):
 # ---------------------------------------------------------------------------
 
 @TestStep(Given)
-def fips_edit_manifest(self, source_manifest, replicas_count=None, kind="chi"):
+def fips_edit_manifest(self, source_manifest, replicas_count=None,  cipher_suites=None, kind="chi"):
     """Load a CHI/CHK manifest, patch ``replicasCount``, write a temp copy."""
     source_path = util.get_full_path(source_manifest)
     with open(source_path, encoding="utf-8") as f:
@@ -677,6 +681,20 @@ def fips_edit_manifest(self, source_manifest, replicas_count=None, kind="chi"):
     if replicas_count is not None:
         manifest["spec"]["configuration"]["clusters"][0]["layout"]["replicasCount"] = (
             replicas_count
+        )
+    if cipher_suites is not None:
+        xml = manifest["spec"]["configuration"]["files"]["openssl.xml"]
+
+        old = (
+            "TLS_AES_128_GCM_SHA256:"
+            "TLS_AES_256_GCM_SHA384"
+        )
+
+        manifest["spec"]["configuration"]["files"]["openssl.xml"] = (
+            xml.replace(
+                old,
+                ":".join(cipher_suites),
+            )
         )
 
     fd, temp_path = tempfile.mkstemp(suffix=".yaml", prefix=f"fips-{kind}-")
@@ -688,6 +706,7 @@ def fips_edit_manifest(self, source_manifest, replicas_count=None, kind="chi"):
     if replicas_count is not None:
         note(f"  replicasCount={replicas_count}")
 
+
     return temp_path
 
 
@@ -695,7 +714,7 @@ def fips_edit_manifest(self, source_manifest, replicas_count=None, kind="chi"):
 def fips_apply_manifest(
     self,
     manifest_path,
-    expected_pod_count=None,
+    replica_count=None,
     kind="chi",
     apply_templates=None,
     timeout=None,
@@ -712,8 +731,8 @@ def fips_apply_manifest(
     check = {
         "do_not_delete": 1,
     }
-    if expected_pod_count is not None:
-        check["pod_count"] = expected_pod_count
+    if replica_count is not None:
+        check["pod_count"] = replica_count
     if expected_status is not None:
         if kind == "chi":
             check["chi_status"] = expected_status
@@ -744,18 +763,20 @@ def get_binary_version(self, pod, binary, container=None, ns=None):
         ns=ns,
     )
 
+@TestStep(Then)
+def check_fips_binary_version(self, pod, binary, container=None, ns=None):
+    """Run ``<binary> --version`` inside a pod and check it contains altinityfips tag."""
 
-@TestStep(When)
-def fips_read_listening_ports(self, pod, container="clickhouse", ns=None):
-    """Return TCP ports in LISTEN state inside the container via ``/proc/net/tcp``."""
-    ns = ns or self.context.test_namespace
-    raw = kubectl.launch(
-        f"exec {pod} -c {container} -- "
-        f"sh -c 'cat /proc/net/tcp /proc/net/tcp6'",
-        ns=ns,
+    version = get_binary_version(pod=pod, binary=binary, container=container, ns=ns)
+
+    assert "altinityfips" in version, error(
+        f"{pod}: expected altinityfips in {binary} version, got {version!r}"
     )
 
+def translate_tcp_port_output(raw):
+    """Translates raw output to a readable set of ports"""
     ports = set()
+
     for line in raw.splitlines():
         cols = line.split()
         if len(cols) < 4 or cols[0] == "sl" or cols[3] != "0A":
@@ -764,26 +785,70 @@ def fips_read_listening_ports(self, pod, container="clickhouse", ns=None):
             ports.add(int(cols[1].split(":")[1], 16))
         except (IndexError, ValueError):
             continue
+
     return ports
+
+@TestStep(When)
+def fips_read_listening_ports(
+    self,
+    pod,
+    container,
+    ns=None,
+    debug=False,
+    target=None,
+):
+    """Return TCP ports in LISTEN state from /proc/net/tcp and /proc/net/tcp6."""
+
+    ns = ns or self.context.test_namespace
+
+    if debug:
+        target = target or container
+        raw = kubectl.launch(
+            f"debug {pod} "
+            f"--image=busybox:1.36 "
+            f"--target={target} "
+            f"--attach "
+            f"-- sh -c 'cat /proc/1/net/tcp /proc/1/net/tcp6'",
+            ns=ns,
+        )
+    else:
+        raw = kubectl.launch(
+            f"exec {pod} -c {container} -- "
+            f"sh -c 'cat /proc/net/tcp /proc/net/tcp6'",
+            ns=ns,
+        )
+
+    return translate_tcp_port_output(raw=raw)
 
 
 @TestStep(Then)
-def fips_assert_only_tls_ports(
+def fips_assert_only_expected_ports(
     self,
     pod,
-    required,
+    expected,
     container="clickhouse",
+    ns=None,
     max_iters=1,
     sleep_s=2,
+    debug=False
 ):
-    """Assert the container listens on exactly ``required`` and nothing else."""
+    """Assert the container listens on expected required ports."""
+
     ports = set()
+
     for attempt in range(max_iters):
-        ports = fips_read_listening_ports(pod=pod, container=container)
+        ports = fips_read_listening_ports(
+            pod=pod,
+            container=container,
+            ns=ns,
+            debug=debug
+        )
+
         note(f"listening ports on {pod}: {sorted(ports)}")
 
-        missing = required - ports
-        unexpected = ports - required
+        missing = expected - ports
+        unexpected = ports - expected
+
         if not missing and not unexpected:
             return
 
@@ -795,15 +860,15 @@ def fips_assert_only_tls_ports(
             )
             time.sleep(sleep_s)
 
-    missing = required - ports
+    missing = expected - ports
     assert not missing, error(
         f"{pod}: required {container} TLS ports missing: {sorted(missing)}"
     )
 
-    unexpected = ports - required
+    unexpected = ports - expected
     assert not unexpected, error(
         f"{pod}: unexpected {container} ports listening "
-        f"(approved={sorted(required)}): {sorted(unexpected)}"
+        f"(approved={sorted(expected)}): {sorted(unexpected)}"
     )
 
 
@@ -835,7 +900,7 @@ def fips_wait_cluster_topology(
     self,
     pod,
     cluster_name,
-    expected_count,
+    replica_count,
     max_iters=30,
     sleep_s=2,
 ):
@@ -846,63 +911,665 @@ def fips_wait_cluster_topology(
             f"SELECT count() FROM system.clusters "
             f"WHERE cluster = '{cluster_name}'"
         ),
-        expected=expected_count,
+        expected=replica_count,
         max_iters=max_iters,
         sleep_s=sleep_s,
     )
-    note(f"{pod} sees {expected_count} hosts in cluster {cluster_name!r}")
+    note(f"{pod} sees {replica_count} hosts in cluster {cluster_name!r}")
+
+
+@TestStep(When)
+def fips_run_openssl_s_client_on_pod_port(
+    self,
+    pod,
+    port,
+    cipher_suite="TLS_AES_128_GCM_SHA256",
+    tls_version="1.3",
+    ok_to_fail=False,
+    ns=None,
+):
+    """Run ``openssl s_client`` against a pod listener through ``kubectl port-forward``."""
+    ns = ns or self.context.test_namespace
+    ca_crt = self.context.tls["ca_crt"]
+    local_port = _free_local_port()
+
+    pf = subprocess.Popen(
+        [
+            "kubectl",
+            "-n", ns,
+            "port-forward",
+            f"pod/{pod}",
+            f"{local_port}:{port}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if pf.poll() is not None:
+                out, err = pf.communicate()
+                assert False, error(
+                    "kubectl port-forward exited early\n"
+                    f"stdout:\n{out}\n"
+                    f"stderr:\n{err}"
+                )
+
+            try:
+                socket.create_connection(
+                    ("127.0.0.1", int(local_port)), timeout=0.5
+                ).close()
+                break
+            except OSError:
+                time.sleep(0.2)
+        else:
+            assert False, error(
+                f"kubectl port-forward to {pod}:{port} "
+                f"did not become ready on 127.0.0.1:{local_port}"
+            )
+
+        command = [
+            "openssl", "s_client",
+            "-connect", f"127.0.0.1:{local_port}",
+            "-servername", "localhost",
+            "-CAfile", ca_crt,
+            "-verify_return_error",
+        ]
+
+        if tls_version == "1.3":
+            command.append("-tls1_3")
+            if cipher_suite:
+                command.extend(["-ciphersuites", cipher_suite])
+        elif tls_version == "1.2":
+            command.append("-tls1_2")
+            if cipher_suite:
+                command.extend(["-cipher", cipher_suite])
+        elif tls_version == "1.1":
+            command.append("-tls1_1")
+            if cipher_suite:
+                command.extend(["-cipher", cipher_suite])
+        else:
+            raise ValueError(f"unsupported TLS version: {tls_version}")
+
+        result = subprocess.run(
+            command,
+            input="Q\n",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        output = f"{result.stdout}\n{result.stderr}"
+
+        if not ok_to_fail:
+            assert result.returncode == 0, error(
+                f"{pod}:{port}: openssl s_client failed for "
+                f"tls={tls_version}, cipher={cipher_suite}\n"
+                f"exit code: {result.returncode}\n"
+                f"output:\n{output}"
+            )
+
+        return output
+
+    finally:
+        pf.terminate()
+        try:
+            pf.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            pf.kill()
+
+@TestStep(Then)
+def fips_assert_rejected_tls_probes(
+    self,
+    chi_pods,
+    chk_pods,
+    ns=None,
+):
+    """Assert rejected TLS protocol/cipher combinations fail handshake."""
+    ns = ns or self.context.test_namespace
+
+    rejected_cases = (
+        {
+            "name": "TLS 1.3 ChaCha20-Poly1305",
+            "tls_version": "1.3",
+            "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
+        },
+        {
+            "name": "TLS 1.1 protocol",
+            "tls_version": "1.1",
+            "cipher_suite": None,
+        },
+    )
+
+    endpoints = (
+        ("ClickHouse HTTPS", chi_pods[0], 8443),
+        ("ClickHouse native TLS", chi_pods[0], 9440),
+        ("ClickHouse interserver HTTPS", chi_pods[0], 9010),
+        ("Keeper secure client", chk_pods[0], 2281),
+        ("Backup API HTTPS", chi_pods[0], 7171),
+    )
+
+    rejected_markers = (
+        "Cipher is (NONE)",
+        "handshake failure",
+        "no protocols available",
+        "no shared cipher",
+    )
+
+    for case in rejected_cases:
+        for label, pod, port in endpoints:
+            with Then(f"{label} {pod}:{port} rejects {case['name']}"):
+                output = fips_run_openssl_s_client_on_pod_port(
+                    pod=pod,
+                    port=port,
+                    tls_version=case["tls_version"],
+                    cipher_suite=case["cipher_suite"],
+                    ok_to_fail=True,
+                    ns=ns,
+                )
+
+                assert any(
+                    marker.lower() in output.lower()
+                    for marker in rejected_markers
+                ), error(
+                    f"{label} {pod}:{port}: expected rejected TLS probe to fail "
+                    f"for {case['name']}\n"
+                    f"output:\n{output}"
+                )
+
+@TestStep(Then)
+def fips_assert_aes256_tls13_probes(
+    self,
+    chi_pods,
+    chk_pods,
+    ns=None,
+):
+    """Assert approved TLS 1.3 AES-256-GCM cipher negotiates on FIPS TLS listeners."""
+    ns = ns or self.context.test_namespace
+    approved_cipher = "TLS_AES_256_GCM_SHA384"
+
+    endpoints = (
+        ("ClickHouse HTTPS", chi_pods[0], 8443),
+        ("ClickHouse native TLS", chi_pods[0], 9440),
+        ("ClickHouse interserver HTTPS", chi_pods[0], 9010),
+        ("Keeper secure client", chk_pods[0], 2281),
+        ("Backup API HTTPS", chi_pods[0], 7171),
+    )
+
+    for label, pod, port in endpoints:
+        with Then(f"{label} {pod}:{port} accepts approved AES-256 TLS 1.3 cipher"):
+            output = fips_run_openssl_s_client_on_pod_port(
+                pod=pod,
+                port=port,
+                tls_version="1.3",
+                cipher_suite=approved_cipher,
+                ok_to_fail=True,
+                ns=ns,
+            )
+
+            assert f"Cipher is {approved_cipher}" in output, error(
+                f"{label} {pod}:{port}: expected {approved_cipher} to negotiate\n"
+                f"output:\n{output}"
+            )
+
+@TestStep(When)
+def fips_curl_pod_port(self, pod, port, path="/", ns=None):
+    """Return the HTTP status code from a plain ``curl`` to a pod listener via port-forward."""
+    ns = ns or self.context.test_namespace
+    local_port = _free_local_port()
+
+    pf = subprocess.Popen(
+        [
+            "kubectl",
+            "-n", ns,
+            "port-forward",
+            f"pod/{pod}",
+            f"{local_port}:{port}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if pf.poll() is not None:
+                out, err = pf.communicate()
+                assert False, error(
+                    "kubectl port-forward exited early\n"
+                    f"stdout:\n{out}\n"
+                    f"stderr:\n{err}"
+                )
+
+            try:
+                socket.create_connection(
+                    ("127.0.0.1", int(local_port)), timeout=0.5
+                ).close()
+                break
+            except OSError:
+                time.sleep(0.2)
+        else:
+            assert False, error(
+                f"kubectl port-forward to {pod}:{port} "
+                f"did not become ready on 127.0.0.1:{local_port}"
+            )
+
+        result = subprocess.run(
+            [
+                "curl", "-sS",
+                "-o", "/dev/null",
+                "-w", "%{http_code}",
+                f"http://127.0.0.1:{local_port}{path}",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, error(
+            f"{pod}:{port}{path}: curl failed\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        return result.stdout.strip()
+
+    finally:
+        pf.terminate()
+        try:
+            pf.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            pf.kill()
 
 
 @TestStep(Then)
-def fips_assert_replicas_healthy(
-    self,
-    workload,
-    expected_count,
-    kind="chi",
-    cluster_name="default",
-):
-    """Run essential FIPS/TLS health checks for the current CHI or CHK replica set."""
-    if kind == "chi":
-        pods = sorted(kubectl.get_pod_names(workload))
-        binary = "clickhouse"
-        container = "clickhouse"
-        tls_ports = {8443, 9440, 9010, 7171}
-    elif kind == "chk":
-        pods = sorted(kubectl.get_chk_pod_names(workload))
-        binary = "clickhouse-keeper"
-        container = "clickhouse-keeper"
-        tls_ports = {2281, 9444, 9182}
-    else:
-        raise ValueError(f"unsupported workload kind: {kind}")
+def check_chi_ports(self, pod, ns=None):
+    """TLS positive/negative probes for ClickHouse HTTPS and native ports."""
+    ns = ns or self.context.test_namespace
+    approved_cipher = "TLS_AES_128_GCM_SHA256"
 
-    note(f"{kind.upper()} pods: {pods}")
-    assert len(pods) == expected_count, error(
-        f"expected {expected_count} {kind.upper()} pods, "
-        f"got {len(pods)}: {pods}"
+    for port in (8443, 9010):
+        with Then(f"{pod}:{port} accepts approved TLS 1.3 cipher"):
+            output = fips_run_openssl_s_client_on_pod_port(
+                pod=pod, port=port, cipher_suite=approved_cipher, ns=ns,
+            )
+            assert f"Cipher is {approved_cipher}" in output, error(
+                f"{pod}:{port}: expected approved cipher negotiation\n{output}"
+            )
+
+    with And(f"{pod}:9440 accepts approved native TLS query"):
+        out = fips_ch_external_secure_query(pod=pod, sql="SELECT 1")
+        assert out == "1", error(
+            f"{pod}:9440: expected SELECT 1 over native TLS, got {out!r}"
+        )
+
+
+
+@TestStep(Then)
+def check_chk_ports(self, pod, ns=None):
+    """TLS and readiness HTTP probes for ClickHouse Keeper listeners."""
+    ns = ns or self.context.test_namespace
+    approved_cipher = "TLS_AES_128_GCM_SHA256"
+    port = 2281
+
+    # raft 9444 doesnt communicate over TLS endpoint
+    with Then(f"{pod}:{port} accepts approved TLS 1.3 cipher"):
+        output = fips_run_openssl_s_client_on_pod_port(
+            pod=pod, port=port, cipher_suite=approved_cipher, ns=ns,
+        )
+        assert f"Cipher is {approved_cipher}" in output, error(
+            f"{pod}:{port}: expected approved cipher negotiation\n{output}"
+        )
+
+    with And(f"{pod}:9182/ready accepts plain HTTP"):
+        code = fips_curl_pod_port(pod=pod, port=9182, path="/ready", ns=ns)
+        assert code == "200", error(
+            f"{pod}:9182/ready: expected HTTP 200, got {code!r}"
+        )
+
+
+@TestStep(Then)
+def check_backup_ports(self, pod, ns=None):
+    """TLS positive/negative probes for the clickhouse-backup HTTPS API."""
+    ns = ns or self.context.test_namespace
+    approved_cipher = "TLS_AES_128_GCM_SHA256"
+
+    with Then(f"{pod}:7171 accepts approved TLS 1.3 cipher"):
+        out = kubectl.launch(
+            f"exec {pod} -c clickhouse-backup -- "
+            f"sh -c 'curl -sS -o /dev/null -w HTTP:%{{http_code}} "
+            f"--cacert /etc/clickhouse-backup/tls/ca.crt "
+            f"--tlsv1.3 --tls13-ciphers {approved_cipher} "
+            f"https://127.0.0.1:7171/backup/tables'",
+            ns=ns,
+        )
+        assert out == "HTTP:200", error(
+            f"{pod}:7171: expected HTTP 200 with approved cipher, got {out!r}"
+        )
+
+    with Then(f"{pod}:7171 rejects plaintext requests"):
+        out = kubectl.launch(
+            f"exec {pod} -c clickhouse-backup -- "
+            f"sh -c 'curl -s -o /dev/null -w %{{http_code}} "
+            f"http://127.0.0.1:7171/backup/tables'",
+            ns=ns,
+            ok_to_fail=True,
+        )
+        assert out != "200", error(
+            f"{pod}:7171: expected plaintext HTTP request to be rejected, got {out!r}"
+        )
+
+@TestStep(Then)
+def check_k8s_api_requires_tls_from_operator_pod(self, ns=None):
+    """Assert Kubernetes API :443 rejects plaintext HTTP from operator pod containers."""
+    ns = ns or current().context.operator_namespace
+    pod = kubectl.get_operator_pod(ns=ns)
+
+    for container in ("clickhouse-operator", "metrics-exporter"):
+        with Then(f"{container} cannot use plaintext HTTP to Kubernetes API :443"):
+            out = kubectl.launch(
+                f"exec {pod} -c {container} -- "
+                "curl -skv http://kubernetes.default.svc:443",
+                ns=ns,
+                ok_to_fail=True,
+            )
+
+            assert "Client sent an HTTP request to an HTTPS server" in out, error(
+                f"{container}: expected Kubernetes API :443 to reject plaintext HTTP\n{out}"
+            )
+
+@TestStep(Then)
+def check_operator_clickhouse_tls_logs(self, ns=None):
+    """Assert operator uses HTTPS/TLS config when communicating with ClickHouse."""
+    ns = ns or current().context.operator_namespace
+    pod = kubectl.get_operator_pod(ns=ns)
+
+    logs = kubectl.launch(
+        f"logs {pod} -c clickhouse-operator",
+        ns=ns,
     )
 
+    assert "setupTLSAdvanced():TLS setup OK" in logs, error(
+        "operator did not log ClickHouse TLS setup"
+    )
+    assert "verify=Strict minVersion=1.3" in logs, error(
+        "operator ClickHouse TLS config is not Strict / TLS 1.3"
+    )
+    assert "Ping(https://clickhouse_operator:" in logs, error(
+        "operator did not log HTTPS ClickHouse ping"
+    )
+    assert ":8443?tls_config=" in logs, error(
+        "operator ClickHouse ping did not use HTTPS port 8443 with TLS config"
+    )
+
+@TestStep(Then)
+def check_metrics_exporter_discovers_clickhouse_https(self, ns=None):
+    """Assert metrics-exporter discovers ClickHouse hosts using HTTPS :8443."""
+
+    ns = ns or current().context.operator_namespace
+    pod = kubectl.get_operator_pod(ns=ns)
+
+    logs = kubectl.launch(
+        f"logs {pod} -c metrics-exporter --tail=4000",
+        ns=ns,
+    )
+
+    assert '"httpsPort":8443' in logs, error(
+        "metrics-exporter did not discover ClickHouse hosts with httpsPort=8443\n"
+        f"{logs}"
+    )
+
+@TestStep(Then)
+def check_clickhouse_uses_secure_keeper_port(self, chi, ns=None):
+    """Assert ClickHouse replicas use Keeper secure client port 2281 with secure=yes."""
+
+    ns = ns or current().context.test_namespace
+    pods = sorted(kubectl.get_pod_names(chi))
+
     for pod in pods:
-        version = get_binary_version(pod=pod, binary=binary)
-        assert "altinityfips" in version, error(
-            f"{pod}: expected altinityfips in {binary} version, got {version!r}"
-        )
-        fips_assert_only_tls_ports(
+        with Then(f"{pod} connects to Keeper on secure port 2281"):
+            logs = kubectl.launch(
+                f"logs {pod} -c clickhouse --tail=5000",
+                ns=ns,
+            )
+
+            assert re.search(r"Connected to ZooKeeper at .+:2281\b", logs), error(
+                f"{pod}: ClickHouse did not connect to Keeper on port 2281\n{logs}"
+            )
+
+
+@TestStep(Then)
+def check_operator_skips_plaintext_keeper_dial(self, ns=None):
+    """Assert operator skips plaintext ZK helper when Keeper ensemble is TLS-only."""
+    ns = ns or current().context.operator_namespace
+    pod = kubectl.get_operator_pod(ns=ns)
+
+    logs = kubectl.launch(
+        f"logs {pod} -c clickhouse-operator",
+        ns=ns,
+    )
+
+    assert 'Port:&2281,Secure:&"yes"' in logs, error(
+        "operator logs do not show Keeper configured as secure port 2281"
+    )
+    assert "Skip ZK root-path ensure" in logs, error(
+        "operator did not log skipping ZK root-path ensure"
+    )
+    assert "ensemble is TLS-only and the operator dial is plaintext" in logs, error(
+        "operator did not log that plaintext Keeper dial was skipped for TLS-only ensemble"
+    )
+
+@TestStep(Then)
+def check_operator_ports(self, ns=None):
+    """Plain HTTP probes for operator Prometheus listener ports."""
+    ns = ns or current().context.operator_namespace
+    pod = kubectl.get_operator_pod(ns=ns)
+
+    for port in (9999, 8888):
+        with Then(f"operator pod:{port}/metrics accepts plain HTTP"):
+            code = fips_curl_pod_port(pod=pod, port=port, path="/metrics", ns=ns)
+            assert code == "200", error(
+                f"operator pod:{port}/metrics: expected HTTP 200, got {code!r}"
+            )
+
+
+@TestStep(Then)
+def run_operator_fips_checks(self):
+    """
+    Run FIPS validation checks against the operator pod:
+
+    * verify the pod network namespace exposes only expected Prometheus ports
+    * verify clickhouse-operator and metrics-exporter emit FIPS startup banners
+    * verify metrics ports accept HTTP and reject disapproved TLS handshakes
+    """
+    ns = current().context.operator_namespace
+    pod = kubectl.get_operator_pod(ns=ns)
+    expected_ports = {8888, 9999}
+
+    with Then("operator pod exposes only expected listener ports"):
+        fips_assert_only_expected_ports(
             pod=pod,
-            required=tls_ports,
-            container=container,
-            max_iters=30,
-            sleep_s=2,
+            container="clickhouse-operator",
+            ns=ns,
+            expected=expected_ports,
+            debug=True,
         )
 
-    if kind == "chi":
-        pod0 = pods[0]
-        out = fips_ch_external_secure_query(pod=pod0, sql="SELECT 1")
-        assert out == "1", error(f"external secure query failed, got {out!r}")
+    with And("both containers report the FIPS startup banner"):
+        op_logs = get_container_logs(
+            pod=pod,
+            container="clickhouse-operator",
+            ns=ns,
+        )
+        me_logs = get_container_logs(
+            pod=pod,
+            container="metrics-exporter",
+            ns=ns,
+        )
+        fips_startup_banner_ok(container="clickhouse-operator", logs=op_logs)
+        fips_startup_banner_ok(container="metrics-exporter", logs=me_logs)
+
+    with Then("operator metrics ports accept HTTP and reject disapproved TLS"):
+        check_operator_ports(ns=ns)
+
+    with Then("Kubernetes API port 443 requires TLS from operator pod containers"):
+        check_k8s_api_requires_tls_from_operator_pod(ns=ns)
+
+@TestStep(Then)
+def run_operator_reconcile_fips_checks(self):
+    """Run the fips checks after operator already reconciled CHK and CHI."""
+
+    ns = current().context.operator_namespace
+
+    with Then("operator communicates with ClickHouse over HTTPS/TLS"):
+        check_operator_clickhouse_tls_logs(ns=ns)
+
+    with And("operator skips plaintext Keeper helper against TLS-only Keeper"):
+        check_operator_skips_plaintext_keeper_dial(ns=ns)
+
+
+@TestStep(Then)
+def run_chi_fips_checks(self, workload, replica_count, cluster_name="default"):
+    """
+    Run FIPS and TLS validation checks against the ClickHouse cluster:
+
+    * wait for the expected cluster topology to become available
+    * verify ClickHouse binaries report an Altinity FIPS build
+    * verify only approved secure listener ports are exposed
+    * verify external TLS connectivity to ClickHouse succeeds
+    * verify the server reports a FIPS version string
+    * verify operator-generated configuration removes plaintext listeners
+    * verify each listener accepts approved TLS and rejects disapproved TLS
+    """
+    pods = sorted(kubectl.get_pod_names(workload))
+    binary = "clickhouse"
+    container = "clickhouse"
+    expected_ports = {8443, 9440, 9010, 7171}
+    pod0 = pods[0]
+
+    note(f"CHI pods: {pods}")
+    assert len(pods) == replica_count, error(
+        f"expected {replica_count} CHI pods, got {len(pods)}: {pods}"
+    )
+
+    with When("I wait for full cluster deployment"):
         fips_wait_cluster_topology(
             pod=pod0,
             cluster_name=cluster_name,
-            expected_count=expected_count,
+            replica_count=replica_count,
         )
+
+    for pod in pods:
+        with Then("check the binary version contains altinityfips tag"):
+            check_fips_binary_version(pod=pod, binary=binary, container=container)
+
+        with And("check the container only listens on expected ports"):
+            fips_assert_only_expected_ports(
+                pod=pod,
+                expected=expected_ports,
+                container=container,
+                max_iters=30,
+                sleep_s=2,
+            )
+
+        with And("check TLS port behavior on each replica"):
+            check_chi_ports(pod=pod)
+
+        with And("operator-generated ClickHouse config removes plaintext ports"):
+            check_ports_in_chi_settings(pod=pod)
+
+    with Then("check connection via external secure query"):
+        check_external_clickhouse_reports_fips_version(pod=pod0)
+
+    return pods
+
+
+@TestStep(Then)
+def run_chk_fips_checks(self, workload, replica_count):
+    """
+    Run FIPS and TLS validation checks against the ClickHouse Keeper cluster:
+
+    * verify the expected number of Keeper pods are running
+    * verify Keeper binaries report an Altinity FIPS build
+    * verify only approved secure listener ports are exposed
+    * verify operator-generated configuration removes plaintext listeners
+    * verify Raft inter-node communication is configured for TLS
+    * verify each listener accepts approved TLS and rejects disapproved TLS
+    """
+    pods = sorted(kubectl.get_chk_pod_names(workload))
+    binary = "clickhouse-keeper"
+    container = "clickhouse-keeper"
+    expected_ports = {2281, 9444, 9182}
+
+    note(f"CHK pods: {pods}")
+    assert len(pods) == replica_count, error(
+        f"expected {replica_count} CHK pods, got {len(pods)}: {pods}"
+    )
+
+    for pod in pods:
+        with Then("check the binary version contains altinityfips tag"):
+            check_fips_binary_version(pod=pod, binary=binary, container=container)
+
+        with And("check the container only listens on expected ports"):
+            fips_assert_only_expected_ports(
+                pod=pod,
+                expected=expected_ports,
+                container=container,
+                max_iters=30,
+                sleep_s=2,
+            )
+
+        with And("check TLS port behavior on each Keeper node"):
+            check_chk_ports(pod=pod)
+
+        with And("operator-generated Keeper config removes plaintext listeners"):
+            check_ports_in_chk_settings(pod=pod)
+
+    return pods
+
+
+@TestStep(Then)
+def run_backup_fips_checks(self, workload, replica_count):
+    """
+    Run FIPS and TLS validation checks against clickhouse-backup sidecars:
+
+    * verify the expected number of CHI pods with backup sidecars are running
+    * verify clickhouse-backup binaries report a FIPS build
+    * verify only approved secure listener ports are exposed
+    * verify each sidecar binary embeds GOFIPS metadata
+    * verify the HTTPS API accepts approved TLS and rejects disapproved TLS
+    """
+    pods = sorted(kubectl.get_pod_names(workload))
+    container = "clickhouse-backup"
+    expected_ports = {8443, 9440, 9010, 7171}
+
+    note(f"CHI pods with backup sidecar: {pods}")
+    assert len(pods) == replica_count, error(
+        f"expected {replica_count} CHI pods, got {len(pods)}: {pods}"
+    )
+
+    for pod in pods:
+        with Then("check the backup binary version contains fips tag"):
+            check_backup_fips_binary_version(pod=pod)
+
+        with And("check the sidecar only listens on expected ports"):
+            fips_assert_only_expected_ports(
+                pod=pod,
+                expected=expected_ports,
+                container=container,
+                max_iters=30,
+                sleep_s=2,
+            )
+
+        with Then("check TLS port behavior on each backup sidecar"):
+            check_backup_ports(pod=pod)
+
+        with And("each sidecar binary embeds GOFIPS metadata"):
+            check_clickhouse_backup_embeds_gofips(pod=pod)
+
+        with And("clickhouse-backup TLS config is secure"):
+            check_clickhouse_backup_clickhouse_tls_config(pod=pod)
 
     return pods
 
@@ -945,7 +1612,7 @@ def fips_check_replication_across_replicas(self, chi_pods, table="repl_test"):
 
 
 @TestStep(When)
-def fips_read_chop_generated_settings(self, pod, container="clickhouse", ns=None):
+def fips_read_chop_generated_chi_settings(self, pod, container="clickhouse", ns=None):
     """Return the operator-generated ``chop-generated-settings.xml`` from ``pod``."""
     ns = ns or self.context.test_namespace
     return kubectl.launch(
@@ -956,8 +1623,12 @@ def fips_read_chop_generated_settings(self, pod, container="clickhouse", ns=None
 
 
 @TestStep(Then)
-def check_ports_in_chi_settings(self, settings_xml):
+def check_ports_in_chi_settings(self, pod):
     """Check approved TLS ports and removed plaintext ports in CHI settings."""
+
+    settings_xml = fips_read_chop_generated_chi_settings(pod=pod)
+    note(f"chop-generated-settings.xml:\n{settings_xml}")
+
     assert "<https_port>8443</https_port>" in settings_xml, error(
         "https_port 8443 missing from operator-generated settings"
     )
@@ -980,14 +1651,57 @@ def check_ports_in_chi_settings(self, settings_xml):
         )
 
 
-# ---------------------------------------------------------------------------
-# clickhouse-backup sidecar
-# ---------------------------------------------------------------------------
+@TestStep(When)
+def fips_read_chop_generated_chk_settings(self, pod, container="clickhouse-keeper", ns=None):
+    """Return operator-generated Keeper listener and Raft XML from ``pod``."""
+    ns = ns or self.context.test_namespace
+    common_listeners_xml = kubectl.launch(
+        f"exec {pod} -c {container} -- "
+        "cat /etc/clickhouse-keeper/keeper_config.d/chop-generated-common-listeners.xml",
+        ns=ns,
+    )
+    raft_xml = kubectl.launch(
+        f"exec {pod} -c {container} -- "
+        "cat /etc/clickhouse-keeper/keeper_config.d/chop-generated-raft.xml",
+        ns=ns,
+    )
+    return common_listeners_xml, raft_xml
+
+
+@TestStep(Then)
+def check_ports_in_chk_settings(self, pod):
+    """Check plaintext listener removal and Raft TLS in CHK settings."""
+
+    common_listeners_xml, raft_xml = fips_read_chop_generated_chk_settings(pod=pod)
+    note(f"chop-generated-common-listeners.xml:\n{common_listeners_xml}")
+    note(f"chop-generated-raft.xml:\n{raft_xml}")
+
+    assert '<tcp_port remove="1"/>' in common_listeners_xml, error(
+        "tcp_port not marked removed in operator-generated Keeper settings"
+    )
+    assert "<secure>1</secure>" in raft_xml, error(
+        "expected <secure>1</secure> in operator-generated Raft config"
+    )
+
+@TestStep(Then)
+def check_backup_fips_binary_version(self, pod, ns=None):
+    """Run ``clickhouse-backup --version`` and check it contains a fips tag."""
+    version = get_binary_version(
+        pod=pod,
+        binary="/bin/clickhouse-backup",
+        container="clickhouse-backup",
+        ns=ns,
+    )
+    note(f"{pod} clickhouse-backup --version: {version}")
+    assert "fips" in version.lower(), error(
+        f"{pod}: expected fips in clickhouse-backup version, got {version!r}"
+    )
+
 
 @TestStep(Then)
 def check_clickhouse_backup_embeds_gofips(
     self,
-    pods,
+    pod,
     gofips_version="v1.0.0",
     ns=None,
 ):
@@ -995,54 +1709,17 @@ def check_clickhouse_backup_embeds_gofips(
     ns = ns or self.context.test_namespace
     expected = f"GOFIPS140={gofips_version}"
 
-    for pod in pods:
-        backup_bin = f"/tmp/{pod}-clickhouse-backup"
-        kubectl.launch(
-            f"cp {pod}:/bin/clickhouse-backup {backup_bin} "
-            f"-c clickhouse-backup",
-            ns=ns,
-        )
-        build_info = kubectl.run_shell(f"go version -m {backup_bin}")
-        assert expected in build_info, error(
-            f"{pod}: expected {expected} in clickhouse-backup binary"
-        )
-        note(f"{pod} clickhouse-backup embeds {expected}")
-
-
-@TestStep(Then)
-def check_clickhouse_backup_https_api_serves_tls(self, pods, ns=None):
-    """Verify clickhouse-backup HTTPS API accepts clients trusted by the test CA."""
-    ns = ns or self.context.test_namespace
-
-    for pod in pods:
-        out = kubectl.launch(
-            f"exec {pod} -c clickhouse-backup -- "
-            f"curl -sS -o /tmp/backup_tables.out -w 'HTTP:%{{http_code}}' "
-            f"--cacert /etc/clickhouse-backup/tls/ca.crt "
-            f"https://127.0.0.1:7171/backup/tables",
-            ns=ns,
-        )
-        assert out == "HTTP:200", error(
-            f"{pod}: /backup/tables did not return HTTP 200, got {out!r}"
-        )
-
-
-@TestStep(Then)
-def check_clickhouse_backup_https_api_rejects_untrusted(self, pods, ns=None):
-    """Verify clickhouse-backup HTTPS API rejects clients without the test CA."""
-    ns = ns or self.context.test_namespace
-
-    for pod in pods:
-        out = kubectl.launch(
-            f"exec {pod} -c clickhouse-backup -- "
-            f"sh -c 'curl -sS --fail "
-            f"https://127.0.0.1:7171/backup/tables >/dev/null 2>&1; "
-            f"echo EXIT:$?'",
-            ns=ns,
-        )
-        assert "EXIT:60" in out, error(
-            f"{pod}: expected certificate verification failure EXIT:60, got {out!r}"
-        )
+    backup_bin = f"/tmp/{pod}-clickhouse-backup"
+    kubectl.launch(
+        f"cp {pod}:/bin/clickhouse-backup {backup_bin} "
+        f"-c clickhouse-backup",
+        ns=ns,
+    )
+    build_info = kubectl.run_shell(f"go version -m {backup_bin}")
+    assert expected in build_info, error(
+        f"{pod}: expected {expected} in clickhouse-backup binary"
+    )
+    note(f"{pod} clickhouse-backup embeds {expected}")
 
 
 @TestStep(Then)
@@ -1196,24 +1873,6 @@ def check_clickhouse_backup_clickhouse_tls_config(self, pod, ns=None):
     assert "TLS_CA:/etc/clickhouse-backup/tls/ca.crt" in out, error(out)
     assert "SKIP_VERIFY:false" in out, error(out)
 
-
-@TestStep(Then)
-def check_clickhouse_backup_can_list_tables_over_clickhouse_tls(self, pod, ns=None):
-    """Use backup API to prove backup can talk to ClickHouse using its configured TLS path."""
-    ns = ns or self.context.test_namespace
-
-    out = kubectl.launch(
-        f"exec {pod} -c clickhouse-backup -- "
-        "curl -sS "
-        "--cacert /etc/clickhouse-backup/tls/ca.crt "
-        "-o /tmp/backup_tables.out "
-        "-w 'HTTP:%{http_code}' "
-        "https://127.0.0.1:7171/backup/tables",
-        ns=ns,
-    )
-
-    assert out == "HTTP:200", error(out)
-
 @TestStep(Then)
 def check_clickhouse_backup_restore_roundtrip_https(
     self,
@@ -1280,6 +1939,7 @@ def check_clickhouse_backup_restore_roundtrip_https(
             sql=f"SELECT count() FROM {table}",
             expected=10,
         )
+
 @TestStep(Then)
 def fips_wait_table_removed_from_dropped_tables(
     self,
@@ -1309,219 +1969,424 @@ def fips_wait_table_removed_from_dropped_tables(
     assert False, error(
         f"{database}.{table} still present in system.dropped_tables after {timeout}s"
     )
-@TestStep(Given)
-def fips_edit_cipher_suites_manifest(
-    self,
-    source_manifest,
-    cipher_suites,
-):
-    """Load CHI/CHK manifest, patch OpenSSL cipherSuites, write temp copy."""
 
-    source_path = util.get_full_path(source_manifest)
-    cipher_suites_value = ":".join(cipher_suites)
-
-    with open(source_path, encoding="utf-8") as f:
-        manifest = yaml.safe_load(f)
-
-    files = (
-        manifest
-        .setdefault("spec", {})
-        .setdefault("configuration", {})
-        .setdefault("files", {})
+@TestStep(Then)
+def check_fips_cast_failure(self, binary_path, binary, cast_name="HMAC-SHA2-256"):
+    """Assert binary exits non-zero when FIPS CAST is forced to fail."""
+    result = subprocess.run(
+        [
+            "env",
+            f"GODEBUG=fips140=only,failfipscast={cast_name}",
+            binary_path,
+            "--version",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
     )
 
-    openssl_xml = files["openssl.xml"]
+    output = f"{result.stdout}\n{result.stderr}"
 
-    openssl_xml = re.sub(
-        r"<cipherSuites>.*?</cipherSuites>",
-        f"<cipherSuites>{cipher_suites_value}</cipherSuites>",
-        openssl_xml,
-        flags=re.DOTALL,
+    assert result.returncode != 0, error(
+        f"{binary}: expected CAST failure exit, got {result.returncode}\n{output}"
+    )
+    assert f"FIPS 140-3 self-test failed: {cast_name}" in output, error(
+        f"{binary}: expected CAST failure for {cast_name}\n{output}"
+    )
+    assert "simulated CAST failure" in output, error(
+        f"{binary}: expected simulated CAST failure message\n{output}"
     )
 
-    files["openssl.xml"] = openssl_xml
+def _free_local_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return str(s.getsockname()[1])
 
-    fd, temp_path = tempfile.mkstemp(
-        suffix=".yaml",
-        prefix="fips-cipher-update-",
+
+@TestStep(Then)
+def check_fips_integrity_failure(self, binary_path, binary_label):
+    """Assert binary panics when the .go.fipsinfo HMAC is tampered with."""
+
+    cmd = f"readelf -S -W {shlex.quote(binary_path)}"
+    readelf_out = kubectl.run_shell(cmd)
+
+    match = re.search(r"\.go\.fipsinfo\s+\w+\s+\w+\s+([0-9a-fA-F]+)", readelf_out)
+    assert match, error(f"{binary_label}: .go.fipsinfo section not found in ELF headers")
+
+    section_offset = int(match.group(1), 16)
+    hmac_byte_offset = section_offset + 16
+
+    corrupted_bin = f"{binary_path}.corrupted"
+    shutil.copy2(binary_path, corrupted_bin)
+
+    with open(corrupted_bin, "rb+") as f:
+        f.seek(hmac_byte_offset)
+        original_byte = f.read(1)
+        corrupted_byte = bytes([original_byte[0] ^ 0xFF])
+        f.seek(hmac_byte_offset)
+        f.write(corrupted_byte)
+
+    result = subprocess.run(
+        [corrupted_bin, "--version"],
+        env={"GODEBUG": "fips140=on"},
+        capture_output=True,
+        text=True,
+        check=False
     )
-    os.close(fd)
 
-    with open(temp_path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(
-            manifest,
-            f,
-            default_flow_style=False,
-            sort_keys=False,
+    output = f"{result.stdout}\n{result.stderr}"
+    note(output)
+
+    with Then("the process must terminate with a verification mismatch panic"):
+        assert result.returncode != 0, error(
+            f"{binary_label}: tampered binary did not exit with error"
+        )
+        assert "fips140: verification mismatch" in output, error(
+            f"{binary_label}: expected integrity panic not found in output:\n{output}"
         )
 
-    note(f"edited cipher-suite manifest written to {temp_path}")
-    note(f"cipherSuites={cipher_suites_value}")
-
-    return temp_path
+    note(f"{binary_label}: integrity check successfully detected tampering")
 
 @TestStep(Then)
-def fips_assert_chi_cipher_suites_configured(
+def check_tls13_cipher_fails(
     self,
     pod,
-    cipher_suites,
+    port,
+    cipher,
+    target_host="localhost",
+    container=None,
+    ns=None,
 ):
-    """Assert ClickHouse generated OpenSSL config contains the expected cipherSuites."""
+    """Verify a TLS 1.3 cipher cannot be negotiated."""
 
-    expected = ":".join(cipher_suites)
+    ns = ns or self.context.test_namespace
 
-    openssl_xml = kubectl.launch(
-        f"exec {pod} -c clickhouse -- "
-        "cat /etc/clickhouse-server/config.d/openssl.xml"
-    )
+    container_arg = f"-c {container} " if container else ""
 
-    expected_line = f"<cipherSuites>{expected}</cipherSuites>"
-
-    assert expected_line in openssl_xml, error(
-        f"{pod}: expected cipherSuites not found\n"
-        f"expected: {expected_line}\n"
-        f"openssl.xml:\n{openssl_xml}"
-    )
-
-
-@TestStep(Then)
-def fips_assert_clickhouse_https_cipher_suite_accepted(
-    self,
-    pod,
-    cipher_suite,
-):
-    """Assert ClickHouse HTTPS accepts the configured TLS 1.3 cipher suite."""
-
-    output = fips_run_openssl_s_client_for_clickhouse_https(
-        pod=pod,
-        cipher_suite=cipher_suite,
-        ok_to_fail=False,
-    )
-
-    assert f"Cipher is {cipher_suite}" in output, error(
-        f"{pod}: expected negotiated cipher {cipher_suite}\n"
-        f"output:\n{output}"
-    )
-
-    assert "Protocol  : TLSv1.3" in output or "Protocol: TLSv1.3" in output, error(
-        f"{pod}: expected TLSv1.3 negotiation\n"
-        f"output:\n{output}"
-    )
-
-
-@TestStep(Then)
-def fips_assert_clickhouse_https_cipher_suite_rejected(
-    self,
-    pod,
-    cipher_suite,
-):
-    """Assert ClickHouse HTTPS rejects a TLS 1.3 cipher suite not present in config."""
-
-    output = fips_run_openssl_s_client_for_clickhouse_https(
-        pod=pod,
-        cipher_suite=cipher_suite,
+    out = kubectl.launch(
+        f"exec {pod} {container_arg}-- "
+        "openssl s_client "
+        f"-connect {target_host}:{port} "
+        "-tls1_3 "
+        f"-ciphersuites {cipher}",
+        ns=ns,
         ok_to_fail=True,
     )
 
-    assert f"Cipher is {cipher_suite}" not in output, error(
-        f"{pod}: unexpected negotiated cipher {cipher_suite}\n"
-        f"output:\n{output}"
+    assert (
+        "Cipher is (NONE)" in out
+        or "handshake failure" in out
+        or "alert handshake failure" in out
+        or "no shared cipher" in out
+    ), error(
+        f"{target_host}:{port}: expected {cipher} to be rejected\n{out}"
     )
+
+@TestStep(Finally)
+def fips_cleanup_admission_only_chi(self, chi):
+    """Cleanup chi"""
+    kubectl.launch(
+        f"delete chi {chi} --ignore-not-found=true --wait=false",
+        ns=current().context.test_namespace,
+        timeout=600,
+        ok_to_fail=True,
+    )
+    kubectl.launch(
+        f"delete sts,pod,svc,pvc,cm,secret "
+        f"-l clickhouse.altinity.com/chi={chi} "
+        f"--ignore-not-found=true --wait=false",
+        ns=current().context.test_namespace,
+        timeout=600,
+        ok_to_fail=True,
+    )
+
+@TestStep(Then)
+def check_synthetic_tls13_smoke_from_operator_pod(self, chi_pod, ns=None):
+    """Synthetic TLS 1.3 AES-256 smoke from operator pod containers.
+
+    Uses real endpoints:
+    * Kubernetes API: kubernetes.default.svc:443
+    * ClickHouse HTTPS: CHI pod IP:8443
+
+    Kubernetes is checked in two parts:
+    * verbose unauthenticated /version request proves TLS version/cipher;
+    * non-verbose authenticated pod API request proves service-account API access
+      without leaking the bearer token into logs.
+
+    CHK is intentionally excluded because the operator does not normally
+    establish a runtime TLS client session to ClickHouse Keeper.
+    """
+    test_ns = ns or current().context.test_namespace
+    operator_ns = current().context.operator_namespace
+    operator_pod = kubectl.get_operator_pod(ns=operator_ns)
+
+    chi_ip = kubectl.get_field(
+        "pod",
+        chi_pod,
+        ".status.podIP",
+        ns=test_ns,
+    )
+
+    approved_cipher = "TLS_AES_256_GCM_SHA384"
+    k8s_auth_url = (
+        "https://kubernetes.default.svc:443"
+        f"/api/v1/namespaces/{operator_ns}/pods/{operator_pod}"
+    )
+
+    for container in ("clickhouse-operator", "metrics-exporter"):
+        with Then(f"{container} negotiates AES-256 TLS 1.3 to Kubernetes API"):
+            tls_out = kubectl.launch(
+                f"exec {operator_pod} -c {container} -- "
+                "sh -c '"
+                "curl -sS -v "
+                "--tlsv1.3 "
+                f"--tls13-ciphers {approved_cipher} "
+                "--cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt "
+                "-o /dev/null "
+                "-w \"HTTP:%{http_code}\" "
+                "https://kubernetes.default.svc:443/version "
+                "2>&1"
+                "'",
+                ns=operator_ns,
+                ok_to_fail=True,
+            )
+
+            assert "TLSv1.3" in tls_out, error(
+                f"{container}: expected TLSv1.3 to Kubernetes API\n{tls_out}"
+            )
+            assert approved_cipher in tls_out, error(
+                f"{container}: expected {approved_cipher} to Kubernetes API\n{tls_out}"
+            )
+            assert "HTTP:200" in tls_out, error(
+                f"{container}: expected Kubernetes /version HTTP 200\n{tls_out}"
+            )
+
+            auth_out = kubectl.launch(
+                f"exec {operator_pod} -c {container} -- "
+                "sh -c '"
+                "IFS= read -r TOKEN < /var/run/secrets/kubernetes.io/serviceaccount/token; "
+                "curl -sS "
+                "--tlsv1.3 "
+                f"--tls13-ciphers {approved_cipher} "
+                "--cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt "
+                "-H \"Authorization: Bearer ${TOKEN}\" "
+                "-o /dev/null "
+                "-w \"HTTP:%{http_code}\" "
+                f"{k8s_auth_url}"
+                "'",
+                ns=operator_ns,
+                ok_to_fail=True,
+            )
+
+            assert "HTTP:200" in auth_out, error(
+                f"{container}: expected authenticated Kubernetes API HTTP 200\n{auth_out}"
+            )
+
+        with And(f"{container} negotiates AES-256 TLS 1.3 to ClickHouse HTTPS"):
+            out = kubectl.launch(
+                f"exec {operator_pod} -c {container} -- "
+                "sh -c '"
+                "curl -sS -k -v "
+                "--tlsv1.3 "
+                f"--tls13-ciphers {approved_cipher} "
+                "-o /dev/null "
+                "-w \"HTTP:%{http_code}\" "
+                f"https://{chi_ip}:8443/ping "
+                "2>&1"
+                "'",
+                ns=operator_ns,
+                ok_to_fail=True,
+            )
+
+            assert "TLSv1.3" in out, error(
+                f"{container}: expected TLSv1.3 to ClickHouse HTTPS\n{out}"
+            )
+            assert approved_cipher in out, error(
+                f"{container}: expected {approved_cipher} to ClickHouse HTTPS\n{out}"
+            )
+            assert "HTTP:200" in out, error(
+                f"{container}: expected ClickHouse /ping HTTP 200\n{out}"
+            )
+
+
+
+@TestStep(Finally)
+def fips_delete_fake_openssl_server(self, ns=None):
+    """Delete fake OpenSSL TLS server pod/service."""
+    ns = ns or current().context.test_namespace
+
+    kubectl.launch(
+        f"delete svc {FAKE_OPENSSL_SERVER} --ignore-not-found",
+        ns=ns,
+        ok_to_fail=True,
+    )
+    kubectl.launch(
+        f"delete pod {FAKE_OPENSSL_SERVER} --ignore-not-found",
+        ns=ns,
+        ok_to_fail=True,
+    )
+
+
+@TestStep(Given)
+def fips_create_fake_openssl_server(self, cipher_suite, ns=None):
+    """Create fake TLS 1.3 server restricted to one cipher suite."""
+    ns = ns or current().context.test_namespace
+
+    fips_delete_fake_openssl_server(ns=ns)
+
+    manifest = f"""
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {FAKE_OPENSSL_SERVER}
+  labels:
+    app: {FAKE_OPENSSL_SERVER}
+spec:
+  restartPolicy: Always
+  containers:
+  - name: openssl
+    image: altinity/clickhouse-server:25.3.8.30001.altinityfips
+    command: ["sh", "-lc"]
+    args:
+    - |
+      openssl s_server \\
+        -accept 18443 \\
+        -cert /tls/server.crt \\
+        -key /tls/server.key \\
+        -tls1_3 \\
+        -ciphersuites {cipher_suite} \\
+        -www \\
+        -state
+    ports:
+    - containerPort: 18443
+    volumeMounts:
+    - name: tls
+      mountPath: /tls
+      readOnly: true
+  volumes:
+  - name: tls
+    secret:
+      secretName: clickhouse-certs
+"""
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix="-fake-openssl-server.yaml",
+            delete=False,
+        ) as f:
+            f.write(manifest)
+            tmp_path = f.name
+
+        kubectl.launch(f"apply -f {shlex.quote(tmp_path)}", ns=ns)
+
+        kubectl.launch(
+            f"expose pod {FAKE_OPENSSL_SERVER} "
+            f"--name={FAKE_OPENSSL_SERVER} "
+            "--port=8443 "
+            "--target-port=18443",
+            ns=ns,
+        )
+
+        kubectl.launch(
+            f"wait pod {FAKE_OPENSSL_SERVER} "
+            "--for=condition=Ready "
+            "--timeout=120s",
+            ns=ns,
+        )
+    finally:
+        if tmp_path:
+            os.unlink(tmp_path)
 
 
 @TestStep(When)
-def fips_run_openssl_s_client_for_clickhouse_https(
+def fips_curl_tls13_from_operator_container(
     self,
-    pod,
+    container,
+    url,
     cipher_suite,
-    ok_to_fail=False,
+    ns=None,
 ):
-    """Run openssl s_client against ClickHouse HTTPS through kubectl port-forward."""
+    """Run curl from one operator pod container with forced TLS 1.3 cipher."""
+    ns = ns or current().context.operator_namespace
+    operator_pod = kubectl.get_operator_pod(ns=ns)
 
-    ns = self.context.test_namespace
-    ca_crt = self.context.tls["ca_crt"]
-
-    # Bind an ephemeral local port so concurrent scenarios never collide on a
-    # fixed forward port (keeps this step parallel-safe). Use the suite-configured
-    # kubectl command rather than a hardcoded "kubectl".
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _probe:
-        _probe.bind(("127.0.0.1", 0))
-        local_port = str(_probe.getsockname()[1])
-
-    pf = subprocess.Popen(
-        self.context.kubectl_cmd.split()
-        + [
-            "-n",
-            ns,
-            "port-forward",
-            f"pod/{pod}",
-            f"{local_port}:8443",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+    return kubectl.launch(
+        f"exec {operator_pod} -c {container} -- "
+        "sh -c '"
+        "curl -k -sS -v "
+        "--tlsv1.3 "
+        f"--tls13-ciphers {cipher_suite} "
+        f"{url} "
+        "-o /dev/null "
+        "-w \"HTTP:%{http_code}\" "
+        "2>&1"
+        "'",
+        ns=ns,
+        ok_to_fail=True,
     )
 
-    try:
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            if pf.poll() is not None:
-                out, err = pf.communicate()
-                assert False, error(
-                    "kubectl port-forward exited early\n"
-                    f"stdout:\n{out}\n"
-                    f"stderr:\n{err}"
-                )
 
-            try:
-                socket.create_connection(
-                    ("127.0.0.1", int(local_port)),
-                    timeout=0.5,
-                ).close()
-                break
-            except OSError:
-                time.sleep(0.2)
-        else:
-            assert False, error(
-                f"kubectl port-forward to {pod}:8443 "
-                f"did not become ready on 127.0.0.1:{local_port}"
+@TestStep(Then)
+def fips_assert_operator_containers_tls13_fails(
+    self,
+    url,
+    cipher_suite,
+    ns=None,
+):
+    """Assert both operator pod containers fail with the requested TLS 1.3 cipher."""
+    ns = ns or current().context.operator_namespace
+
+    failure_needles = (
+        "handshake failure",
+        "no shared cipher",
+        "alert handshake failure",
+        "TLS connect error",
+        "HTTP:000",
+    )
+
+    for container in ("clickhouse-operator", "metrics-exporter"):
+        with Then(f"{container} fails to negotiate {cipher_suite} to {url}"):
+            out = fips_curl_tls13_from_operator_container(
+                container=container,
+                url=url,
+                cipher_suite=cipher_suite,
+                ns=ns,
             )
 
-        result = subprocess.run(
-            [
-                "openssl",
-                "s_client",
-                "-connect",
-                f"127.0.0.1:{local_port}",
-                "-servername",
-                "localhost",
-                "-tls1_3",
-                "-ciphersuites",
-                cipher_suite,
-                "-CAfile",
-                ca_crt,
-                "-verify_return_error",
-            ],
-            input="Q\n",
-            text=True,
-            capture_output=True,
-            check=False,
+            assert any(needle in out for needle in failure_needles), error(
+                f"{container}: expected TLS handshake failure for {cipher_suite}\n{out}"
+            )
+
+
+@TestStep(Then)
+def fips_assert_connection_rejected_on_non_approved_cipher(
+    self,
+    ns=None,
+):
+    """Assert fake ChaCha-only TLS server rejects approved AES-only clients.
+
+    This is the synthetic negative control for rejected cipher behavior.
+    """
+    ns = ns or current().context.test_namespace
+
+    approved_cipher = "TLS_AES_256_GCM_SHA384"
+    rejected_cipher = "TLS_CHACHA20_POLY1305_SHA256"
+    fake_url = f"https://{FAKE_OPENSSL_SERVER}:8443/ping"
+
+    with Given("fake OpenSSL server offers only non-approved ChaCha TLS 1.3 cipher"):
+        fips_create_fake_openssl_server(
+            cipher_suite=rejected_cipher,
+            ns=ns,
         )
 
-        output = f"{result.stdout}\n{result.stderr}"
+    with Then("operator pod containers restricted to approved AES-256 fail the handshake"):
+        fips_assert_operator_containers_tls13_fails(
+            url=fake_url,
+            cipher_suite=approved_cipher,
+            ns=ns,
+        )
 
-        if not ok_to_fail:
-            assert result.returncode == 0, error(
-                f"{pod}: openssl s_client failed for {cipher_suite}\n"
-                f"exit code: {result.returncode}\n"
-                f"output:\n{output}"
-            )
-
-        return output
-
-    finally:
-        pf.terminate()
-        try:
-            pf.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            pf.kill()
+    with Finally("delete fake OpenSSL server"):
+        fips_delete_fake_openssl_server(ns=ns)

--- a/tests/e2e/test_acvp.py
+++ b/tests/e2e/test_acvp.py
@@ -45,8 +45,10 @@ from testflows.asserts import error
 
 from requirements.fips import (
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_ConfigGeneration,
+    RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_SHA2256AFT,
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_WrapperIntegration,
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_ConfigGeneration,
+    RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_SHA2256AFT,
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_WrapperIntegration,
 )
 
@@ -248,6 +250,7 @@ def _acvp_smoke(binary_name, cmd_path):
 @Requirements(
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_WrapperIntegration("1.0"),
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_ConfigGeneration("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_SHA2256AFT("1.0"),
 )
 def test_acvp_operator(self):
     """Build operator with -tags acvp_wrapper and verify the embedded ACVP
@@ -265,6 +268,7 @@ def test_acvp_operator(self):
 @Requirements(
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_WrapperIntegration("1.0"),
     RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_ConfigGeneration("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_SHA2256AFT("1.0"),
 )
 def test_acvp_metrics_exporter(self):
     """Mirror of test_acvp_operator for the metrics-exporter binary. Both

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -6338,9 +6338,7 @@ def test_010065_0(self):
 @TestScenario
 @Tags("HEAVY")
 @Name("test_010065. FIPS IPC Secure mode: operator↔exporter token-protected channel")
-@Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_IPCSecure("1.0")
-)
+@Requirements(RQ_SRS_026_ClickHouseOperator_Create("1.0"))
 def test_010065(self):
     """Verify clickhouse.security.ipc.mode=Secure activates token-based auth
     on the operator↔metrics-exporter /chi REST channel without breaking the

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -7667,12 +7667,11 @@ def test_020016(self):
         delete_test_namespace()
 
 
-
 @TestScenario
 @Tags("HEAVY")
 @Name("test_030001. FIPS build: shipped image binaries embed GOFIPS140=v1.0.0")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Build_ShippedBinaries("1.0")
+    RQ_SRS_026_ClickHouseOperator_FIPS_OperatorBuild_ShippedBinaries("1.0")
 )
 def test_030001(self):
     """Verify FIPS metadata and runtime behavior for shipped image binaries.
@@ -7697,9 +7696,6 @@ def test_030001(self):
 
     gofips_version = "v1.0.0"
     gofips140_needle = f"GOFIPS140={gofips_version}"
-    # --fips-info reports the build-baked release version (ldflags from the
-    # `release` file), NOT the image tag — so compare against release_version,
-    # which holds the release-file value even when OPERATOR_VERSION=dev.
     release_version = self.context.release_version
     godebug_default = "fips140=on"
 
@@ -7735,64 +7731,34 @@ def test_030001(self):
 
 @TestScenario
 @Tags("HEAVY")
-@Name("test_030002. FIPS build: startup banners with strict chopconf and GODEBUG")
+@Name("test_030003. FIPS data plane: TLS-only ClickHouse, Keeper, and backup")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Build_ShippedBinaries_StartupLogs("1.0")
-)
-def test_030002(self):
-    """Verify FIPS startup banners from running operator and exporter binaries."""
-    chopconf = "manifests/chopconf/test-030002-chopconf.yaml"
-
-    fips_create_shell_namespace_clickhouse_template()
-    operator_namespace = self.context.operator_namespace
-
-    with Given("strict FIPS operator configuration is applied"):
-        fips_apply_operator_config(chopconf_path=chopconf)
-
-    with When("operator startup logs are fetched"):
-        operator_pod = kubectl.get_operator_pod(ns=operator_namespace)
-        op_logs = get_container_logs(
-            pod=operator_pod,
-            container="clickhouse-operator",
-            ns=operator_namespace,
-        )
-        me_logs = get_container_logs(
-            pod=operator_pod,
-            container="metrics-exporter",
-            ns=operator_namespace,
-        )
-
-    with Then("both containers report runtime.enforced=true in the FIPS banner"):
-        fips_startup_banner_ok(container="clickhouse-operator", logs=op_logs)
-        fips_startup_banner_ok(container="metrics-exporter", logs=me_logs)
-
-@TestScenario
-@Tags("HEAVY")
-@Name("test_030003. FIPS CHI/CHK: TLS-only ports and replicated CH traffic")
-@Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_Listeners("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHIDeploy("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHKDeploy("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_FIPSConfig("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_FIPSConfig("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_VersionString("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoPlainHTTP("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoPlainNative("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_NoPlainClientPort("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoUnexpectedPorts("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_NoUnexpectedPorts("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_RaftTLS("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_InternodeTLS("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_FIPSBinary("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_GOFIPS140("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_OnlyTLSPorts("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_HTTPSAPI("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_OperatorBuild_ShippedBinaries_StartupLogs("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_HTTPPorts("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CHK_FIPSConfig("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CH_FIPSConfig("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CH_FIPSConfig_ExternalClient("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Backup_FIPSBinary("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Backup_FIPSConfig("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Backup_RestoreRoundTrip("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_TLS_ApprovedCiphers("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_TLS_RejectedCiphers("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_KubernetesAPI("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_KubernetesAPI("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_ClickHouse("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_ClickHouse("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_KeeperRestriction("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Connect_ClickHouse_KeeperTLS("1.0"),
 )
 def test_030003(self):
-    """Verify a FIPS ClickHouse + Keeper deployment runs with TLS-only data paths:
-    FIPS-built ClickHouse, Keeper, and clickhouse-backup binaries; only secure
-    ports exposed; the backup HTTPS API serving over TLS with CA-trust enforcement;
-    and ReplicatedMergeTree data converging over the TLS setup.
+    """Deploy a FIPS ClickHouse + Keeper installation under strict operator config
+    and verify TLS-only data paths:
+
+    - operator, Keeper, ClickHouse, and clickhouse-backup pass FIPS binary and
+      listener-port checks, with only secure ports exposed
+    - ReplicatedMergeTree data converges across replicas over TLS
+    - the backup sidecar reaches ClickHouse over secure native TCP and completes a
+      backup/restore round-trip through the HTTPS API
     """
     chopconf = "manifests/chopconf/test-030002-chopconf.yaml"
     chi_manifest = "manifests/chi/test-030003.yaml"
@@ -7804,10 +7770,15 @@ def test_030003(self):
     chi = yaml_manifest.get_name(util.get_full_path(chi_manifest))
     chk = yaml_manifest.get_name(util.get_full_path(chk_manifest))
 
-    with Given("strict FIPS operator configuration is applied"):
-        util.apply_operator_config(chopconf)
+    chi_replica_count = 2
 
-    with And("test TLS secret is installed"):
+    with Given("strict FIPS operator configuration is applied"):
+        fips_apply_operator_config(chopconf_path=chopconf)
+
+    with Check("operator pod passes essential FIPS checks"):
+        run_operator_fips_checks()
+
+    with When("test TLS secret is installed"):
         create_tls_secret_for_fips_hosts(chi=chi, chk=chk)
 
     with And("external ClickHouse client container is started"):
@@ -7816,84 +7787,66 @@ def test_030003(self):
     with And("FIPS ClickHouse Keeper is deployed with TLS settings"):
         fips_apply_manifest(
             manifest_path=chk_manifest,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chk",
         )
 
     with Then("Keeper cluster passes essential FIPS checks"):
-        fips_assert_replicas_healthy(
-            workload=chk,
-            expected_count=2,
-            kind="chk",
-        )
+        chk_pods = run_chk_fips_checks(workload=chk, replica_count=2)
 
-    with And("FIPS ClickHouse is deployed with TLS settings"):
+    with When("FIPS ClickHouse is deployed with TLS settings"):
         fips_apply_manifest(
             manifest_path=chi_manifest,
-            expected_pod_count=2,
+            replica_count=chi_replica_count,
             kind="chi",
             apply_templates=[backup_template],
         )
 
-    with Then("ClickHouse cluster passes essential FIPS checks"):
-        chi_pods = fips_assert_replicas_healthy(
+    with Check("operator outbound connections to CHI and CHK after reconcile"):
+        run_operator_reconcile_fips_checks()
+
+    with Check("metrics-exporter discovers ClickHouse using HTTPS"):
+        check_metrics_exporter_discovers_clickhouse_https()
+
+    with Check("ClickHouse replicas connect to Keeper using secure client port"):
+        check_clickhouse_uses_secure_keeper_port(chi=chi)
+
+    with Then("check ClickHouse cluster passes essential FIPS checks"):
+        chi_pods = run_chi_fips_checks(
             workload=chi,
-            expected_count=2,
-            kind="chi",
+            replica_count=chi_replica_count,
         )
 
-    chi_pod0 = chi_pods[0]
+    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+        backup_pods = run_backup_fips_checks(
+            workload=chi,
+            replica_count=chi_replica_count,
+        )
 
-    with And("each clickhouse-backup sidecar uses a FIPS-built binary"):
-        for pod in chi_pods:
-            version = get_binary_version(
-                pod=pod,
-                binary="/bin/clickhouse-backup",
-                container="clickhouse-backup",
-            )
-            note(f"{pod} clickhouse-backup --version: {version}")
-            assert "fips" in version.lower(), error(
-                f"{pod}: expected fips in clickhouse-backup version, got {version!r}"
-            )
-
-    with And("each clickhouse-backup sidecar embeds GOFIPS metadata"):
-        check_clickhouse_backup_embeds_gofips(pods=chi_pods)
-
-    with And("clickhouse-backup sidecar exposes only its TLS API port"):
-        for pod in chi_pods:
-            fips_assert_only_tls_ports(
-                pod=pod,
-                required={8443, 9010, 9440, 7171},
-                container="clickhouse-backup",
-            )
-
-    with And("clickhouse-backup HTTPS API serves over TLS with the FIPS cert"):
-        check_clickhouse_backup_https_api_serves_tls(pods=chi_pods)
-
-    with And("clickhouse-backup HTTPS API rejects untrusted clients"):
-        check_clickhouse_backup_https_api_rejects_untrusted(pods=chi_pods)
-
-    with And("external ClickHouse client reports a FIPS server version"):
-        check_external_clickhouse_reports_fips_version(pod=chi_pod0)
-
-    with And("operator-generated ClickHouse config removes plaintext ports"):
-        settings_xml = fips_read_chop_generated_settings(pod=chi_pod0)
-        note(f"chop-generated-settings.xml:\n{settings_xml}")
-        check_ports_in_chi_settings(settings_xml=settings_xml)
-
-    with Then("ReplicatedMergeTree data converges over the TLS setup"):
+    with Check("ReplicatedMergeTree data converges over the TLS setup"):
         fips_check_replication_across_replicas(chi_pods=chi_pods)
 
-    with Finally("external ClickHouse client container is removed"):
-        stop_external_ch_container()
+    with Check("backup and restore succeeds through HTTPS API"):
+        check_clickhouse_backup_restore_roundtrip_https(pod=backup_pods[0])
 
+    with Check("approved AES-256 TLS 1.3 cipher is negotiated"):
+        fips_assert_aes256_tls13_probes(
+            chi_pods=chi_pods,
+            chk_pods=chk_pods,
+        )
+
+    with Check("rejected TLS protocol and cipher combinations are not negotiated"):
+        fips_assert_rejected_tls_probes(
+            chi_pods=chi_pods,
+            chk_pods=chk_pods
+        )
 
 @TestScenario
 @Tags("HEAVY")
 @Name("test_030004. FIPS CHI: scale replicas 2 -> 3 -> 1")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ScaleUp("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ScaleDown("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CH_Rescale("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CH_ConfigUpdate("1.0"),
 )
 def test_030004(self):
     """Verify FIPS ClickHouse survives replica scale-up and scale-down.
@@ -7924,7 +7877,7 @@ def test_030004(self):
     with And("FIPS ClickHouse Keeper is deployed with TLS settings"):
         fips_apply_manifest(
             manifest_path=chk_manifest,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chk",
         )
 
@@ -7936,16 +7889,21 @@ def test_030004(self):
         )
         fips_apply_manifest(
             manifest_path=chi_manifest_2,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chi",
             apply_templates=[backup_template],
         )
 
     with Then("2-replica cluster passes essential FIPS checks"):
-        chi_pods = fips_assert_replicas_healthy(
+        chi_pods = run_chi_fips_checks(
             workload=chi,
-            expected_count=2,
-            kind="chi",
+            replica_count=2,
+        )
+
+    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+        run_backup_fips_checks(
+            workload=chi,
+            replica_count=2,
         )
 
     with And("ReplicatedMergeTree data converges across 2 replicas"):
@@ -7959,15 +7917,20 @@ def test_030004(self):
         )
         fips_apply_manifest(
             manifest_path=chi_manifest_3,
-            expected_pod_count=3,
+            replica_count=3,
             kind="chi",
         )
 
     with Then("3-replica cluster passes essential FIPS checks"):
-        chi_pods = fips_assert_replicas_healthy(
+        chi_pods = run_chi_fips_checks(
             workload=chi,
-            expected_count=3,
-            kind="chi",
+            replica_count=3,
+        )
+
+    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+        run_backup_fips_checks(
+            workload=chi,
+            replica_count=3,
         )
 
     with And("ReplicatedMergeTree data converges across 3 replicas"):
@@ -7984,27 +7947,53 @@ def test_030004(self):
         )
         fips_apply_manifest(
             manifest_path=chi_manifest_1,
-            expected_pod_count=1,
+            replica_count=1,
             kind="chi",
         )
 
     with Then("single-replica cluster passes essential FIPS checks"):
-        fips_assert_replicas_healthy(
+        run_chi_fips_checks(
             workload=chi,
-            expected_count=1,
+            replica_count=1,
+        )
+
+    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+        run_backup_fips_checks(
+            workload=chi,
+            replica_count=1,
+        )
+
+    with When("CHI OpenSSL cipher suites are updated"):
+        chi_manifest_update = fips_edit_manifest(
+            source_manifest=chi_manifest,
+            replicas_count=1,
+            cipher_suites=["TLS_AES_128_GCM_SHA256"],
             kind="chi",
         )
 
-    with Finally("external ClickHouse client container is removed"):
-        stop_external_ch_container()
+        fips_apply_manifest(
+            manifest_path=chi_manifest_update,
+            replica_count=1,
+            kind="chi",
+            apply_templates=[backup_template],
+        )
+
+    with Then("removed ClickHouse cipher is no longer negotiated"):
+        chi_pods = sorted(kubectl.get_pod_names(chi))
+
+        check_tls13_cipher_fails(
+            pod=chi_pods[0],
+            port=9440,
+            cipher="TLS_AES_256_GCM_SHA384",
+        )
 
 
 @TestScenario
 @Tags("HEAVY")
 @Name("test_030005. FIPS CHK: scale replicas 2 -> 3 -> 1")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ScaleUp("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ScaleDown("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CHK_Rescale("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CHK_ConfigUpdate("1.0"),
 )
 def test_030005(self):
     """Verify FIPS ClickHouse Keeper survives replica scale-up and scale-down.
@@ -8040,15 +8029,14 @@ def test_030005(self):
         )
         fips_apply_manifest(
             manifest_path=chk_manifest_2,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chk",
         )
 
     with Then("2-replica Keeper cluster passes essential FIPS checks"):
-        fips_assert_replicas_healthy(
+        run_chk_fips_checks(
             workload=chk,
-            expected_count=2,
-            kind="chk",
+            replica_count=2,
         )
 
     with And("FIPS ClickHouse is deployed with 2 replicas"):
@@ -8059,16 +8047,21 @@ def test_030005(self):
         )
         fips_apply_manifest(
             manifest_path=chi_manifest_2,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chi",
             apply_templates=[backup_template],
         )
 
     with And("2-replica ClickHouse cluster passes essential FIPS checks"):
-        chi_pods = fips_assert_replicas_healthy(
+        chi_pods = run_chi_fips_checks(
             workload=chi,
-            expected_count=2,
-            kind="chi",
+            replica_count=2,
+        )
+
+    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+        run_backup_fips_checks(
+            workload=chi,
+            replica_count=2,
         )
 
     with And("ReplicatedMergeTree data converges across 2 ClickHouse replicas"):
@@ -8082,22 +8075,26 @@ def test_030005(self):
         )
         fips_apply_manifest(
             manifest_path=chk_manifest_3,
-            expected_pod_count=3,
+            replica_count=3,
             kind="chk",
         )
 
     with Then("3-replica Keeper cluster passes essential FIPS checks"):
-        fips_assert_replicas_healthy(
+        run_chk_fips_checks(
             workload=chk,
-            expected_count=3,
-            kind="chk",
+            replica_count=3,
         )
 
     with And("ClickHouse remains healthy after Keeper upscale"):
-        chi_pods = fips_assert_replicas_healthy(
+        chi_pods = run_chi_fips_checks(
             workload=chi,
-            expected_count=2,
-            kind="chi",
+            replica_count=2,
+        )
+
+    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+        run_backup_fips_checks(
+            workload=chi,
+            replica_count=2,
         )
 
     with And("ReplicatedMergeTree data still converges after Keeper upscale"):
@@ -8114,22 +8111,26 @@ def test_030005(self):
         )
         fips_apply_manifest(
             manifest_path=chk_manifest_1,
-            expected_pod_count=1,
+            replica_count=1,
             kind="chk",
         )
 
     with Then("single-replica Keeper cluster passes essential FIPS checks"):
-        fips_assert_replicas_healthy(
+        run_chk_fips_checks(
             workload=chk,
-            expected_count=1,
-            kind="chk",
+            replica_count=1,
         )
 
     with And("ClickHouse remains healthy after Keeper downscale"):
-        chi_pods = fips_assert_replicas_healthy(
+        chi_pods = run_chi_fips_checks(
             workload=chi,
-            expected_count=2,
-            kind="chi",
+            replica_count=2,
+        )
+
+    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+        run_backup_fips_checks(
+            workload=chi,
+            replica_count=2,
         )
 
     with And("ReplicatedMergeTree data still converges after Keeper downscale"):
@@ -8138,18 +8139,42 @@ def test_030005(self):
             table="repl_chk_scale_test_1",
         )
 
-    with Finally("external ClickHouse client container is removed"):
-        stop_external_ch_container()
+    with When("CHK OpenSSL cipher suites are updated"):
+        chk_manifest_update = fips_edit_manifest(
+            source_manifest=chk_manifest,
+            replicas_count=1,
+            cipher_suites=["TLS_AES_128_GCM_SHA256"],
+            kind="chk",
+        )
 
+        fips_apply_manifest(
+            manifest_path=chk_manifest_update,
+            replica_count=1,
+            kind="chk",
+        )
+
+    with Then("removed Keeper cipher is no longer negotiated"):
+        chi_pods = sorted(kubectl.get_pod_names(chi))
+        chk_pods = kubectl.get_chk_pod_names(chk)
+
+        chk_ip = kubectl.launch(
+            f"get pod {chk_pods[0]} "
+            "-o jsonpath='{.status.podIP}'",
+            ns=self.context.test_namespace,
+        )
+
+        check_tls13_cipher_fails(
+            pod=chi_pods[0],
+            target_host=chk_ip,
+            port=2281,
+            cipher="TLS_AES_256_GCM_SHA384",
+        )
 
 @TestScenario
 @Tags("HEAVY")
 @Name("test_030006. FIPS enforced: coerces verify, minVersion, and IPC")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceVerifyStrict("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceMinVersion13("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_OverrideMinVersion12To13("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceIPCSecure("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_SecurityCoercion("1.0"),
 )
 def test_030006(self):
     """Verify ``fips.enforced=true`` coerces relaxed chopconf TLS verify, minVersion, and IPC."""
@@ -8179,15 +8204,12 @@ def test_030006(self):
 @Tags("HEAVY")
 @Name("test_030007. FIPS enforced: invalid CHI/CHK specs are rejected")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectVerifyNoneCHI("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectVerifyNoneZK("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectInvalidMinVersion("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectExternalZookeeper("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectCHKBypass("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectNonCompliantSpecs("1.0"),
 )
 def test_030007(self):
-    """Verify strict FIPS mode rejects non-compliant CHI and CHK specifications."""
+    """Verify strict FIPS mode rejects non-compliant CHI and CHK specs."""
     chopconf = "manifests/chopconf/test-030002-chopconf.yaml"
+
     chi_zk_rejected = "manifests/chi/test-073-fips-zk-rejected.yaml"
     chi_zk_rejected_explicit_false = (
         "manifests/chi/test-073-fips-zk-rejected-explicit-false.yaml"
@@ -8299,24 +8321,18 @@ def test_030007(self):
         )
 
 
+
 @TestScenario
 @Tags("HEAVY")
-@Name("test_030008. FIPS image policy Required: admission and runtime checks")
+@Name("test_030008. FIPS image policy: Required admission/runtime checks and Permissive default")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectCHI("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_AcceptCHI("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectCHK("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RuntimeVersion("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_ShortCircuit("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_AltinityFIPS("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_FIPSSuffix("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_CaseInsensitive("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_DigestOnly("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_RegistryPath("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectNonFIPS("1.0"),
 )
 def test_030008(self):
     """Verify ``security.images.policy=FIPSRequired`` rejects non-fips images
-    and accepts images whose tags contain ``fips`` (case-insensitive).
+    and accepts images whose tags contain ``fips`` (case-insensitive), then
+    switch to ``security.images.policy=Permissive`` and confirm a non-fips
+    image is admitted (the default posture).
     """
     chopconf = "manifests/chopconf/test-074-fips-images-required-chopconf.yaml"
     chi_non_fips_manifest = (
@@ -8344,6 +8360,19 @@ def test_030008(self):
     chi_case_insensitive_manifest = (
         "manifests/chi/test-030008-case-insensitive.yaml"
     )
+    chi_permissive_chopconf = (
+        "manifests/chopconf/test-030008-permissive-chopconf.yaml"
+    )
+    chi_permissive_manifest = (
+        "manifests/chi/test-030008-permissive-non-fips.yaml"
+    )
+    backup_non_fips_template = (
+        "manifests/chit/test-030008-backup-non-fips-template.yaml"
+    )
+    chi_backup_non_fips_manifest = (
+        "manifests/chi/test-030003.yaml"
+    )
+
 
     fips_create_shell_namespace_clickhouse_template()
 
@@ -8372,6 +8401,12 @@ def test_030008(self):
     chi_case_insensitive = yaml_manifest.get_name(
         util.get_full_path(chi_case_insensitive_manifest)
     )
+    chi_permissive = yaml_manifest.get_name(
+        util.get_full_path(chi_permissive_manifest)
+    )
+    chi_backup_non_fips = yaml_manifest.get_name(
+        util.get_full_path(chi_backup_non_fips_manifest)
+    )
 
     with Given("FIPS image policy Required is applied"):
         fips_apply_operator_config(chopconf_path=chopconf)
@@ -8395,6 +8430,14 @@ def test_030008(self):
             chk=chk_non_fips,
             reason="FIPSImagePolicyViolation",
             expect_no_sts=True,
+        )
+
+    with And("aborted non-fips CHK is deleted before switching image policy"):
+        kubectl.launch(
+            f"delete chk {chk_non_fips}",
+            ns=self.context.test_namespace,
+            timeout=600,
+            ok_to_fail=True,
         )
 
     with When("CHI with two non-fips replicas is applied"):
@@ -8436,7 +8479,7 @@ def test_030008(self):
     with When("CHI with altinityfips-tagged image is applied"):
         fips_apply_manifest(
             manifest_path=chi_fips_manifest,
-            expected_pod_count=1,
+            replica_count=1,
             kind="chi",
         )
 
@@ -8449,14 +8492,20 @@ def test_030008(self):
     with When("CHI with fips-suffix tag is applied"):
         fips_apply_manifest_raw(manifest_path=chi_fips_suffix_manifest)
 
-    with Then("CHI is admitted because tag contains fips"):
+    with Then("CHI passes image-policy admission because tag contains fips"):
         fips_assert_chi_admitted(chi=chi_fips_suffix)
+
+    with And("fips-suffix CHI is deleted after admission-only check"):
+        fips_cleanup_admission_only_chi(chi=chi_fips_suffix)
 
     with When("CHI with uppercase FIPS tag is applied"):
         fips_apply_manifest_raw(manifest_path=chi_case_insensitive_manifest)
 
-    with Then("CHI is admitted because tag detection is case-insensitive"):
+    with Then("CHI passes image-policy admission because tag detection is case-insensitive"):
         fips_assert_chi_admitted(chi=chi_case_insensitive)
+
+    with And("case-insensitive CHI is deleted after admission-only check"):
+        fips_cleanup_admission_only_chi(chi=chi_case_insensitive)
 
     with When("runtime decoy image alias is prepared"):
         decoy_tag = "altinity/clickhouse-server:25.8.16.10002.altinityfips-decoy"
@@ -8467,10 +8516,6 @@ def test_030008(self):
             text=True,
             check=False,
         )
-        # The kubelet uses minikube's own image store, not the host docker
-        # daemon where `docker tag` created the alias — load it in, otherwise the
-        # decoy pod is ImagePullBackOff (the synthetic tag exists on no registry)
-        # and never starts, so the runtime SELECT version() check never runs.
         load_result = None
         if tag_result.returncode == 0:
             load_result = subprocess.run(
@@ -8500,11 +8545,28 @@ def test_030008(self):
                     f"expected runtime FIPSImagePolicyViolation, got {errors}"
                 )
 
+    with When("operator image policy is switched to Permissive"):
+        kubectl.launch(
+            "delete chopconf test-074-fips-images-required-chopconf",
+            ns=self.context.operator_namespace,
+            timeout=600,
+            ok_to_fail=True,
+        )
+
+        fips_apply_operator_config(chopconf_path=chi_permissive_chopconf)
+
+    with And("a non-fips CHI is applied under Permissive policy"):
+        fips_apply_manifest_raw(manifest_path=chi_permissive_manifest)
+
+    with Then("non-fips CHI is admitted without FIPSImagePolicyViolation"):
+        fips_assert_chi_admitted(chi=chi_permissive)
+
+
 @TestScenario
 @Tags("HEAVY")
 @Name("test_030009. FIPS enforced: operator TLS clients reject servers without TLS 1.3")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceMinVersion13("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_SecurityCoercion("1.0"),
     RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_MinVersionScope("1.0"),
 )
 def test_030009(self):
@@ -8535,15 +8597,14 @@ def test_030009(self):
     with And("normal CHK is applied"):
         fips_apply_manifest(
             manifest_path=chk_manifest,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chk",
         )
 
     with Then("normal CHK becomes healthy"):
-        fips_assert_replicas_healthy(
+        run_chk_fips_checks(
             workload=chk,
-            expected_count=2,
-            kind="chk",
+            replica_count=2,
         )
 
     with When("CHI server disables TLS 1.3"):
@@ -8572,61 +8633,20 @@ def test_030009(self):
             min_version="1.3",
         )
 
-
 @TestScenario
 @Tags("HEAVY")
-@Name("test_030010. FIPS on-wire TLS verification: Strict + wrong rootCA fails ClickHouse fetch")
-def test_030010(self):
-    """Strict verify with a wrong rootCA must fail operator ClickHouse fetch."""
-    tls_secret = "manifests/secret/test-058-secret.yaml"
-    chi_manifest = "manifests/chi/test-077-fips-tls-wrong-ca.yaml"
-    chopconf = "manifests/chopconf/test-077-fips-tls-wrong-ca-chopconf.yaml"
-
-    fips_create_shell_namespace_clickhouse_template()
-
-    operator_namespace = self.context.operator_namespace
-    chi = yaml_manifest.get_name(util.get_full_path(chi_manifest))
-
-    with Given("test-058 TLS secret is installed"):
-        kubectl.apply(util.get_full_path(tls_secret))
-
-    with When("HTTPS ClickHouse CHI is deployed"):
-        fips_apply_manifest(
-            manifest_path=chi_manifest,
-            expected_pod_count=1,
-            kind="chi",
-            apply_templates=[current().context.clickhouse_template],
-        )
-
-    with And("operator chopconf sets verify=Strict with an unrelated rootCA"):
-        fips_apply_operator_config(chopconf_path=chopconf)
-        kubectl.wait_chi_status(chi, "Completed")
-
-    with Then("chi_clickhouse_metric_fetch_errors is 1 for this CHI"):
-        check_metrics_monitoring(
-            operator_namespace=operator_namespace,
-            operator_pod=kubectl.get_operator_pod(ns=operator_namespace),
-            expect_pattern=(
-                f'^chi_clickhouse_metric_fetch_errors{{[^}}]*chi="{chi}"[^}}]*}} 1$'
-            ),
-        )
-
-    with When("operator configuration is reset to default"):
-        kubectl.delete(
-            util.get_full_path(chopconf, lookup_in_host=False),
-            operator_namespace,
-        )
-        util.restart_operator()
-
-@TestScenario
-@Tags("HEAVY")
-@Name("test_030012. FIPS backup: ClickHouse over TLS and HTTPS restore round-trip")
+@Name("test_030010. FIPS synthetic TLS cipher validation: K8s API and CHI HTTPS")
 @Requirements(
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_ClickHouseOverTLS("1.0"),
-    RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_RestoreRoundTrip("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_TLS_ApprovedCiphers("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_TLS_RejectedCiphers("1.0"),
 )
-def test_030012(self):
-    """Verify clickhouse-backup uses TLS to ClickHouse and restore works via HTTPS API."""
+def test_030010(self):
+    """Supplementary synthetic AES-256 TLS 1.3 cipher smoke.
+
+    This scenario proves that both containers in the operator pod can negotiate
+    TLS 1.3 with TLS_AES_256_GCM_SHA384 against real Kubernetes API and real
+    ClickHouse HTTPS endpoints.
+    """
 
     chopconf = "manifests/chopconf/test-030002-chopconf.yaml"
     chi_manifest = "manifests/chi/test-030003.yaml"
@@ -8639,47 +8659,98 @@ def test_030012(self):
     chk = yaml_manifest.get_name(util.get_full_path(chk_manifest))
 
     with Given("strict FIPS operator configuration is applied"):
-        util.apply_operator_config(chopconf)
+        fips_apply_operator_config(chopconf_path=chopconf)
 
     with And("test TLS secret is installed"):
         create_tls_secret_for_fips_hosts(chi=chi, chk=chk)
 
-    with And("external ClickHouse client container is started"):
-        start_external_ch_container()
-
-    with And("FIPS Keeper is deployed"):
+    with And("FIPS ClickHouse Keeper is deployed as CHI dependency"):
         fips_apply_manifest(
             manifest_path=chk_manifest,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chk",
         )
 
-    with And("FIPS ClickHouse with backup sidecar is deployed"):
+    with When("FIPS ClickHouse is deployed with TLS settings"):
         fips_apply_manifest(
             manifest_path=chi_manifest,
-            expected_pod_count=2,
+            replica_count=2,
             kind="chi",
             apply_templates=[backup_template],
         )
 
-    with Given("FIPS ClickHouse cluster is healthy"):
-        chi_pods = fips_assert_replicas_healthy(
-            workload=chi,
-            expected_count=2,
-            kind="chi",
+    with Then("ClickHouse cluster pods are ready"):
+        kubectl.wait_chi_status(chi, "Completed")
+        kubectl.wait_objects(
+            chi,
+            {
+                "statefulset": 2,
+                "pod": 2,
+                "service": 3,
+            },
+        )
+        chi_pods = sorted(kubectl.get_pod_names(chi))
+
+    with Then("operator pod containers negotiate AES-256 TLS 1.3 to K8s and CHI"):
+        check_synthetic_tls13_smoke_from_operator_pod(
+            chi_pod=chi_pods[0],
         )
 
-        pod = chi_pods[0]
+    with Then("operator pod containers reject fake openSSL server with non approved cipher"):
+        fips_assert_connection_rejected_on_non_approved_cipher()
 
-    with Then("backup sidecar reaches ClickHouse through secure native TCP"):
-        check_clickhouse_backup_clickhouse_tls_config(pod=pod)
-        check_clickhouse_backup_can_list_tables_over_clickhouse_tls(pod=pod)
 
-    with Then("backup and restore succeeds through HTTPS API"):
-        check_clickhouse_backup_restore_roundtrip_https(pod=pod)
+@TestScenario
+@Name("test_030011. FIPS Integrity check: detect binary tampering")
+@Requirements(
+    RQ_SRS_026_ClickHouseOperator_FIPS_Integrity_VerificationMismatch("1.0")
+)
+def test_030011(self):
+    """Verify that corrupting the embedded FIPS HMAC causes binaries to panic at startup.
 
-    with Finally("external ClickHouse client container is removed"):
-        stop_external_ch_container()
+    Procedure:
+    1. Extract FIPS binaries from release images.
+    2. Locate the '.go.fipsinfo' ELF section.
+    3. Flip bits in the HMAC header.
+    4. Verify the binary panics with 'fips140: verification mismatch'.
+    """
+    with Given("operator and metrics-exporter binaries are extracted"):
+        fips_extract_shipped_binaries()
+
+    with Then("clickhouse-operator detects tampering"):
+        check_fips_integrity_failure(
+            binary_path=self.context.fips_op_bin,
+            binary_label="clickhouse-operator"
+        )
+
+    with And("metrics-exporter detects tampering"):
+        check_fips_integrity_failure(
+            binary_path=self.context.fips_me_bin,
+            binary_label="metrics-exporter"
+        )
+
+@TestScenario
+@Name("test_030015. FIPS CAST failure: operator and exporter binaries")
+@Requirements(
+    RQ_SRS_026_ClickHouseOperator_FIPS_CAST_OperatorFail("1.0"),
+    RQ_SRS_026_ClickHouseOperator_FIPS_CAST_ExporterFail("1.0"),
+)
+def test_030015(self):
+    """Verify forced FIPS CAST failure terminates each shipped binary independently."""
+    fips_extract_shipped_binaries()
+
+    with Then("clickhouse-operator terminates with CAST failure"):
+        check_fips_cast_failure(
+            binary_path=self.context.fips_op_bin,
+            binary="clickhouse-operator",
+        )
+
+    with Then("metrics-exporter terminates with CAST failure"):
+        check_fips_cast_failure(
+            binary_path=self.context.fips_me_bin,
+            binary="metrics-exporter",
+        )
+
 
 def cleanup_chis(self):
     with Given("Cleanup CHIs"):

--- a/tests/requirements/fips.md
+++ b/tests/requirements/fips.md
@@ -7,153 +7,74 @@
 
 **Author:** Saba Momtselidze
 
-**Date:** May 29, 2026
+**Date:** June 12, 2026
 
 ## Table of Contents
 
 * 1 [Introduction](#introduction)
 * 2 [Configuration Requirements](#configuration-requirements)
-    * 2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Config.ExternalTLS](#rqsrs-026clickhouseoperatorfipsconfigexternaltls)
+    * 2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.HTTPPorts](#rqsrs-026clickhouseoperatorfipshttpports)
 * 3 [Build Verification](#build-verification)
-    * 3.1 [Shipped Binaries](#shipped-binaries)
-        * 3.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries](#rqsrs026clickhouseoperatorfipsbuildshippedbinaries)
-            * 3.1.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.GOFIPS140](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesgofips140)
-            * 3.1.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.FIPSIdentity](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesfipsidentity)
-            * 3.1.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.FIPSVersion](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesfipsversion)
-            * 3.1.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.FIPSEnabled](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesfipsenabled)
-            * 3.1.1.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.StartupBanner](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesstartupbanner)
-* 4 [GODEBUG Strict Mode Smoke Test](#godebug-strict-mode-smoke-test)
-    * 4.1 [RQ.SRS-026.ClickHouseOperator.FIPS.GODEBUG.StrictMode](#rqsrs-026clickhouseoperatorfipsgodebugstrictmode)
-* 5 [FIPS 140-3 Valid TLS Cipher Suites](#fips-140-3-valid-tls-cipher-suites)
-    * 5.1 [Approved TLS Cipher Suites](#approved-tls-cipher-suites)
-        * 5.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
-    * 5.2 [Rejected Cipher Suites and Protocols](#rejected-cipher-suites-and-protocols)
-        * 5.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.RejectedCiphers](#rqsrs-026clickhouseoperatorfipstlsrejectedciphers)
-* 6 [ClickHouse Server and Keeper FIPS Configurations](#clickhouse-server-and-keeper-fips-configurations)
-    * 6.1 [ClickHouse Server](#clickhouse-server)
-        * 6.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.FIPSConfig](#rqsrs026clickhouseoperatorfipsdataplanechfipsconfig)
-        * 6.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHIDeploy](#rqsrs026clickhouseoperatorfipsdataplanechideploy)
-        * 6.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainHTTP](#rqsrs026clickhouseoperatorfipsdataplanechnoplainhttp)
-        * 6.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainNative](#rqsrs026clickhouseoperatorfipsdataplanechnoplainnative)
-        * 6.1.5 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoUnexpectedPorts](#rqsrs026clickhouseoperatorfipsdataplanechnounexpectedports)
-        * 6.1.6 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.InternodeTLS](#rqsrs026clickhouseoperatorfipsdataplanechinternodetls)
-        * 6.1.7 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleUp](#rqsrs026clickhouseoperatorfipsdataplanechscaleup)
-        * 6.1.8 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleDown](#rqsrs026clickhouseoperatorfipsdataplanechscaledown)
-        * 6.1.9 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ConfigUpdate](#rqsrs026clickhouseoperatorfipsdataplanechconfigupdate)
-    * 6.2 [ClickHouse Keeper](#clickhouse-keeper)
-        * 6.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.FIPSConfig](#rqsrs026clickhouseoperatorfipsdataplanechkfipsconfig)
-        * 6.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHKDeploy](#rqsrs026clickhouseoperatorfipsdataplanechkdeploy)
-        * 6.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoPlainClientPort](#rqsrs026clickhouseoperatorfipsdataplanechknoplainclientport)
-        * 6.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoUnexpectedPorts](#rqsrs026clickhouseoperatorfipsdataplanechknounexpectedports)
-        * 6.2.5 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.RaftTLS](#rqsrs026clickhouseoperatorfipsdataplanechkrafttls)
-        * 6.2.6 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleUp](#rqsrs026clickhouseoperatorfipsdataplanechkscaleup)
-        * 6.2.7 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleDown](#rqsrs026clickhouseoperatorfipsdataplanechkscaledown)
-        * 6.2.8 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ConfigUpdate](#rqsrs026clickhouseoperatorfipsdataplanechkconfigupdate)
-    * 6.3 [ClickHouse Backup Sidecar](#clickhouse-backup-sidecar)
-        * 6.3.0 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.VersionString](#rqsrs026clickhouseoperatorfipsdataplanechversionstring)
-        * 6.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.FIPSBinary](#rqsrs026clickhouseoperatorfipsdataplanebackupfipsbinary)
-        * 6.3.2 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.GOFIPS140](#rqsrs026clickhouseoperatorfipsdataplanebackupgofips140)
-        * 6.3.3 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.OnlyTLSPorts](#rqsrs026clickhouseoperatorfipsdataplanebackuponlytlsports)
-        * 6.3.4 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.HTTPSAPI](#rqsrs026clickhouseoperatorfipsdataplanebackuphttpsapi)
-        * 6.3.5 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.ClickHouseOverTLS](#rqsrs026clickhouseoperatorfipsdataplanebackupclickhouseovertls)
-        * 6.3.6 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RestoreRoundTrip](#rqsrs026clickhouseoperatorfipsdataplanebackuprestoreroundtrip)
-        * 6.3.7 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RemoteUploadTLS](#rqsrs026clickhouseoperatorfipsdataplanebackupremoteuploadtls)
-* 7 [FIPS Enforcement Mode](#fips-enforcement-mode)
-    * 7.1 [Security Coercion](#security-coercion)
-        * 7.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceVerifyStrict](#rqsrs026clickhouseoperatorfipsenforcedcoerceverifystrict)
-        * 7.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceMinVersion13](#rqsrs026clickhouseoperatorfipsenforcedcoerceminversion13)
-        * 7.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.OverrideMinVersion12To13](#rqsrs-026clickhouseoperatorfipsenforcedoverrideminversion12to13)
-        * 7.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceIPCSecure](#rqsrs026clickhouseoperatorfipsenforcedcoerceipcsecure)
-        * 7.1.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInsecureKubeconfig](#rqsrs026clickhouseoperatorfipsenforcedrejectinsecurekubeconfig)
-        * 7.1.6 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneCHI](#rqsrs026clickhouseoperatorfipsenforcedrejectverifynonechi)
-        * 7.1.7 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneZK](#rqsrs026clickhouseoperatorfipsenforcedrejectverifynonezk)
-        * 7.1.8 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInvalidMinVersion](#rqsrs026clickhouseoperatorfipsenforcedrejectinvalidminversion)
-        * 7.1.9 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectExternalZookeeper](#rqsrs026clickhouseoperatorfipsenforcedrejectexternalzookeeper)
-        * 7.1.10 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectCHKBypass](#rqsrs026clickhouseoperatorfipsenforcedrejectchkbypass)
-    * 7.2 [Image Policy](#image-policy)
-        * 7.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHI](#rqsrs026clickhouseoperatorfipsimagesrequiredrejectchi)
-        * 7.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.AcceptCHI](#rqsrs026clickhouseoperatorfipsimagesrequiredacceptchi)
-        * 7.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHK](#rqsrs026clickhouseoperatorfipsimagesrequiredrejectchk)
-        * 7.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RuntimeVersion](#rqsrs026clickhouseoperatorfipsimagesrequiredruntimeversion)
-        * 7.2.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Permissive](#rqsrs026clickhouseoperatorfipsimagespermissive)
-        * 7.2.6 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.ShortCircuit](#rqsrs026clickhouseoperatorfipsimagesrequiredshortcircuit)
-    * 7.3 [Image Tag Detection](#image-tag-detection)
-        * 7.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.FIPSSuffix](#rqsrs026clickhouseoperatorfipsimagestagdetectionfipssuffix)
-        * 7.3.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.AltinityFIPS](#rqsrs026clickhouseoperatorfipsimagestagdetectionaltinityfips)
-        * 7.3.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.DigestOnly](#rqsrs026clickhouseoperatorfipsimagestagdetectiondigestonly)
-        * 7.3.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.RegistryPath](#rqsrs026clickhouseoperatorfipsimagestagdetectionregistrypath)
-        * 7.3.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.CaseInsensitive](#rqsrs026clickhouseoperatorfipsimagestagdetectioncaseinsensitive)
-* 8 [Operator External Connections](#operator-external-connections)
-    * 8.1 [Operator Runtime Listener Verification](#operator-runtime-listener-verification)
-        * 8.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Listeners](#rqsrs026clickhouseoperatorfipsconnectoperatorlisteners)
-    * 8.2 [Operator to Kubernetes API](#operator-to-kubernetes-api)
-        * 8.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Kubernetes](#rqsrs026clickhouseoperatorfipsconnectoperatorkubernetes)
-    * 8.3 [Operator to ClickHouse Server](#operator-to-clickhouse-server)
-        * 8.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse](#rqsrs026clickhouseoperatorfipsconnectoperatorclickhouse)
-    * 8.4 [Operator to ZooKeeper/Keeper](#operator-to-zookeeperkeeper)
-        * 8.4.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Zookeeper](#rqsrs026clickhouseoperatorfipsconnectoperatorzookeeper)
-    * 8.5 [Operator to metrics-exporter IPC](#operator-to-metrics-exporter-ipc)
-        * 8.5.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.IPCSecure](#rqsrs026clickhouseoperatorfipsconnectoperatoripcsecure)
-    * 8.6 [Operator Prometheus Metrics](#operator-prometheus-metrics)
-        * 8.6.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Gap.OperatorMetricsTLS](#rqsrs026clickhouseoperatorfipsgapoperatormetricstls)
-* 9 [Exporter External Connections](#exporter-external-connections)
-    * 9.1 [Exporter Runtime Listener Verification](#exporter-runtime-listener-verification)
-        * 9.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Listeners](#rqsrs026clickhouseoperatorfipsconnectexporterlisteners)
-    * 9.2 [Exporter to Kubernetes API](#exporter-to-kubernetes-api)
-        * 9.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Kubernetes](#rqsrs026clickhouseoperatorfipsconnectexporterkubernetes)
-    * 9.3 [Exporter to ClickHouse Server](#exporter-to-clickhouse-server)
-        * 9.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse](#rqsrs026clickhouseoperatorfipsconnectexporterclickhouse)
-    * 9.4 [Exporter Prometheus Metrics](#exporter-prometheus-metrics)
-        * 9.4.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Gap.ExporterMetricsTLS](#rqsrs026clickhouseoperatorfipsgapexportermetricstls)
-* 10 [Integrity Check Failure](#integrity-check-failure)
-    * 10.1 [Operator Integrity Tampering](#operator-integrity-tampering)
-        * 10.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.OperatorMismatch](#rqsrs026clickhouseoperatorfipsintegrityoperatormismatch)
-    * 10.2 [Exporter Integrity Tampering](#exporter-integrity-tampering)
-        * 10.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.ExporterMismatch](#rqsrs026clickhouseoperatorfipsintegrityexportermismatch)
+    * 3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries](#rqsrs-026clickhouseoperatorfipsoperatorbuildshippedbinaries)
+    * 3.2 [RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries.StartupLogs](#rqsrs-026clickhouseoperatorfipsoperatorbuildshippedbinariesstartuplogs)
+* 4 [FIPS 140-3 TLS Cipher Suites](#fips-140-3-tls-cipher-suites)
+    * 4.1 [Approved TLS Cipher Suites](#approved-tls-cipher-suites)
+        * 4.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
+    * 4.2 [Rejected Cipher Suites and Protocols](#rejected-cipher-suites-and-protocols)
+        * 4.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.RejectedCiphers](#rqsrs-026clickhouseoperatorfipstlsrejectedciphers)
+* 5 [ClickHouse Server](#clickhouse-server)
+        * 5.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig](#rqsrs-026clickhouseoperatorfipschfipsconfig)
+        * 5.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient](#rqsrs-026clickhouseoperatorfipschfipsconfigexternalclient)
+        * 5.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.Rescale](#rqsrs-026clickhouseoperatorfipschrescale)
+        * 5.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.ConfigUpdate](#rqsrs-026clickhouseoperatorfipschconfigupdate)
+* 6 [ClickHouse Keeper](#clickhouse-keeper)
+        * 6.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CHK.FIPSConfig](#rqsrs-026clickhouseoperatorfipschkfipsconfig)
+        * 6.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.CHK.Rescale](#rqsrs-026clickhouseoperatorfipschkrescale)
+        * 6.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.CHK.ConfigUpdate](#rqsrs-026clickhouseoperatorfipschkconfigupdate)
+* 7 [ClickHouse Backup Sidecar](#clickhouse-backup-sidecar)
+        * 7.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSBinary](#rqsrs-026clickhouseoperatorfipsbackupfipsbinary)
+        * 7.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSConfig](#rqsrs-026clickhouseoperatorfipsbackupfipsconfig)
+        * 7.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Backup.RestoreRoundTrip](#rqsrs-026clickhouseoperatorfipsbackuprestoreroundtrip)
+* 8 [FIPS Enforcement Mode](#fips-enforcement-mode)
+    * 8.1 [Security Coercion](#security-coercion)
+        * 8.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.SecurityCoercion](#rqsrs-026clickhouseoperatorfipsenforcedsecuritycoercion)
+        * 8.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectNonCompliantSpecs](#rqsrs-026clickhouseoperatorfipsenforcedrejectnoncompliantspecs)
+        * 8.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.MinVersionScope](#rqsrs-026clickhouseoperatorfipsenforcedminversionscope)
+    * 8.2 [Image Policy](#image-policy)
+        * 8.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectNonFIPS](#rqsrs-026clickhouseoperatorfipsimagesrequiredrejectnonfips)
+* 9 [Runtime Connection Evidence](#runtime-connection-evidence)
+    * 9.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KubernetesAPI](#rqsrs-026clickhouseoperatorfipsconnectoperatorkubernetesapi)
+    * 9.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.KubernetesAPI](#rqsrs-026clickhouseoperatorfipsconnectexporterkubernetesapi)
+    * 9.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse](#rqsrs-026clickhouseoperatorfipsconnectoperatorclickhouse)
+    * 9.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse](#rqsrs-026clickhouseoperatorfipsconnectexporterclickhouse)
+    * 9.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KeeperRestriction](#rqsrs-026clickhouseoperatorfipsconnectoperatorkeeperrestriction)
+    * 9.6 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.ClickHouse.KeeperTLS](#rqsrs-026clickhouseoperatorfipsconnectclickhousekeepertls)
+* 10 [Integrity Check](#integrity-check)
+    * 10.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.VerificationMismatch](#rqsrs-026clickhouseoperatorfipsintegrityverificationmismatch)
 * 11 [CAST Failure](#cast-failure)
     * 11.1 [Operator CAST Failure](#operator-cast-failure)
-        * 11.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.OperatorFail](#rqsrs026clickhouseoperatorfipscastoperatorfail)
+        * 11.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.OperatorFail](#rqsrs-026clickhouseoperatorfipscastoperatorfail)
     * 11.2 [Exporter CAST Failure](#exporter-cast-failure)
-        * 11.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.ExporterFail](#rqsrs026clickhouseoperatorfipscastexporterfail)
-* 12 [Synthetic TLS Cipher Validation](#synthetic-tls-cipher-validation)
-    * 12.1 [Approved cipher matrix](#approved-cipher-matrix)
-        * 12.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipssyntheticapprovedciphers)
-    * 12.2 [Rejected cipher matrix](#rejected-cipher-matrix)
-        * 12.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.RejectedCiphers](#rqsrs-026clickhouseoperatorfipssyntheticrejectedciphers)
-* 13 [CI/CD Image and Policy Verification](#cicd-image-and-policy-verification)
-    * 13.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CICD.OperatorImageBuild](#rqsrs-026clickhouseoperatorfipscicdoperatorimagebuild)
-    * 13.2 [RQ.SRS-026.ClickHouseOperator.FIPS.CICD.ExporterImageBuild](#rqsrs-026clickhouseoperatorfipscicdexporterimagebuild)
-    * 13.3 [RQ.SRS-026.ClickHouseOperator.FIPS.CICD.VulnerabilityScan](#rqsrs-026clickhouseoperatorfipscicdvulnerabilityscan)
-* 14 [AI Static Code Review](#ai-static-code-review)
-    * 14.1 [Operator Source Review](#operator-source-review)
-        * 14.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.Tree](#rqsrs-026clickhouseoperatorfipsaireviewoperatortree)
-        * 14.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.SharedPkg](#rqsrs-026clickhouseoperatorfipsaireviewoperatorsharedpkg)
-        * 14.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.RegressionGate](#rqsrs-026clickhouseoperatorfipsaireviewoperatorregressiongate)
-    * 14.2 [Exporter Source Review](#exporter-source-review)
-        * 14.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.Tree](#rqsrs-026clickhouseoperatorfipsaireviewexportertree)
-        * 14.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.SharedPkg](#rqsrs-026clickhouseoperatorfipsaireviewexportersharedpkg)
-        * 14.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.RegressionGate](#rqsrs-026clickhouseoperatorfipsaireviewexporterregressiongate)
-* 15 [ACVP Algorithm Validation](#acvp-algorithm-validation)
-    * 15.1 [Operator ACVP Validation](#operator-acvp-validation)
-        * 15.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration](#rqsrs026clickhouseoperatorfipsacvpoperatorwrapperintegration)
-        * 15.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration](#rqsrs026clickhouseoperatorfipsacvpoperatorconfiggeneration)
-        * 15.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ExpectedOutputReplay](#rqsrs026clickhouseoperatorfipsacvpoperatorexpectedoutputreplay)
-        * 15.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SuiteCount](#rqsrs026clickhouseoperatorfipsacvpoperatorsuitecount)
-    * 15.2 [Exporter ACVP Validation](#exporter-acvp-validation)
-        * 15.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration](#rqsrs026clickhouseoperatorfipsacvpexporterwrapperintegration)
-        * 15.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration](#rqsrs026clickhouseoperatorfipsacvpexporterconfiggeneration)
-        * 15.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ExpectedOutputReplay](#rqsrs026clickhouseoperatorfipsacvpexporterexpectedoutputreplay)
-        * 15.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SuiteCount](#rqsrs026clickhouseoperatorfipsacvpexportersuitecount)
-* 16 [Terminology](#terminology)
-    * 16.1 [SRS](#srs)
-    * 16.2 [FIPS 140-3](#fips-140-3)
-    * 16.3 [clickhouse-operator](#clickhouse-operator)
-    * 16.4 [metrics-exporter](#metrics-exporter)
-    * 16.5 [CHI](#chi)
-    * 16.6 [CHK](#chk)
-    * 16.7 [ACVP](#acvp)
-    * 16.8 [CMVP](#cmvp)
-    * 16.9 [CAVP](#cavp)
+        * 11.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.ExporterFail](#rqsrs-026clickhouseoperatorfipscastexporterfail)
+* 12 [ACVP Algorithm Validation](#acvp-algorithm-validation)
+    * 12.1 [Operator ACVP Validation](#operator-acvp-validation)
+        * 12.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration](#rqsrs-026clickhouseoperatorfipsacvpoperatorwrapperintegration)
+        * 12.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration](#rqsrs-026clickhouseoperatorfipsacvpoperatorconfiggeneration)
+        * 12.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SHA2256AFT](#rqsrs-026clickhouseoperatorfipsacvpoperatorsha2256aft)
+    * 12.2 [Exporter ACVP Validation](#exporter-acvp-validation)
+        * 12.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration](#rqsrs-026clickhouseoperatorfipsacvpexporterwrapperintegration)
+        * 12.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration](#rqsrs-026clickhouseoperatorfipsacvpexporterconfiggeneration)
+        * 12.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SHA2256AFT](#rqsrs-026clickhouseoperatorfipsacvpexportersha2256aft)
+* 13 [Terminology](#terminology)
+    * 13.1 [SRS](#srs)
+    * 13.2 [FIPS 140-3](#fips-140-3)
+    * 13.3 [clickhouse-operator](#clickhouse-operator)
+    * 13.4 [metrics-exporter](#metrics-exporter)
+    * 13.5 [CHI](#chi)
+    * 13.6 [CHK](#chk)
+    * 13.7 [ACVP](#acvp)
+    * 13.8 [CMVP](#cmvp)
+    * 13.9 [CAVP](#cavp)
 
 ## Introduction
 
@@ -163,46 +84,32 @@ This specification describes FIPS 140-3 compatibility requirements for the
 The goal is to verify that FIPS-enabled builds of the operator and metrics-exporter:
 - Operate correctly under FIPS constraints
 - Properly enforce cryptographic restrictions
-- Use FIPS-compliant TLS for all inbound and outbound connections
+- Use FIPS-compliant TLS for all outbound connections
 
 Autotests that trace to these requirements live in
-[`tests/e2e/test_operator_fips.py`](../e2e/test_operator_fips.py) and
+[`tests/e2e/test_operator.py`](../e2e/test_operator.py) and
 [`tests/e2e/test_acvp.py`](../e2e/test_acvp.py).
 
 **Boundary:** The operator and metrics-exporter run in the same pod. Internal IPC between
 them is localhost HTTP and is not subject to FIPS TLS requirements. The Prometheus metrics
 endpoints (operator `:9999` and metrics-exporter `:8888`) are also served over plain HTTP
-and remain outside the FIPS TLS scope as a known gap.
+and remain outside the FIPS TLS scope as a known gap. The ClickHouse Keeper readiness probe
+endpoint (`:9182` `/ready`, which reflects Raft quorum status) likewise stays unconditionally
+plaintext HTTP regardless of the secure/insecure knobs and is outside the FIPS TLS scope.
 
 ## Configuration Requirements
 
 Plain HTTP/TCP on any external connection is a configuration error for FIPS compliance.
-TLS must be enabled for all connections to:
 
-- Kubernetes API
-- ClickHouse Server
-- ZooKeeper/Keeper
-- Prometheus scrape endpoints
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.Config.ExternalTLS
+### RQ.SRS-026.ClickHouseOperator.FIPS.HTTPPorts
 version: 1.0
 
-Plain HTTP/TCP on external connections SHALL be treated as a configuration error for FIPS compliance. TLS SHALL be enabled for connections to the [Kubernetes API], [ClickHouse Server], [ZooKeeper/Keeper], and Prometheus scrape endpoints.
+All external connections SHALL require TLS with FIPS-compliant settings, except for localhost IPC between the operator
+and metrics-exporter and the Prometheus metrics endpoints `:9999` and `:8888`.
 
 ## Build Verification
 
-**Objective:** Verify each shipped binary is a FIPS build and linked to Go Cryptographic Module v1.0.0.
-
-**Certificates:**
-- [CMVP #5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247)
-- [CAVP A6650](https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/details?product=19371)
-
-**Build requirement:** `GOFIPS140=v1.0.0` (or `certified`)
-
-
-### Shipped Binaries
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries
+### RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries
 version: 1.0
 
 Each shipped pod binary — `clickhouse-operator` and `metrics-exporter` — SHALL satisfy all of the following:
@@ -231,26 +138,22 @@ Examples:
     enabled: true
   ```
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.StartupLogs
+### RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries.StartupLogs
 version: 1.0
 
-At startup, each binary SHALL emit a FIPS startup banner in logs indicating build and runtime FIPS state.
+At startup, each binary SHALL emit a FIPS startup log line indicating build and runtime FIPS state.
 
-when GODEBUG=fips140=only:
+When `GODEBUG=fips140=only`:
 
 ```text
-FIPS: chopconf.fips.enforced=true \
-build.linked=true \
-module.active=true \
-runtime.enforced=true \
-module=v1.0.0
+FIPS: chopconf.fips.enforced=true build.linked=true module.active=true runtime.enforced=true module=v1.0.0
 ```
 
+## FIPS 140-3 TLS Cipher Suites
 
+### Approved TLS Cipher Suites
 
-## Approved TLS Cipher Suites
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers
+#### RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers
 version: 1.0
 
 TLS-enforced external connections for [clickhouse-operator] and [metrics-exporter]
@@ -258,188 +161,216 @@ SHALL negotiate only TLS 1.3 with the following approved cipher suites.
 
 * TLS_AES_128_GCM_SHA256
 * TLS_AES_256_GCM_SHA384
-* TLS_AES_128_CCM_SHA256
-* TLS_AES_128_CCM_8_SHA256
+
+Note: `TLS_CHACHA20_POLY1305_SHA256` is TLS v1.3 but not FIPS approved.
 
 ### Rejected Cipher Suites and Protocols
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.TLS.RejectedCiphers
 version: 1.0
 
-TLS connections SHALL reject the following for all TLS-enabled external connections:
-
-- Any TLS cipher suite not explicitly listed in [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
-- Protocol versions: SSLv2, SSLv3, TLS 1.0, TLS 1.1
-- Cipher suites using non-approved/legacy algorithms (for this profile), including:
-  - ChaCha20-Poly1305
-  - RC4, RC2, DES, 3DES, IDEA, SEED, CAMELLIA, ARIA
-  - NULL encryption / NULL authentication
-  - Anonymous key exchange (`aNULL`, `eNULL`, `ADH`, `AECDH`)
-  - Export/weak suites (`EXP`, `LOW`, `40-bit`, `56-bit`)
-  - MD5- or SHA-1-based legacy suites
+On TLS-enforced external connections for [clickhouse-operator] and [metrics-exporter], any protocol version
+older than TLS 1.3 and any cipher suite not listed in [approved ciphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
+SHALL be rejected by the operator in a FIPS-compliant configuration.
 
 
-## ClickHouse Server and Keeper FIPS Configurations
+## ClickHouse Server
 
-**Objective:** Verify the operator generates and maintains FIPS-compliant configurations for ClickHouse servers and Keepers.
-
-
-### ClickHouse Server
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.FIPSConfig
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig
 version: 1.0
 
-Deploying a CHI with FIPS TLS settings SHALL start ClickHouse with FIPS-compliant TLS configuration.
+Operator deploying a `ClickHouseInstallation` with FIPS TLS OpenSSL settings SHALL start a FIPS-compliant ClickHouse server and client.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHIDeploy
+```yaml
+  configuration:
+    clusters:
+      - name: default
+        secure: "yes"
+        insecure: "no"
+        layout:
+          shardsCount: 1
+          replicasCount: 2
+    zookeeper:
+      nodes:
+        - host: chk-test-030003-keeper-0-0
+          port: 2281
+          secure: "yes"
+    settings:
+      http_port: _removed_
+      tcp_port: _removed_
+      interserver_http_port: _removed_
+      mysql_port: _removed_
+      postgresql_port: _removed_
+      https_port: 8443
+      tcp_port_secure: 9440
+      interserver_https_port: 9010
+    files:
+      openssl.xml: |
+        <yandex>
+          <openSSL>
+            <server>
+              <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>
+              <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>
+              <dhParamsFile>/etc/clickhouse-server/secrets.d/dhparam.pem/clickhouse-certs/dhparam.pem</dhParamsFile>
+              <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
+              <verificationMode>none</verificationMode>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+            </server>
+            <client>
+              <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
+              <loadDefaultCAFile>false</loadDefaultCAFile>
+              <verificationMode>strict</verificationMode>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+            </client>
+          </openSSL>
+        </yandex>
+```
+
+The deployed ClickHouse server SHALL use only the following ports:
+
+* HTTPS API port 8443 (instead of 8123)
+* Secure native TCP port 9440 (instead of 9000)
+* Interserver HTTPS port 9010 (instead of interserver HTTP port 9009)
+* Backup sidecar HTTPS API port 7171 (instead of 7180), when backups are enabled
+
+Each exposed port SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites.
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient
 version: 1.0
 
-The operator SHALL deploy FIPS `ClickHouseInstallation` resources to `Completed` with Running pods when configuration is valid.
+External clients connecting to the ClickHouse server SHALL be able to use any enabled TLS protocol version, including TLS 1.2.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainHTTP
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.Rescale
 version: 1.0
 
-When FIPS transport hardening applies, ClickHouse pods SHALL NOT listen on plain HTTP port 8123; HTTPS port 8443 SHALL be used.
+Adding or removing a replica from a FIPS-configured `ClickHouseInstallation` SHALL reconcile successfully and result in the expected number of running pods.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainNative
-version: 1.0
+After rescaling, all replicas SHALL continue to run the FIPS ClickHouse binary and maintain the configured TLS-only OpenSSL settings.
 
-When FIPS transport hardening applies, ClickHouse pods SHALL NOT listen on plain native TCP port 9000; secure native port 9440 SHALL be used.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoUnexpectedPorts
-version: 1.0
-
-ClickHouse pods in a FIPS deployment SHALL expose only expected secure listener ports and no additional unexpected ports.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.InternodeTLS
-version: 1.0
-
-ReplicatedMergeTree replicas SHALL communicate over interserver HTTPS (`interserver_https_port`) and data SHALL converge across replicas.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleUp
-version: 1.0
-
-Adding a replica to a FIPS-configured CHI SHALL reconcile to `Completed` and the new replica SHALL run the FIPS ClickHouse binary with TLS-only listeners.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleDown
-version: 1.0
-
-Removing a replica from a FIPS-configured CHI SHALL reconcile to `Completed` and remaining replicas SHALL keep FIPS binary and TLS-only configuration.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ConfigUpdate
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.ConfigUpdate
 version: 1.0
 
 Updating TLS settings on a running CHI SHALL reload ClickHouse with the new FIPS-compliant configuration.
 
 
-### ClickHouse Keeper
+## ClickHouse Keeper
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.FIPSConfig
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CHK.FIPSConfig
 version: 1.0
 
-Deploying a CHK with FIPS TLS settings SHALL start Keeper with FIPS-compliant TLS configuration.
+Operator deploying a `ClickHouseKeeperInstallation` with FIPS TLS OpenSSL settings SHALL start a FIPS-compliant ClickHouse
+Keeper server and client.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHKDeploy
+```yaml
+  configuration:
+    clusters:
+      - name: keeper
+        secure: "yes"
+        insecure: "no"
+        layout:
+          replicasCount: 2
+    settings:
+      keeper_server/log_storage_path: /var/lib/clickhouse/coordination/log
+      keeper_server/snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+      keeper_server/raft_configuration/server/port: 9444
+    files:
+      openssl.xml: |
+        <clickhouse>
+          <openSSL>
+              <server>
+                <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>
+                <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>
+                <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
+                <verificationMode>none</verificationMode>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+              </server>
+              <client>
+                <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
+                <loadDefaultCAFile>false</loadDefaultCAFile>
+                <verificationMode>strict</verificationMode>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+              </client>
+          </openSSL>
+        </clickhouse>
+```
+
+The deployed ClickHouse Keeper cluster SHALL use only the following ports:
+
+* Secure client port 2281 (instead of 2181)
+* Secure Raft communication port 9444
+* Plaintext HTTP readiness probe port 9182 (the `/ready` Raft-quorum health check)
+
+Every exposed port except the readiness probe port 9182 and Raft replication port 9444 (which enforces peer-only authentication)
+SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites. Port 9182 SHALL stay 
+unconditionally plaintext HTTP regardless of the secure/insecure configuration (see Boundary).
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CHK.Rescale
 version: 1.0
 
-The operator SHALL deploy FIPS `ClickHouseKeeperInstallation` resources to `Completed` with Running pods when configuration is valid.
+Adding or removing a node from a FIPS-configured `ClickHouseKeeperInstallation` SHALL reconcile successfully and result 
+in the expected number of running pods.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoPlainClientPort
+After rescaling, all Keeper nodes SHALL continue to run the FIPS ClickHouse Keeper binary and maintain the configured 
+TLS-only OpenSSL settings.
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CHK.ConfigUpdate
 version: 1.0
 
-When FIPS transport hardening applies, Keeper pods SHALL NOT listen on plain client port 2181; secure client port 2281 SHALL be used.
+Updating TLS settings on a running CHK SHALL reload ClickHouse with the new FIPS-compliant configuration.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoUnexpectedPorts
+
+## ClickHouse Backup Sidecar
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSBinary
 version: 1.0
 
-Keeper pods in a FIPS deployment SHALL expose only expected secure listener ports.
+The `clickhouse-backup` sidecar SHALL run a FIPS-built binary.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.RaftTLS
+The sidecar binary SHALL satisfy all of the following:
+
+* `clickhouse-backup --version` contains `fips`
+* When inspectable, `go version -m` reports `GOFIPS140=v1.0.0`
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSConfig
 version: 1.0
 
-Keeper Raft communication SHALL use TLS on the configured secure Raft port.
+Deploying a `ClickHouseInstallation` with a FIPS-configured backup sidecar SHALL start `clickhouse-backup` with a FIPS-compliant TLS configuration.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleUp
+The deployed backup sidecar SHALL only add the following listener ports to the ClickHouse container:
+
+* HTTPS API port 7171 (instead of 7180)
+
+The FIPS-configured backup sidecar SHALL additionally satisfy all of the following:
+
+* Each exposed port SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites.
+* The `clickhouse-backup` sidecar SHALL connect to ClickHouse using secure native TCP with TLS enabled.
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Backup.RestoreRoundTrip
 version: 1.0
 
-Adding a node to a FIPS-configured Keeper cluster SHALL reconcile to `Completed` and the new node SHALL run the FIPS Keeper binary with TLS-only client and Raft listeners.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleDown
-version: 1.0
-
-Removing a node from a FIPS-configured Keeper cluster SHALL reconcile to `Completed` and remaining nodes SHALL keep FIPS configuration.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ConfigUpdate
-version: 1.0
-
-Updating TLS settings on a running CHK SHALL reload Keeper with the new FIPS-compliant configuration.
-
-
-### ClickHouse Backup Sidecar
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.VersionString
-version: 1.0
-
-A running ClickHouse host under FIPS image policy SHALL report a `version()` string containing `fips` (case-insensitive).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.FIPSBinary
-version: 1.0
-
-The `clickhouse-backup` sidecar SHALL run a FIPS-built binary; `clickhouse-backup --version` SHALL contain `fips` (case-insensitive).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.GOFIPS140
-version: 1.0
-
-When inspectable, the clickhouse-backup sidecar binary SHALL embed `GOFIPS140=v1.0.0` per `go version -m`.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.OnlyTLSPorts
-version: 1.0
-
-The clickhouse-backup sidecar SHALL expose only secure listener ports (including HTTPS API port 7171).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.HTTPSAPI
-version: 1.0
-
-The clickhouse-backup HTTPS API SHALL serve over TLS with CA-trust enforcement: trusted clients accepted, untrusted clients rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.ClickHouseOverTLS
-version: 1.0
-
-The clickhouse-backup sidecar SHALL reach ClickHouse over secure native TCP.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RestoreRoundTrip
-version: 1.0
-
-Backup and restore through the HTTPS API SHALL succeed over TLS.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RemoteUploadTLS
-version: 1.0
-
-Remote backup upload to object storage SHALL use FIPS-approved TLS.
-
+Creating a backup and restoring it through the HTTPS API SHALL succeed over TLS.
 
 ## FIPS Enforcement Mode
 
-**Objective:** Verify `security.fips.enforced=true` coerces security settings and rejects non-compliant configurations.
-
+**Objective:** Verify that `security.fips.enforced: "true"` coerces relaxed security settings and rejects non-compliant CHI/CHK specifications and non-FIPS images.
 
 ### Security Coercion
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceVerifyStrict
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.SecurityCoercion
 version: 1.0
 
-With `fips.enforced=true`, unset TLS verify SHALL be coerced to Strict for ClickHouse, ZooKeeper/Keeper, and Kubernetes clients.
+When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL coerce unset or relaxed security settings as follows:
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceMinVersion13
-version: 1.0
+* Unset TLS verify SHALL be coerced to Strict for ClickHouse, ZooKeeper/Keeper, and Kubernetes clients.
+* Unset TLS `minVersion` SHALL be coerced to `"1.3"` for the operator's outbound TLS clients (`security.clickhouse.tls`, `security.zookeeper.tls`, and `security.kubernetes.tls`).
+* Explicit `minVersion: "1.2"` for those TLS clients SHALL be coerced to `"1.3"`.
+* Unset IPC mode SHALL be coerced to Secure.
 
-With `fips.enforced=true`, unset TLS minVersion SHALL be coerced to 1.3 for the
-operator's outbound TLS clients.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.OverrideMinVersion12To13
-version: 1.0
-
-When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL coerce `minVersion` to `"1.3"` for `security.clickhouse.tls`, `security.zookeeper.tls`, and `security.kubernetes.tls`, even when those fields are explicitly set to `"1.2"`.
+Example configuration with explicit `minVersion: "1.2"`:
 
 ```yaml
 spec:
@@ -457,230 +388,87 @@ spec:
         minVersion: "1.2"
 ```
 
-After operator configuration normalization, the effective `minVersion` for each component listed above SHALL be `"1.3"`.
+After operator configuration normalization, the effective `minVersion` for each TLS client listed above SHALL be `"1.3"`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceIPCSecure
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectNonCompliantSpecs
 version: 1.0
 
-With `fips.enforced=true`, unset IPC mode SHALL be coerced to Secure.
+When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL reject 
+non-compliant CHI and CHK specifications with `FIPSValidationFailed` and SHALL NOT create workload StatefulSets for:
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInsecureKubeconfig
-version: 1.0
-
-The operator SHALL refuse to start when kubeconfig uses `TLSClientConfig.Insecure=true` under strict/FIPS mode.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneCHI
-version: 1.0
-
-CHI with `clickhouse.tls.verify=None` at CHI spec or cluster level under enforced mode SHALL be rejected with `FIPSValidationFailed`.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneZK
-version: 1.0
-
-CHI with `zookeeper.tls.verify=None` under enforced mode SHALL be rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInvalidMinVersion
-version: 1.0
-
-CHI with invalid TLS minVersion under enforced mode SHALL be rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectExternalZookeeper
-version: 1.0
-
-CHI referencing plain external ZooKeeper nodes under enforced mode SHALL be rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectCHKBypass
-version: 1.0
-
-CHK with TLS verify bypass under enforced mode SHALL be rejected.
+* CHI referencing plain external ZooKeeper nodes, including when `secure` is explicitly set to `"false"`.
+* CHI with `clickhouse.tls.verify=None` at spec or cluster level.
+* CHI with `zookeeper.tls.verify=None`.
+* CHI with invalid `clickhouse.tls.minVersion`.
+* CHK with TLS verify bypass at spec level.
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.MinVersionScope
 version: 1.0
 
 The `minVersion` coercion SHALL apply only to TLS clients created and managed by the operator.
-They SHALL NOT require ClickHouse Server or ClickHouse Keeper listener endpoints to reject TLS 1.2.
+They SHALL NOT require ClickHouse Server or ClickHouse Keeper listener endpoints to reject TLS 1.2
+(see [RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient](#rqsrs-026clickhouseoperatorfipschfipsconfigexternalclient)).
 
 ### Image Policy
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHI
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectNonFIPS
 version: 1.0
 
-With `security.fips.images.policy=Required`, CHI with non-FIPS image tag SHALL be rejected with `FIPSImagePolicyViolation`.
+With `security.fips.images.policy=Required`, non-FIPS images SHALL be rejected with `FIPSImagePolicyViolation` as follows:
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.AcceptCHI
+* CHI with non-FIPS ClickHouse image tag SHALL be rejected at admission.
+* CHK with non-FIPS Keeper image tag SHALL be rejected at admission.
+* CHI with non-FIPS `clickhouse-backup` sidecar image tag SHALL be rejected at admission.
+* CHI with multiple non-FIPS hosts SHALL produce a single policy violation error.
+* Digest-only image references SHALL NOT be detected as FIPS at admission.
+* Registry hostname containing `fips` SHALL NOT satisfy FIPS tag detection.
+* CHI admitted with a FIPS-tagged ClickHouse image whose running binary lacks `fips` in `SELECT version()` SHALL fail at runtime.
+
+## Runtime Connection Evidence
+
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KubernetesAPI
 version: 1.0
 
-With image policy Required, CHI with FIPS-tagged image SHALL reconcile normally.
+The clickhouse-operator SHALL access the Kubernetes API through the HTTPS endpoint on port `443`.
+Plain HTTP requests to the Kubernetes API endpoint SHALL be rejected.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHK
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.KubernetesAPI
 version: 1.0
 
-With image policy Required, CHK with non-FIPS Keeper image SHALL be rejected.
+The metrics-exporter SHALL access the Kubernetes API through the HTTPS endpoint on port `443`.
+Plain HTTP requests to the Kubernetes API endpoint SHALL be rejected.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RuntimeVersion
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse
 version: 1.0
 
-With image policy Required, host `SELECT version()` lacking `fips` SHALL fail with `FIPSImagePolicyViolation`.
+The clickhouse-operator SHALL communicate with ClickHouse hosts using HTTPS port `8443`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Permissive
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse
 version: 1.0
 
-With permissive image policy, non-FIPS CHI images SHALL reconcile (default).
+The metrics-exporter SHALL discover ClickHouse hosts using the HTTPS endpoint `8443`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.ShortCircuit
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KeeperRestriction
 version: 1.0
 
-Multiple non-FIPS hosts SHALL produce a single policy violation error.
+When a Keeper ensemble is configured as TLS-only, the clickhouse-operator SHALL NOT attempt plaintext ZooKeeper/Keeper
+operations against it.
 
-
-### Image Tag Detection
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.FIPSSuffix
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.ClickHouse.KeeperTLS
 version: 1.0
 
-Image tags containing `fips` (case-insensitive) SHALL be detected as FIPS.
+ClickHouse replicas SHALL connect to Keeper using secure client port `2281` with `secure=yes`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.AltinityFIPS
+
+## Integrity Check
+
+### RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.VerificationMismatch
 version: 1.0
 
-Image tags containing `altinityfips` SHALL be detected as FIPS.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.DigestOnly
-version: 1.0
-
-Digest-only image references SHALL NOT be detected as FIPS at admission.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.RegistryPath
-version: 1.0
-
-Registry hostname containing `fips` SHALL NOT satisfy FIPS tag detection.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.CaseInsensitive
-version: 1.0
-
-Image tags such as `25.3.FIPS` or `25.3.Fips` SHALL be detected as FIPS (case-insensitive match on the tag).
-
-
-## Operator External Connections
-
-**Objective:** Verify all **clickhouse-operator** inbound and outbound connections use FIPS-compliant TLS.
-
-
-### Operator Runtime Listener Verification
-
-In a FIPS deployment, workload containers deployed by the operator (ClickHouse, Keeper, and sidecar containers) SHALL expose only expected TLS listener ports. Verification reads `/proc/net/tcp` and `/proc/net/tcp6` inside each container and parses ports in LISTEN state (`0A`):
-
-```bash
-kubectl exec <pod> -c clickhouse -- sh -c 'cat /proc/net/tcp /proc/net/tcp6'
-```
-
-E2e coverage: [`test_020011`](../e2e/test_operator_fips.py#L200).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Listeners
-version: 1.0
-
-FIPS workload pods (ClickHouse, Keeper, and sidecar containers) SHALL listen only on expected TLS ports. Plaintext service ports (8123, 9000, 2181) SHALL NOT be open when FIPS transport hardening applies.
-
-
-### Operator to Kubernetes API
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Kubernetes
-version: 1.0
-
-The operator SHALL connect to the Kubernetes API using FIPS-approved TLS ciphers.
-
-
-### Operator to ClickHouse Server
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse
-version: 1.0
-
-The operator SHALL connect to ClickHouse using FIPS-approved TLS ciphers.
-
-
-### Operator to ZooKeeper/Keeper
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Zookeeper
-version: 1.0
-
-The operator SHALL connect to ZooKeeper/Keeper using FIPS-approved TLS ciphers.
-
-
-### Operator to metrics-exporter IPC
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.IPCSecure
-version: 1.0
-
-Operator IPC with `security.ipc.mode=Secure` SHALL work over localhost HTTP with token auth.
-
-
-### Operator Prometheus Metrics
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Gap.OperatorMetricsTLS
-version: 1.0
-
-Operator Prometheus metrics on :9999 currently expose a known FIPS gap (HTTP-only).
-
-
-## Exporter External Connections
-
-**Objective:** Verify all **metrics-exporter** inbound and outbound connections use FIPS-compliant TLS.
-
-
-### Exporter Runtime Listener Verification
-
-Listener audits use the same `/proc/net/tcp` technique as [Operator Runtime Listener Verification](#operator-runtime-listener-verification). E2e audits the **clickhouse-backup** sidecar in [`test_020011`](../e2e/test_operator_fips.py#L200). The **metrics-exporter** process on `:8888` remains a known gap until metrics TLS is implemented.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Listeners
-version: 1.0
-
-The metrics-exporter process SHALL expose only expected listener ports on `:8888`. Sidecar containers in the same pod SHALL be listener-audited with the same `/proc/net/tcp` procedure.
-
-
-### Exporter to Kubernetes API
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Kubernetes
-version: 1.0
-
-The exporter SHALL connect to the Kubernetes API using FIPS-approved TLS ciphers.
-
-
-### Exporter to ClickHouse Server
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse
-version: 1.0
-
-The exporter SHALL query ClickHouse using FIPS-approved TLS when configured for HTTPS.
-
-
-### Exporter Prometheus Metrics
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Gap.ExporterMetricsTLS
-version: 1.0
-
-Exporter Prometheus metrics on :8888 currently expose a known FIPS gap (HTTP-only).
-
-
-## Integrity Check Failure
-
-**Objective:** Verify FIPS integrity self-test detects binary tampering for each shipped binary independently.
-
-
-### Operator Integrity Tampering
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.OperatorMismatch
-version: 1.0
-
-Tampering with `clickhouse-operator` `.go.fipsinfo` SHALL panic with `fips140: verification mismatch`.
-
-
-### Exporter Integrity Tampering
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.ExporterMismatch
-version: 1.0
-
-Tampering with `metrics-exporter` `.go.fipsinfo` SHALL panic with `fips140: verification mismatch`.
-
+Each shipped FIPS binary — `clickhouse-operator` and `metrics-exporter` — SHALL perform a software integrity 
+self-test at initialization by verifying its embedded HMAC. If the binary is tampered with or corrupted such that
+the HMAC verification fails, the process SHALL immediately terminate with a `fips140: verification mismatch` panic 
+to prevent the execution of a compromised cryptographic module.
 
 ## CAST Failure
 
@@ -703,164 +491,46 @@ version: 1.0
 Running `metrics-exporter` with `GODEBUG=failfipscast=<name>` SHALL terminate with a CAST error.
 
 
-## Synthetic TLS Cipher Validation
-
-**Objective:** Validate FIPS cipher enforcement on all external (to the pod) connections using `openssl s_client` and `openssl s_server`.
-
-Use `openssl` to simulate connections with specific ciphers and verify the operator/exporter accepts FIPS-approved ciphers and rejects non-approved ones.
-
-```bash
-# Operator as TLS client against server offering only approved cipher
-openssl s_server -accept 8443 -cert server.crt -key server.key \
-  -ciphersuites TLS_AES_256_GCM_SHA384
-
-# Operator as TLS client against server offering non-approved cipher
-openssl s_server -accept 8443 -cert server.crt -key server.key \
-  -cipher ECDHE-RSA-CHACHA20-POLY1305
-
-# Inbound connection to operator/exporter metrics endpoint
-openssl s_client -connect localhost:9999 -cipher ECDHE-RSA-AES256-GCM-SHA384
-```
-
-### Approved cipher matrix
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.ApprovedCiphers
-version: 1.0
-
-For each external connection listed below, when exercised as a TLS **client** with `openssl s_server` offering only [approved ciphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers), or as a TLS **server** with `openssl s_client` using only approved ciphers, the connection SHALL succeed:
-
-| Connection | Role | Tool |
-|------------|------|------|
-| Operator to Kubernetes API | Client | `openssl s_server` |
-| Operator to ClickHouse Server | Client | `openssl s_server` |
-| Operator to ZooKeeper/Keeper | Client | `openssl s_server` |
-| Operator metrics :9999 | Server | `openssl s_client` |
-| Exporter to Kubernetes API | Client | `openssl s_server` |
-| Exporter to ClickHouse Server | Client | `openssl s_server` |
-| Exporter metrics :8888 | Server | `openssl s_client` |
-
-
-### Rejected cipher matrix
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.RejectedCiphers
-version: 1.0
-
-For each external connection listed below, when the peer offers only [rejected ciphers or protocols](#rqsrs-026clickhouseoperatorfipstlsrejectedciphers), the connection SHALL be rejected:
-
-| Connection | Role | Tool |
-|------------|------|------|
-| Operator to Kubernetes API | Client | `openssl s_server` |
-| Operator to ClickHouse Server | Client | `openssl s_server` |
-| Operator to ZooKeeper/Keeper | Client | `openssl s_server` |
-| Operator metrics :9999 | Server | `openssl s_client` |
-| Exporter to Kubernetes API | Client | `openssl s_server` |
-| Exporter to ClickHouse Server | Client | `openssl s_server` |
-| Exporter metrics :8888 | Server | `openssl s_client` |
-
-
-## CI/CD Image and Policy Verification
-
-**Objective:** Add CI/CD jobs to validate FIPS image build and supply-chain checks.
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.CICD.OperatorImageBuild
-version: 1.0
-
-CI SHALL build the [clickhouse-operator] FIPS image successfully.
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.CICD.ExporterImageBuild
-version: 1.0
-
-CI SHALL build the [metrics-exporter] FIPS image successfully.
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.CICD.VulnerabilityScan
-version: 1.0
-
-FIPS images SHALL pass vulnerability scanning with no Critical, High, or Medium findings.
-
-
-### Operator Source Review
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.Tree
-version: 1.0
-
-Static review of operator-scoped paths SHALL produce no Critical findings; Warning-level findings SHALL be documented.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.SharedPkg
-version: 1.0
-
-Review of shared packages reachable from `cmd/operator` SHALL produce no Critical findings.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.RegressionGate
-version: 1.0
-
-A signed-off review artifact SHALL be stored with the build record before release.
-
-### Exporter Source Review
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.Tree
-version: 1.0
-
-Static review of exporter-scoped paths SHALL produce no Critical findings; Warning-level findings SHALL be documented.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.SharedPkg
-version: 1.0
-
-Review of shared packages reachable from `cmd/metrics_exporter` SHALL produce no Critical findings.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.RegressionGate
-version: 1.0
-
-A signed-off review artifact SHALL be stored with the build record before release.
-
 ## ACVP Algorithm Validation
 
-**Objective:** Reproduce ACVP expected-output checks for each FIPS binary using the tracked public-scope config in [`pkg/util/fips/acvp/`](../../../pkg/util/fips/acvp/).
+**Objective:** Verify that each FIPS binary can be built with the ACVP wrapper enabled and that the embedded ACVP responder works through the modulewrapper stdin/stdout protocol.
 
+These requirements cover the e2e ACVP smoke tests only. They do not claim full ACVP expected-output replay or suite-count validation from `pkg/util/fips/acvp/run.sh`.
 
 ### Operator ACVP Validation
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration
 version: 1.0
 
-Building clickhouse-operator with `-tags acvp_wrapper` SHALL expose a working ACVP responder via argv0 dispatch.
+Building `clickhouse-operator` with `-tags acvp_wrapper` SHALL produce a binary whose ACVP responder is reachable through argv0 dispatch when executed as `clickhouse-operator-acvp`.
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration
 version: 1.0
 
-The clickhouse-operator ACVP responder SHALL answer `getConfig` with supported capabilities.
+The `clickhouse-operator` ACVP responder SHALL answer a `getConfig` request successfully. The returned payload SHALL be valid JSON, SHALL advertise `SHA2-256` and `ACVP-AES-GCM`, and SHALL NOT advertise `ML-KEM` or `ML-DSA`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ExpectedOutputReplay
+#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SHA2256AFT
 version: 1.0
 
-`bash pkg/util/fips/acvp/run.sh` SHALL match all configured expected outputs for the operator.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SuiteCount
-version: 1.0
-
-The tracked ACVP config SHALL report 38 matched expectations for clickhouse-operator.
-
+The `clickhouse-operator` ACVP responder SHALL answer a `SHA2-256` algorithm functional test request for input `abc` with the digest matching `hashlib.sha256(b"abc").digest()`.
 
 ### Exporter ACVP Validation
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration
 version: 1.0
 
-Building metrics-exporter with `-tags acvp_wrapper` SHALL expose a working ACVP responder.
+Building `metrics-exporter` with `-tags acvp_wrapper` SHALL produce a binary whose ACVP responder is reachable through argv0 dispatch when executed as `metrics-exporter-acvp`.
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration
 version: 1.0
 
-The metrics-exporter ACVP responder SHALL answer `getConfig` with supported capabilities.
+The `metrics-exporter` ACVP responder SHALL answer a `getConfig` request successfully. The returned payload SHALL be valid JSON, SHALL advertise `SHA2-256` and `ACVP-AES-GCM`, and SHALL NOT advertise `ML-KEM` or `ML-DSA`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ExpectedOutputReplay
+#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SHA2256AFT
 version: 1.0
 
-`BINARY=metrics-exporter bash pkg/util/fips/acvp/run.sh` SHALL match all expected outputs.
+The `metrics-exporter` ACVP responder SHALL answer a `SHA2-256` algorithm functional test request for input `abc` with the digest matching `hashlib.sha256(b"abc").digest()`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SuiteCount
-version: 1.0
-
-The tracked ACVP config SHALL report 38 matched expectations for metrics-exporter.
 
 ## Terminology
 

--- a/tests/requirements/fips.py
+++ b/tests/requirements/fips.py
@@ -8,15 +8,16 @@ from testflows.core import Requirement
 
 Heading = Specification.Heading
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Config_ExternalTLS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Config.ExternalTLS',
+RQ_SRS_026_ClickHouseOperator_FIPS_HTTPPorts = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.HTTPPorts',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Plain HTTP/TCP on external connections SHALL be treated as a configuration error for FIPS compliance. TLS SHALL be enabled for connections to the [Kubernetes API], [ClickHouse Server], [ZooKeeper/Keeper], and Prometheus scrape endpoints.\n'
+        'All external connections SHALL require TLS with FIPS-compliant settings, except for localhost IPC between the operator\n'
+        'and metrics-exporter and the Prometheus metrics endpoints `:9999` and `:8888`.\n'
         '\n'
     ),
     link=None,
@@ -24,8 +25,8 @@ RQ_SRS_026_ClickHouseOperator_FIPS_Config_ExternalTLS = Requirement(
     num='2.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Build_ShippedBinaries = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries',
+RQ_SRS_026_ClickHouseOperator_FIPS_OperatorBuild_ShippedBinaries = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries',
     version='1.0',
     priority=None,
     group=None,
@@ -60,36 +61,30 @@ RQ_SRS_026_ClickHouseOperator_FIPS_Build_ShippedBinaries = Requirement(
         '\n'
     ),
     link=None,
-    level=3,
-    num='3.1.1'
+    level=2,
+    num='3.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Build_ShippedBinaries_StartupLogs = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.StartupLogs',
+RQ_SRS_026_ClickHouseOperator_FIPS_OperatorBuild_ShippedBinaries_StartupLogs = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries.StartupLogs',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'At startup, each binary SHALL emit a FIPS startup banner in logs indicating build and runtime FIPS state.\n'
+        'At startup, each binary SHALL emit a FIPS startup log line indicating build and runtime FIPS state.\n'
         '\n'
-        'when GODEBUG=fips140=only:\n'
+        'When `GODEBUG=fips140=only`:\n'
         '\n'
         '```text\n'
-        'FIPS: chopconf.fips.enforced=true \\\n'
-        'build.linked=true \\\n'
-        'module.active=true \\\n'
-        'runtime.enforced=true \\\n'
-        'module=v1.0.0\n'
+        'FIPS: chopconf.fips.enforced=true build.linked=true module.active=true runtime.enforced=true module=v1.0.0\n'
         '```\n'
-        '\n'
-        '\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='3.1.2'
+    level=2,
+    num='3.2'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_TLS_ApprovedCiphers = Requirement(
@@ -103,17 +98,15 @@ RQ_SRS_026_ClickHouseOperator_FIPS_TLS_ApprovedCiphers = Requirement(
         'TLS-enforced external connections for [clickhouse-operator] and [metrics-exporter]\n'
         'SHALL negotiate only TLS 1.3 with the following approved cipher suites.\n'
         '\n'
-        '| Cipher Suite | OpenSSL Name |\n'
-        '|--------------|--------------|\n'
-        '| TLS_AES_128_GCM_SHA256 | TLS_AES_128_GCM_SHA256 |\n'
-        '| TLS_AES_256_GCM_SHA384 | TLS_AES_256_GCM_SHA384 |\n'
-        '| TLS_AES_128_CCM_SHA256 | TLS_AES_128_CCM_SHA256 |\n'
-        '| TLS_AES_128_CCM_8_SHA256 | TLS_AES_128_CCM_8_SHA256 |\n'
+        '* TLS_AES_128_GCM_SHA256\n'
+        '* TLS_AES_256_GCM_SHA384\n'
+        '\n'
+        'Note: `TLS_CHACHA20_POLY1305_SHA256` is TLS v1.3 but not FIPS approved.\n'
         '\n'
     ),
     link=None,
-    level=2,
-    num='4.1'
+    level=3,
+    num='4.1.1'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_TLS_RejectedCiphers = Requirement(
@@ -124,17 +117,9 @@ RQ_SRS_026_ClickHouseOperator_FIPS_TLS_RejectedCiphers = Requirement(
     type=None,
     uid=None,
     description=(
-        'TLS connections SHALL reject the following for all TLS-enabled external connections:\n'
-        '\n'
-        '- Any TLS cipher suite not explicitly listed in [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)\n'
-        '- Protocol versions: SSLv2, SSLv3, TLS 1.0, TLS 1.1\n'
-        '- Cipher suites using non-approved/legacy algorithms (for this profile), including:\n'
-        '  - ChaCha20-Poly1305\n'
-        '  - RC4, RC2, DES, 3DES, IDEA, SEED, CAMELLIA, ARIA\n'
-        '  - NULL encryption / NULL authentication\n'
-        '  - Anonymous key exchange (`aNULL`, `eNULL`, `ADH`, `AECDH`)\n'
-        '  - Export/weak suites (`EXP`, `LOW`, `40-bit`, `56-bit`)\n'
-        '  - MD5- or SHA-1-based legacy suites\n'
+        'On TLS-enforced external connections for [clickhouse-operator] and [metrics-exporter], any protocol version\n'
+        'older than TLS 1.3 and any cipher suite not listed in [approved ciphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)\n'
+        'SHALL be rejected by the operator in a FIPS-compliant configuration.\n'
         '\n'
         '\n'
     ),
@@ -143,136 +128,114 @@ RQ_SRS_026_ClickHouseOperator_FIPS_TLS_RejectedCiphers = Requirement(
     num='4.2.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_FIPSConfig = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.FIPSConfig',
+RQ_SRS_026_ClickHouseOperator_FIPS_CH_FIPSConfig = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Deploying a CHI with FIPS TLS settings SHALL start ClickHouse with FIPS-compliant TLS configuration.\n'
+        'Operator deploying a `ClickHouseInstallation` with FIPS TLS OpenSSL settings SHALL start a FIPS-compliant ClickHouse server and client.\n'
+        '\n'
+        '```yaml\n'
+        '  configuration:\n'
+        '    clusters:\n'
+        '      - name: default\n'
+        '        secure: "yes"\n'
+        '        insecure: "no"\n'
+        '        layout:\n'
+        '          shardsCount: 1\n'
+        '          replicasCount: 2\n'
+        '    zookeeper:\n'
+        '      nodes:\n'
+        '        - host: chk-test-030003-keeper-0-0\n'
+        '          port: 2281\n'
+        '          secure: "yes"\n'
+        '    settings:\n'
+        '      http_port: _removed_\n'
+        '      tcp_port: _removed_\n'
+        '      interserver_http_port: _removed_\n'
+        '      mysql_port: _removed_\n'
+        '      postgresql_port: _removed_\n'
+        '      https_port: 8443\n'
+        '      tcp_port_secure: 9440\n'
+        '      interserver_https_port: 9010\n'
+        '    files:\n'
+        '      openssl.xml: |\n'
+        '        <yandex>\n'
+        '          <openSSL>\n'
+        '            <server>\n'
+        '              <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>\n'
+        '              <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>\n'
+        '              <dhParamsFile>/etc/clickhouse-server/secrets.d/dhparam.pem/clickhouse-certs/dhparam.pem</dhParamsFile>\n'
+        '              <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->\n'
+        '              <verificationMode>none</verificationMode>\n'
+        '              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>\n'
+        '              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>\n'
+        '            </server>\n'
+        '            <client>\n'
+        '              <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>\n'
+        '              <loadDefaultCAFile>false</loadDefaultCAFile>\n'
+        '              <verificationMode>strict</verificationMode>\n'
+        '              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>\n'
+        '              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>\n'
+        '            </client>\n'
+        '          </openSSL>\n'
+        '        </yandex>\n'
+        '```\n'
+        '\n'
+        'The deployed ClickHouse server SHALL use only the following ports:\n'
+        '\n'
+        '* HTTPS API port 8443 (instead of 8123)\n'
+        '* Secure native TCP port 9440 (instead of 9000)\n'
+        '* Interserver HTTPS port 9010 (instead of interserver HTTP port 9009)\n'
+        '* Backup sidecar HTTPS API port 7171 (instead of 7180), when backups are enabled\n'
+        '\n'
+        'Each exposed port SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='5.1.1'
+    num='5.2.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHIDeploy = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHIDeploy',
+RQ_SRS_026_ClickHouseOperator_FIPS_CH_FIPSConfig_ExternalClient = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'The operator SHALL deploy FIPS `ClickHouseInstallation` resources to `Completed` with Running pods when configuration is valid.\n'
+        'External clients connecting to the ClickHouse server SHALL be able to use any enabled TLS protocol version, including TLS 1.2.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='5.1.2'
+    num='5.2.2'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoPlainHTTP = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainHTTP',
+RQ_SRS_026_ClickHouseOperator_FIPS_CH_Rescale = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.Rescale',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'When FIPS transport hardening applies, ClickHouse pods SHALL NOT listen on plain HTTP port 8123; HTTPS port 8443 SHALL be used.\n'
+        'Adding or removing a replica from a FIPS-configured `ClickHouseInstallation` SHALL reconcile successfully and result in the expected number of running pods.\n'
+        '\n'
+        'After rescaling, all replicas SHALL continue to run the FIPS ClickHouse binary and maintain the configured TLS-only OpenSSL settings.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='5.1.3'
+    num='5.2.3'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoPlainNative = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainNative',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'When FIPS transport hardening applies, ClickHouse pods SHALL NOT listen on plain native TCP port 9000; secure native port 9440 SHALL be used.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.1.4'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoUnexpectedPorts = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoUnexpectedPorts',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'ClickHouse pods in a FIPS deployment SHALL expose only expected secure listener ports and no additional unexpected ports.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.1.5'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_InternodeTLS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.InternodeTLS',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'ReplicatedMergeTree replicas SHALL communicate over interserver HTTPS (`interserver_https_port`) and data SHALL converge across replicas.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.1.6'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ScaleUp = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleUp',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Adding a replica to a FIPS-configured CHI SHALL reconcile to `Completed` and the new replica SHALL run the FIPS ClickHouse binary with TLS-only listeners.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.1.7'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ScaleDown = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleDown',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Removing a replica from a FIPS-configured CHI SHALL reconcile to `Completed` and remaining replicas SHALL keep FIPS binary and TLS-only configuration.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.1.8'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ConfigUpdate = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ConfigUpdate',
+RQ_SRS_026_ClickHouseOperator_FIPS_CH_ConfigUpdate = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.ConfigUpdate',
     version='1.0',
     priority=None,
     group=None,
@@ -285,309 +248,186 @@ RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ConfigUpdate = Requirement(
     ),
     link=None,
     level=3,
-    num='5.1.9'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_FIPSConfig = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.FIPSConfig',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Deploying a CHK with FIPS TLS settings SHALL start Keeper with FIPS-compliant TLS configuration.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.2.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHKDeploy = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHKDeploy',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The operator SHALL deploy FIPS `ClickHouseKeeperInstallation` resources to `Completed` with Running pods when configuration is valid.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.2.2'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_NoPlainClientPort = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoPlainClientPort',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'When FIPS transport hardening applies, Keeper pods SHALL NOT listen on plain client port 2181; secure client port 2281 SHALL be used.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.2.3'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_NoUnexpectedPorts = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoUnexpectedPorts',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Keeper pods in a FIPS deployment SHALL expose only expected secure listener ports.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
     num='5.2.4'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_RaftTLS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.RaftTLS',
+RQ_SRS_026_ClickHouseOperator_FIPS_CHK_FIPSConfig = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.CHK.FIPSConfig',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Keeper Raft communication SHALL use TLS on the configured secure Raft port.\n'
+        'Operator deploying a `ClickHouseKeeperInstallation` with FIPS TLS OpenSSL settings SHALL start a FIPS-compliant ClickHouse\n'
+        'Keeper server and client.\n'
+        '\n'
+        '```yaml\n'
+        '  configuration:\n'
+        '    clusters:\n'
+        '      - name: keeper\n'
+        '        secure: "yes"\n'
+        '        insecure: "no"\n'
+        '        layout:\n'
+        '          replicasCount: 2\n'
+        '    settings:\n'
+        '      keeper_server/log_storage_path: /var/lib/clickhouse/coordination/log\n'
+        '      keeper_server/snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots\n'
+        '      keeper_server/raft_configuration/server/port: 9444\n'
+        '    files:\n'
+        '      openssl.xml: |\n'
+        '        <clickhouse>\n'
+        '          <openSSL>\n'
+        '              <server>\n'
+        '                <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>\n'
+        '                <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>\n'
+        '                <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->\n'
+        '                <verificationMode>none</verificationMode>\n'
+        '                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>\n'
+        '                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>\n'
+        '              </server>\n'
+        '              <client>\n'
+        '                <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>\n'
+        '                <loadDefaultCAFile>false</loadDefaultCAFile>\n'
+        '                <verificationMode>strict</verificationMode>\n'
+        '                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>\n'
+        '                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>\n'
+        '              </client>\n'
+        '          </openSSL>\n'
+        '        </clickhouse>\n'
+        '```\n'
+        '\n'
+        'The deployed ClickHouse Keeper cluster SHALL use only the following ports:\n'
+        '\n'
+        '* Secure client port 2281 (instead of 2181)\n'
+        '* Secure Raft communication port 9444\n'
+        '* Plaintext HTTP readiness probe port 9182 (the `/ready` Raft-quorum health check)\n'
+        '\n'
+        'Every exposed port except the readiness probe port 9182 and Raft replication port 9444 (which enforces peer-only authentication)\n'
+        'SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites. Port 9182 SHALL stay \n'
+        'unconditionally plaintext HTTP regardless of the secure/insecure configuration (see Boundary).\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='5.2.5'
+    num='6.2.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ScaleUp = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleUp',
+RQ_SRS_026_ClickHouseOperator_FIPS_CHK_Rescale = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.CHK.Rescale',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Adding a node to a FIPS-configured Keeper cluster SHALL reconcile to `Completed` and the new node SHALL run the FIPS Keeper binary with TLS-only client and Raft listeners.\n'
+        'Adding or removing a node from a FIPS-configured `ClickHouseKeeperInstallation` SHALL reconcile successfully and result \n'
+        'in the expected number of running pods.\n'
+        '\n'
+        'After rescaling, all Keeper nodes SHALL continue to run the FIPS ClickHouse Keeper binary and maintain the configured \n'
+        'TLS-only OpenSSL settings.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='5.2.6'
+    num='6.2.2'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ScaleDown = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleDown',
+RQ_SRS_026_ClickHouseOperator_FIPS_CHK_ConfigUpdate = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.CHK.ConfigUpdate',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Removing a node from a FIPS-configured Keeper cluster SHALL reconcile to `Completed` and remaining nodes SHALL keep FIPS configuration.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.2.7'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ConfigUpdate = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ConfigUpdate',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Updating TLS settings on a running CHK SHALL reload Keeper with the new FIPS-compliant configuration.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.2.8'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_VersionString = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.VersionString',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'A running ClickHouse host under FIPS image policy SHALL report a `version()` string containing `fips` (case-insensitive).\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.3.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_FIPSBinary = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.FIPSBinary',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The `clickhouse-backup` sidecar SHALL run a FIPS-built binary; `clickhouse-backup --version` SHALL contain `fips` (case-insensitive).\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.3.2'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_GOFIPS140 = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.GOFIPS140',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'When inspectable, the clickhouse-backup sidecar binary SHALL embed `GOFIPS140=v1.0.0` per `go version -m`.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.3.3'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_OnlyTLSPorts = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.OnlyTLSPorts',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The clickhouse-backup sidecar SHALL expose only secure listener ports (including HTTPS API port 7171).\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.3.4'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_HTTPSAPI = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.HTTPSAPI',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The clickhouse-backup HTTPS API SHALL serve over TLS with CA-trust enforcement: trusted clients accepted, untrusted clients rejected.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.3.5'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_ClickHouseOverTLS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.ClickHouseOverTLS',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The clickhouse-backup sidecar SHALL reach ClickHouse over secure native TCP.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.3.6'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_RestoreRoundTrip = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RestoreRoundTrip',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Backup and restore through the HTTPS API SHALL succeed over TLS.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='5.3.7'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_RemoteUploadTLS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RemoteUploadTLS',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Remote backup upload to object storage SHALL use FIPS-approved TLS.\n'
+        'Updating TLS settings on a running CHK SHALL reload ClickHouse with the new FIPS-compliant configuration.\n'
         '\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='5.3.8'
+    num='6.2.3'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceVerifyStrict = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceVerifyStrict',
+RQ_SRS_026_ClickHouseOperator_FIPS_Backup_FIPSBinary = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSBinary',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'With `fips.enforced=true`, unset TLS verify SHALL be coerced to Strict for ClickHouse, ZooKeeper/Keeper, and Kubernetes clients.\n'
+        'The `clickhouse-backup` sidecar SHALL run a FIPS-built binary.\n'
+        '\n'
+        'The sidecar binary SHALL satisfy all of the following:\n'
+        '\n'
+        '* `clickhouse-backup --version` contains `fips`\n'
+        '* When inspectable, `go version -m` reports `GOFIPS140=v1.0.0`\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='6.1.1'
+    num='7.2.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceMinVersion13 = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceMinVersion13',
+RQ_SRS_026_ClickHouseOperator_FIPS_Backup_FIPSConfig = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSConfig',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'With `fips.enforced=true`, unset TLS minVersion SHALL be coerced to 1.3 for the\n'
-        "operator's outbound TLS clients.\n"
+        'Deploying a `ClickHouseInstallation` with a FIPS-configured backup sidecar SHALL start `clickhouse-backup` with a FIPS-compliant TLS configuration.\n'
+        '\n'
+        'The deployed backup sidecar SHALL only add the following listener ports to the ClickHouse container:\n'
+        '\n'
+        '* HTTPS API port 7171 (instead of 7180)\n'
+        '\n'
+        'The FIPS-configured backup sidecar SHALL additionally satisfy all of the following:\n'
+        '\n'
+        '* Each exposed port SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites.\n'
+        '* The `clickhouse-backup` sidecar SHALL connect to ClickHouse using secure native TCP with TLS enabled.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='6.1.2'
+    num='7.2.2'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_OverrideMinVersion12To13 = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.OverrideMinVersion12To13',
+RQ_SRS_026_ClickHouseOperator_FIPS_Backup_RestoreRoundTrip = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Backup.RestoreRoundTrip',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL coerce `minVersion` to `"1.3"` for `security.clickhouse.tls`, `security.zookeeper.tls`, and `security.kubernetes.tls`, even when those fields are explicitly set to `"1.2"`.\n'
+        'Creating a backup and restoring it through the HTTPS API SHALL succeed over TLS.\n'
+        '\n'
+    ),
+    link=None,
+    level=3,
+    num='7.2.3'
+)
+
+RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_SecurityCoercion = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.SecurityCoercion',
+    version='1.0',
+    priority=None,
+    group=None,
+    type=None,
+    uid=None,
+    description=(
+        'When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL coerce unset or relaxed security settings as follows:\n'
+        '\n'
+        '* Unset TLS verify SHALL be coerced to Strict for ClickHouse, ZooKeeper/Keeper, and Kubernetes clients.\n'
+        '* Unset TLS `minVersion` SHALL be coerced to `"1.3"` for the operator\'s outbound TLS clients (`security.clickhouse.tls`, `security.zookeeper.tls`, and `security.kubernetes.tls`).\n'
+        '* Explicit `minVersion: "1.2"` for those TLS clients SHALL be coerced to `"1.3"`.\n'
+        '* Unset IPC mode SHALL be coerced to Secure.\n'
+        '\n'
+        'Example configuration with explicit `minVersion: "1.2"`:\n'
         '\n'
         '```yaml\n'
         'spec:\n'
@@ -605,124 +445,35 @@ RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_OverrideMinVersion12To13 = Requireme
         '        minVersion: "1.2"\n'
         '```\n'
         '\n'
-        'After operator configuration normalization, the effective `minVersion` for each component listed above SHALL be `"1.3"`.\n'
+        'After operator configuration normalization, the effective `minVersion` for each TLS client listed above SHALL be `"1.3"`.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='6.1.3'
+    num='8.1.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceIPCSecure = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceIPCSecure',
+RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectNonCompliantSpecs = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectNonCompliantSpecs',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'With `fips.enforced=true`, unset IPC mode SHALL be coerced to Secure.\n'
+        'When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL reject \n'
+        'non-compliant CHI and CHK specifications with `FIPSValidationFailed` and SHALL NOT create workload StatefulSets for:\n'
+        '\n'
+        '* CHI referencing plain external ZooKeeper nodes, including when `secure` is explicitly set to `"false"`.\n'
+        '* CHI with `clickhouse.tls.verify=None` at spec or cluster level.\n'
+        '* CHI with `zookeeper.tls.verify=None`.\n'
+        '* CHI with invalid `clickhouse.tls.minVersion`.\n'
+        '* CHK with TLS verify bypass at spec level.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='6.1.4'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectInsecureKubeconfig = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInsecureKubeconfig',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The operator SHALL refuse to start when kubeconfig uses `TLSClientConfig.Insecure=true` under strict/FIPS mode.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.1.5'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectVerifyNoneCHI = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneCHI',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'CHI with `clickhouse.tls.verify=None` under enforced mode SHALL be rejected with `FIPSValidationFailed`.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.1.6'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectVerifyNoneZK = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneZK',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'CHI with `zookeeper.tls.verify=None` under enforced mode SHALL be rejected.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.1.7'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectInvalidMinVersion = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInvalidMinVersion',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'CHI with invalid TLS minVersion under enforced mode SHALL be rejected.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.1.8'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectExternalZookeeper = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectExternalZookeeper',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'CHI referencing plain external ZooKeeper nodes under enforced mode SHALL be rejected.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.1.9'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectCHKBypass = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectCHKBypass',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'CHK with TLS verify bypass under enforced mode SHALL be rejected.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.1.10'
+    num='8.1.2'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_MinVersionScope = Requirement(
@@ -734,224 +485,71 @@ RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_MinVersionScope = Requirement(
     uid=None,
     description=(
         'The `minVersion` coercion SHALL apply only to TLS clients created and managed by the operator.\n'
-        'They SHALL NOT require ClickHouse Server or ClickHouse Keeper listener endpoints to reject TLS 1.2.\n'
+        'They SHALL NOT require ClickHouse Server or ClickHouse Keeper listener endpoints to reject TLS 1.2\n'
+        '(see [RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient](#rqsrs-026clickhouseoperatorfipschfipsconfigexternalclient)).\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='6.1.11'
+    num='8.1.3'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectCHI = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHI',
+RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectNonFIPS = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectNonFIPS',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'With `security.fips.images.policy=Required`, CHI with non-FIPS image tag SHALL be rejected with `FIPSImagePolicyViolation`.\n'
+        'With `security.fips.images.policy=Required`, non-FIPS images SHALL be rejected with `FIPSImagePolicyViolation` as follows:\n'
+        '\n'
+        '* CHI with non-FIPS ClickHouse image tag SHALL be rejected at admission.\n'
+        '* CHK with non-FIPS Keeper image tag SHALL be rejected at admission.\n'
+        '* CHI with non-FIPS `clickhouse-backup` sidecar image tag SHALL be rejected at admission.\n'
+        '* CHI with multiple non-FIPS hosts SHALL produce a single policy violation error.\n'
+        '* Digest-only image references SHALL NOT be detected as FIPS at admission.\n'
+        '* Registry hostname containing `fips` SHALL NOT satisfy FIPS tag detection.\n'
+        '* CHI admitted with a FIPS-tagged ClickHouse image whose running binary lacks `fips` in `SELECT version()` SHALL fail at runtime.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='6.2.1'
+    num='8.2.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_AcceptCHI = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.AcceptCHI',
+RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_KubernetesAPI = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KubernetesAPI',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'With image policy Required, CHI with FIPS-tagged image SHALL reconcile normally.\n'
+        'The clickhouse-operator SHALL access the Kubernetes API through the HTTPS endpoint on port `443`.\n'
+        'Plain HTTP requests to the Kubernetes API endpoint SHALL be rejected.\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='6.2.2'
+    level=2,
+    num='9.1'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectCHK = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHK',
+RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_KubernetesAPI = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.KubernetesAPI',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'With image policy Required, CHK with non-FIPS Keeper image SHALL be rejected.\n'
+        'The metrics-exporter SHALL access the Kubernetes API through the HTTPS endpoint on port `443`.\n'
+        'Plain HTTP requests to the Kubernetes API endpoint SHALL be rejected.\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='6.2.3'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RuntimeVersion = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RuntimeVersion',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'With image policy Required, host `SELECT version()` lacking `fips` SHALL fail with `FIPSImagePolicyViolation`.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.2.4'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_Permissive = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Permissive',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'With permissive image policy, non-FIPS CHI images SHALL reconcile (default).\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.2.5'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_ShortCircuit = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.ShortCircuit',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Multiple non-FIPS hosts SHALL produce a single policy violation error.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.2.6'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_FIPSSuffix = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.FIPSSuffix',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Image tags containing `fips` (case-insensitive) SHALL be detected as FIPS.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.3.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_AltinityFIPS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.AltinityFIPS',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Image tags containing `altinityfips` SHALL be detected as FIPS.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.3.2'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_DigestOnly = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.DigestOnly',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Digest-only image references SHALL NOT be detected as FIPS at admission.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.3.3'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_RegistryPath = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.RegistryPath',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Registry hostname containing `fips` SHALL NOT satisfy FIPS tag detection.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.3.4'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_CaseInsensitive = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.CaseInsensitive',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Image tags such as `25.3.FIPS` or `25.3.Fips` SHALL be detected as FIPS (case-insensitive match on the tag).\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='6.3.5'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_Listeners = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Listeners',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'FIPS workload pods (ClickHouse, Keeper, and sidecar containers) SHALL listen only on expected TLS ports. Plaintext service ports (8123, 9000, 2181) SHALL NOT be open when FIPS transport hardening applies.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='7.1.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_Kubernetes = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Kubernetes',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The operator SHALL connect to the Kubernetes API using FIPS-approved TLS ciphers.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='7.2.1'
+    level=2,
+    num='9.2'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_ClickHouse = Requirement(
@@ -962,98 +560,12 @@ RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_ClickHouse = Requirement(
     type=None,
     uid=None,
     description=(
-        'The operator SHALL connect to ClickHouse using FIPS-approved TLS ciphers.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='7.3.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_Zookeeper = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Zookeeper',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The operator SHALL connect to ZooKeeper/Keeper using FIPS-approved TLS ciphers.\n'
-        '\n'
+        'The clickhouse-operator SHALL communicate with ClickHouse hosts using HTTPS port `8443`.\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='7.4.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_IPCSecure = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.IPCSecure',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Operator IPC with `security.ipc.mode=Secure` SHALL work over localhost HTTP with token auth.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='7.5.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Gap_OperatorMetricsTLS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Gap.OperatorMetricsTLS',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Operator Prometheus metrics on :9999 currently expose a known FIPS gap (HTTP-only).\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='7.6.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_Listeners = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Listeners',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The metrics-exporter process SHALL expose only expected listener ports on `:8888`. Sidecar containers in the same pod SHALL be listener-audited with the same `/proc/net/tcp` procedure.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='8.1.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_Kubernetes = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Kubernetes',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The exporter SHALL connect to the Kubernetes API using FIPS-approved TLS ciphers.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='8.2.1'
+    level=2,
+    num='9.3'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_ClickHouse = Requirement(
@@ -1064,64 +576,65 @@ RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_ClickHouse = Requirement(
     type=None,
     uid=None,
     description=(
-        'The exporter SHALL query ClickHouse using FIPS-approved TLS when configured for HTTPS.\n'
-        '\n'
+        'The metrics-exporter SHALL discover ClickHouse hosts using the HTTPS endpoint `8443`.\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='8.3.1'
+    level=2,
+    num='9.4'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Gap_ExporterMetricsTLS = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Gap.ExporterMetricsTLS',
+RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_KeeperRestriction = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KeeperRestriction',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Exporter Prometheus metrics on :8888 currently expose a known FIPS gap (HTTP-only).\n'
-        '\n'
+        'When a Keeper ensemble is configured as TLS-only, the clickhouse-operator SHALL NOT attempt plaintext ZooKeeper/Keeper\n'
+        'operations against it.\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='8.4.1'
+    level=2,
+    num='9.5'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Integrity_OperatorMismatch = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.OperatorMismatch',
+RQ_SRS_026_ClickHouseOperator_FIPS_Connect_ClickHouse_KeeperTLS = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.ClickHouse.KeeperTLS',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Tampering with `clickhouse-operator` `.go.fipsinfo` SHALL panic with `fips140: verification mismatch`.\n'
+        'ClickHouse replicas SHALL connect to Keeper using secure client port `2281` with `secure=yes`.\n'
         '\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='9.1.1'
+    level=2,
+    num='9.6'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_Integrity_ExporterMismatch = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.ExporterMismatch',
+RQ_SRS_026_ClickHouseOperator_FIPS_Integrity_VerificationMismatch = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.VerificationMismatch',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        'Tampering with `metrics-exporter` `.go.fipsinfo` SHALL panic with `fips140: verification mismatch`.\n'
-        '\n'
+        'Each shipped FIPS binary — `clickhouse-operator` and `metrics-exporter` — SHALL perform a software integrity \n'
+        'self-test at initialization by verifying its embedded HMAC. If the binary is tampered with or corrupted such that\n'
+        'the HMAC verification fails, the process SHALL immediately terminate with a `fips140: verification mismatch` panic \n'
+        'to prevent the execution of a compromised cryptographic module.\n'
         '\n'
     ),
     link=None,
-    level=3,
-    num='9.2.1'
+    level=2,
+    num='10.1'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_CAST_OperatorFail = Requirement(
@@ -1138,7 +651,7 @@ RQ_SRS_026_ClickHouseOperator_FIPS_CAST_OperatorFail = Requirement(
     ),
     link=None,
     level=3,
-    num='10.1.1'
+    num='11.1.1'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_CAST_ExporterFail = Requirement(
@@ -1155,206 +668,7 @@ RQ_SRS_026_ClickHouseOperator_FIPS_CAST_ExporterFail = Requirement(
     ),
     link=None,
     level=3,
-    num='10.2.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Synthetic_ApprovedCiphers = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.ApprovedCiphers',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'For each external connection listed below, when exercised as a TLS **client** with `openssl s_server` offering only [approved ciphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers), or as a TLS **server** with `openssl s_client` using only approved ciphers, the connection SHALL succeed:\n'
-        '\n'
-        '| Connection | Role | Tool |\n'
-        '|------------|------|------|\n'
-        '| Operator to Kubernetes API | Client | `openssl s_server` |\n'
-        '| Operator to ClickHouse Server | Client | `openssl s_server` |\n'
-        '| Operator to ZooKeeper/Keeper | Client | `openssl s_server` |\n'
-        '| Operator metrics :9999 | Server | `openssl s_client` |\n'
-        '| Exporter to Kubernetes API | Client | `openssl s_server` |\n'
-        '| Exporter to ClickHouse Server | Client | `openssl s_server` |\n'
-        '| Exporter metrics :8888 | Server | `openssl s_client` |\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='11.1.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_Synthetic_RejectedCiphers = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.RejectedCiphers',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'For each external connection listed below, when the peer offers only [rejected ciphers or protocols](#rqsrs-026clickhouseoperatorfipstlsrejectedciphers), the connection SHALL be rejected:\n'
-        '\n'
-        '| Connection | Role | Tool |\n'
-        '|------------|------|------|\n'
-        '| Operator to Kubernetes API | Client | `openssl s_server` |\n'
-        '| Operator to ClickHouse Server | Client | `openssl s_server` |\n'
-        '| Operator to ZooKeeper/Keeper | Client | `openssl s_server` |\n'
-        '| Operator metrics :9999 | Server | `openssl s_client` |\n'
-        '| Exporter to Kubernetes API | Client | `openssl s_server` |\n'
-        '| Exporter to ClickHouse Server | Client | `openssl s_server` |\n'
-        '| Exporter metrics :8888 | Server | `openssl s_client` |\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
     num='11.2.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_CICD_OperatorImageBuild = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.CICD.OperatorImageBuild',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'CI SHALL build the [clickhouse-operator] FIPS image successfully.\n'
-        '\n'
-    ),
-    link=None,
-    level=2,
-    num='12.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_CICD_ExporterImageBuild = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.CICD.ExporterImageBuild',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'CI SHALL build the [metrics-exporter] FIPS image successfully.\n'
-        '\n'
-    ),
-    link=None,
-    level=2,
-    num='12.2'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_CICD_VulnerabilityScan = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.CICD.VulnerabilityScan',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'FIPS images SHALL pass vulnerability scanning with no Critical, High, or Medium findings.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=2,
-    num='12.3'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Operator_Tree = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.Tree',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Static review of operator-scoped paths SHALL produce no Critical findings; Warning-level findings SHALL be documented.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='12.4.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Operator_SharedPkg = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.SharedPkg',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Review of shared packages reachable from `cmd/operator` SHALL produce no Critical findings.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='12.4.2'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Operator_RegressionGate = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.RegressionGate',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'A signed-off review artifact SHALL be stored with the build record before release.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='12.4.3'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Exporter_Tree = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.Tree',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Static review of exporter-scoped paths SHALL produce no Critical findings; Warning-level findings SHALL be documented.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='12.5.1'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Exporter_SharedPkg = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.SharedPkg',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'Review of shared packages reachable from `cmd/metrics_exporter` SHALL produce no Critical findings.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='12.5.2'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Exporter_RegressionGate = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.RegressionGate',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'A signed-off review artifact SHALL be stored with the build record before release.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='12.5.3'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_WrapperIntegration = Requirement(
@@ -1365,12 +679,12 @@ RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_WrapperIntegration = Requiremen
     type=None,
     uid=None,
     description=(
-        'Building clickhouse-operator with `-tags acvp_wrapper` SHALL expose a working ACVP responder via argv0 dispatch.\n'
+        'Building `clickhouse-operator` with `-tags acvp_wrapper` SHALL produce a binary whose ACVP responder is reachable through argv0 dispatch when executed as `clickhouse-operator-acvp`.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='13.1.1'
+    num='12.1.1'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_ConfigGeneration = Requirement(
@@ -1381,45 +695,28 @@ RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_ConfigGeneration = Requirement(
     type=None,
     uid=None,
     description=(
-        'The clickhouse-operator ACVP responder SHALL answer `getConfig` with supported capabilities.\n'
+        'The `clickhouse-operator` ACVP responder SHALL answer a `getConfig` request successfully. The returned payload SHALL be valid JSON, SHALL advertise `SHA2-256` and `ACVP-AES-GCM`, and SHALL NOT advertise `ML-KEM` or `ML-DSA`.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='13.1.2'
+    num='12.1.2'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_ExpectedOutputReplay = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ExpectedOutputReplay',
+RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_SHA2256AFT = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SHA2256AFT',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        '`bash pkg/util/fips/acvp/run.sh` SHALL match all configured expected outputs for the operator.\n'
+        'The `clickhouse-operator` ACVP responder SHALL answer a `SHA2-256` algorithm functional test request for input `abc` with the digest matching `hashlib.sha256(b"abc").digest()`.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='13.1.3'
-)
-
-RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_SuiteCount = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SuiteCount',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The tracked ACVP config SHALL report 38 matched expectations for clickhouse-operator.\n'
-        '\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='13.1.4'
+    num='12.1.3'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_WrapperIntegration = Requirement(
@@ -1430,12 +727,12 @@ RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_WrapperIntegration = Requiremen
     type=None,
     uid=None,
     description=(
-        'Building metrics-exporter with `-tags acvp_wrapper` SHALL expose a working ACVP responder.\n'
+        'Building `metrics-exporter` with `-tags acvp_wrapper` SHALL produce a binary whose ACVP responder is reachable through argv0 dispatch when executed as `metrics-exporter-acvp`.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='13.2.1'
+    num='12.2.1'
 )
 
 RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_ConfigGeneration = Requirement(
@@ -1446,51 +743,36 @@ RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_ConfigGeneration = Requirement(
     type=None,
     uid=None,
     description=(
-        'The metrics-exporter ACVP responder SHALL answer `getConfig` with supported capabilities.\n'
+        'The `metrics-exporter` ACVP responder SHALL answer a `getConfig` request successfully. The returned payload SHALL be valid JSON, SHALL advertise `SHA2-256` and `ACVP-AES-GCM`, and SHALL NOT advertise `ML-KEM` or `ML-DSA`.\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='13.2.2'
+    num='12.2.2'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_ExpectedOutputReplay = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ExpectedOutputReplay',
+RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_SHA2256AFT = Requirement(
+    name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SHA2256AFT',
     version='1.0',
     priority=None,
     group=None,
     type=None,
     uid=None,
     description=(
-        '`BINARY=metrics-exporter bash pkg/util/fips/acvp/run.sh` SHALL match all expected outputs.\n'
+        'The `metrics-exporter` ACVP responder SHALL answer a `SHA2-256` algorithm functional test request for input `abc` with the digest matching `hashlib.sha256(b"abc").digest()`.\n'
+        '\n'
         '\n'
     ),
     link=None,
     level=3,
-    num='13.2.3'
+    num='12.2.3'
 )
 
-RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_SuiteCount = Requirement(
-    name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SuiteCount',
-    version='1.0',
-    priority=None,
-    group=None,
-    type=None,
-    uid=None,
-    description=(
-        'The tracked ACVP config SHALL report 38 matched expectations for metrics-exporter.\n'
-        '\n'
-    ),
-    link=None,
-    level=3,
-    num='13.2.4'
-)
-
-Inbound_connection_to_operator_exporter_metrics_endpoint = Specification(
-    name='Inbound connection to operator/exporter metrics endpoint',
+QA_SRS_ClickHouse_Operator_FIPS_140_3 = Specification(
+    name='QA-SRS ClickHouse Operator FIPS 140-3',
     description=None,
-    author=None,
-    date=None,
+    author='Saba Momtselidze',
+    date='June 12, 2026',
     status=None,
     approved_by=None,
     approved_date=None,
@@ -1505,228 +787,104 @@ Inbound_connection_to_operator_exporter_metrics_endpoint = Specification(
     headings=(
         Heading(name='Introduction', level=1, num='1'),
         Heading(name='Configuration Requirements', level=1, num='2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Config.ExternalTLS', level=2, num='2.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.HTTPPorts', level=2, num='2.1'),
         Heading(name='Build Verification', level=1, num='3'),
-        Heading(name='Shipped Binaries', level=2, num='3.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries', level=3, num='3.1.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.StartupLogs', level=3, num='3.1.2'),
-        Heading(name='Approved TLS Cipher Suites', level=1, num='4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers', level=2, num='4.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries', level=2, num='3.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries.StartupLogs', level=2, num='3.2'),
+        Heading(name='FIPS 140-3 TLS Cipher Suites', level=1, num='4'),
+        Heading(name='Approved TLS Cipher Suites', level=2, num='4.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers', level=3, num='4.1.1'),
         Heading(name='Rejected Cipher Suites and Protocols', level=2, num='4.2'),
         Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.TLS.RejectedCiphers', level=3, num='4.2.1'),
-        Heading(name='ClickHouse Server and Keeper FIPS Configurations', level=1, num='5'),
-        Heading(name='ClickHouse Server', level=2, num='5.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.FIPSConfig', level=3, num='5.1.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHIDeploy', level=3, num='5.1.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainHTTP', level=3, num='5.1.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainNative', level=3, num='5.1.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoUnexpectedPorts', level=3, num='5.1.5'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.InternodeTLS', level=3, num='5.1.6'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleUp', level=3, num='5.1.7'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleDown', level=3, num='5.1.8'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ConfigUpdate', level=3, num='5.1.9'),
-        Heading(name='ClickHouse Keeper', level=2, num='5.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.FIPSConfig', level=3, num='5.2.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHKDeploy', level=3, num='5.2.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoPlainClientPort', level=3, num='5.2.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoUnexpectedPorts', level=3, num='5.2.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.RaftTLS', level=3, num='5.2.5'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleUp', level=3, num='5.2.6'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleDown', level=3, num='5.2.7'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ConfigUpdate', level=3, num='5.2.8'),
-        Heading(name='ClickHouse Backup Sidecar', level=2, num='5.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.VersionString', level=3, num='5.3.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.FIPSBinary', level=3, num='5.3.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.GOFIPS140', level=3, num='5.3.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.OnlyTLSPorts', level=3, num='5.3.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.HTTPSAPI', level=3, num='5.3.5'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.ClickHouseOverTLS', level=3, num='5.3.6'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RestoreRoundTrip', level=3, num='5.3.7'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RemoteUploadTLS', level=3, num='5.3.8'),
-        Heading(name='FIPS Enforcement Mode', level=1, num='6'),
-        Heading(name='Security Coercion', level=2, num='6.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceVerifyStrict', level=3, num='6.1.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceMinVersion13', level=3, num='6.1.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.OverrideMinVersion12To13', level=3, num='6.1.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceIPCSecure', level=3, num='6.1.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInsecureKubeconfig', level=3, num='6.1.5'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneCHI', level=3, num='6.1.6'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneZK', level=3, num='6.1.7'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInvalidMinVersion', level=3, num='6.1.8'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectExternalZookeeper', level=3, num='6.1.9'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectCHKBypass', level=3, num='6.1.10'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.MinVersionScope', level=3, num='6.1.11'),
-        Heading(name='Image Policy', level=2, num='6.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHI', level=3, num='6.2.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.AcceptCHI', level=3, num='6.2.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHK', level=3, num='6.2.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RuntimeVersion', level=3, num='6.2.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Permissive', level=3, num='6.2.5'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.ShortCircuit', level=3, num='6.2.6'),
-        Heading(name='Image Tag Detection', level=2, num='6.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.FIPSSuffix', level=3, num='6.3.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.AltinityFIPS', level=3, num='6.3.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.DigestOnly', level=3, num='6.3.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.RegistryPath', level=3, num='6.3.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.CaseInsensitive', level=3, num='6.3.5'),
-        Heading(name='Operator External Connections', level=1, num='7'),
-        Heading(name='Operator Runtime Listener Verification', level=2, num='7.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Listeners', level=3, num='7.1.1'),
-        Heading(name='Operator to Kubernetes API', level=2, num='7.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Kubernetes', level=3, num='7.2.1'),
-        Heading(name='Operator to ClickHouse Server', level=2, num='7.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse', level=3, num='7.3.1'),
-        Heading(name='Operator to ZooKeeper/Keeper', level=2, num='7.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Zookeeper', level=3, num='7.4.1'),
-        Heading(name='Operator to metrics-exporter IPC', level=2, num='7.5'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.IPCSecure', level=3, num='7.5.1'),
-        Heading(name='Operator Prometheus Metrics', level=2, num='7.6'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Gap.OperatorMetricsTLS', level=3, num='7.6.1'),
-        Heading(name='Exporter External Connections', level=1, num='8'),
-        Heading(name='Exporter Runtime Listener Verification', level=2, num='8.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Listeners', level=3, num='8.1.1'),
-        Heading(name='Exporter to Kubernetes API', level=2, num='8.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Kubernetes', level=3, num='8.2.1'),
-        Heading(name='Exporter to ClickHouse Server', level=2, num='8.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse', level=3, num='8.3.1'),
-        Heading(name='Exporter Prometheus Metrics', level=2, num='8.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Gap.ExporterMetricsTLS', level=3, num='8.4.1'),
-        Heading(name='Integrity Check Failure', level=1, num='9'),
-        Heading(name='Operator Integrity Tampering', level=2, num='9.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.OperatorMismatch', level=3, num='9.1.1'),
-        Heading(name='Exporter Integrity Tampering', level=2, num='9.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.ExporterMismatch', level=3, num='9.2.1'),
-        Heading(name='CAST Failure', level=1, num='10'),
-        Heading(name='Operator CAST Failure', level=2, num='10.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CAST.OperatorFail', level=3, num='10.1.1'),
-        Heading(name='Exporter CAST Failure', level=2, num='10.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CAST.ExporterFail', level=3, num='10.2.1'),
-        Heading(name='Synthetic TLS Cipher Validation', level=1, num='11'),
-        Heading(name='Operator as TLS client against server offering non-approved cipher', level=0, num=''),
-        Heading(name='Approved cipher matrix', level=2, num='11.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.ApprovedCiphers', level=3, num='11.1.1'),
-        Heading(name='Rejected cipher matrix', level=2, num='11.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.RejectedCiphers', level=3, num='11.2.1'),
-        Heading(name='CI/CD Image and Policy Verification', level=1, num='12'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CICD.OperatorImageBuild', level=2, num='12.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CICD.ExporterImageBuild', level=2, num='12.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CICD.VulnerabilityScan', level=2, num='12.3'),
-        Heading(name='Operator Source Review', level=2, num='12.4'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.Tree', level=3, num='12.4.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.SharedPkg', level=3, num='12.4.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.RegressionGate', level=3, num='12.4.3'),
-        Heading(name='Exporter Source Review', level=2, num='12.5'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.Tree', level=3, num='12.5.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.SharedPkg', level=3, num='12.5.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.RegressionGate', level=3, num='12.5.3'),
-        Heading(name='ACVP Algorithm Validation', level=1, num='13'),
-        Heading(name='Operator ACVP Validation', level=2, num='13.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration', level=3, num='13.1.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration', level=3, num='13.1.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ExpectedOutputReplay', level=3, num='13.1.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SuiteCount', level=3, num='13.1.4'),
-        Heading(name='Exporter ACVP Validation', level=2, num='13.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration', level=3, num='13.2.1'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration', level=3, num='13.2.2'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ExpectedOutputReplay', level=3, num='13.2.3'),
-        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SuiteCount', level=3, num='13.2.4'),
-        Heading(name='Terminology', level=1, num='14'),
-        Heading(name='SRS', level=2, num='14.1'),
-        Heading(name='FIPS 140-3', level=2, num='14.2'),
-        Heading(name='clickhouse-operator', level=2, num='14.3'),
-        Heading(name='metrics-exporter', level=2, num='14.4'),
-        Heading(name='CHI', level=2, num='14.5'),
-        Heading(name='CHK', level=2, num='14.6'),
-        Heading(name='ACVP', level=2, num='14.7'),
-        Heading(name='CMVP', level=2, num='14.8'),
-        Heading(name='CAVP', level=2, num='14.9'),
+        Heading(name='ClickHouse Server', level=1, num='5'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig', level=3, num='5.2.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient', level=3, num='5.2.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.Rescale', level=3, num='5.2.3'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CH.ConfigUpdate', level=3, num='5.2.4'),
+        Heading(name='ClickHouse Keeper', level=1, num='6'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CHK.FIPSConfig', level=3, num='6.2.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CHK.Rescale', level=3, num='6.2.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CHK.ConfigUpdate', level=3, num='6.2.3'),
+        Heading(name='ClickHouse Backup Sidecar', level=1, num='7'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSBinary', level=3, num='7.2.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSConfig', level=3, num='7.2.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Backup.RestoreRoundTrip', level=3, num='7.2.3'),
+        Heading(name='FIPS Enforcement Mode', level=1, num='8'),
+        Heading(name='Security Coercion', level=2, num='8.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.SecurityCoercion', level=3, num='8.1.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectNonCompliantSpecs', level=3, num='8.1.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.MinVersionScope', level=3, num='8.1.3'),
+        Heading(name='Image Policy', level=2, num='8.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectNonFIPS', level=3, num='8.2.1'),
+        Heading(name='Runtime Connection Evidence', level=1, num='9'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KubernetesAPI', level=2, num='9.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.KubernetesAPI', level=2, num='9.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse', level=2, num='9.3'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse', level=2, num='9.4'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KeeperRestriction', level=2, num='9.5'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Connect.ClickHouse.KeeperTLS', level=2, num='9.6'),
+        Heading(name='Integrity Check', level=1, num='10'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.VerificationMismatch', level=2, num='10.1'),
+        Heading(name='CAST Failure', level=1, num='11'),
+        Heading(name='Operator CAST Failure', level=2, num='11.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CAST.OperatorFail', level=3, num='11.1.1'),
+        Heading(name='Exporter CAST Failure', level=2, num='11.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.CAST.ExporterFail', level=3, num='11.2.1'),
+        Heading(name='ACVP Algorithm Validation', level=1, num='12'),
+        Heading(name='Operator ACVP Validation', level=2, num='12.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration', level=3, num='12.1.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration', level=3, num='12.1.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SHA2256AFT', level=3, num='12.1.3'),
+        Heading(name='Exporter ACVP Validation', level=2, num='12.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration', level=3, num='12.2.1'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration', level=3, num='12.2.2'),
+        Heading(name='RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SHA2256AFT', level=3, num='12.2.3'),
+        Heading(name='Terminology', level=1, num='13'),
+        Heading(name='SRS', level=2, num='13.1'),
+        Heading(name='FIPS 140-3', level=2, num='13.2'),
+        Heading(name='clickhouse-operator', level=2, num='13.3'),
+        Heading(name='metrics-exporter', level=2, num='13.4'),
+        Heading(name='CHI', level=2, num='13.5'),
+        Heading(name='CHK', level=2, num='13.6'),
+        Heading(name='ACVP', level=2, num='13.7'),
+        Heading(name='CMVP', level=2, num='13.8'),
+        Heading(name='CAVP', level=2, num='13.9'),
         ),
     requirements=(
-        RQ_SRS_026_ClickHouseOperator_FIPS_Config_ExternalTLS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Build_ShippedBinaries,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Build_ShippedBinaries_StartupLogs,
+        RQ_SRS_026_ClickHouseOperator_FIPS_HTTPPorts,
+        RQ_SRS_026_ClickHouseOperator_FIPS_OperatorBuild_ShippedBinaries,
+        RQ_SRS_026_ClickHouseOperator_FIPS_OperatorBuild_ShippedBinaries_StartupLogs,
         RQ_SRS_026_ClickHouseOperator_FIPS_TLS_ApprovedCiphers,
         RQ_SRS_026_ClickHouseOperator_FIPS_TLS_RejectedCiphers,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_FIPSConfig,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHIDeploy,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoPlainHTTP,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoPlainNative,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_NoUnexpectedPorts,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_InternodeTLS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ScaleUp,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ScaleDown,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_ConfigUpdate,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_FIPSConfig,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHKDeploy,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_NoPlainClientPort,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_NoUnexpectedPorts,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_RaftTLS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ScaleUp,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ScaleDown,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CHK_ConfigUpdate,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_CH_VersionString,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_FIPSBinary,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_GOFIPS140,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_OnlyTLSPorts,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_HTTPSAPI,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_ClickHouseOverTLS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_RestoreRoundTrip,
-        RQ_SRS_026_ClickHouseOperator_FIPS_DataPlane_Backup_RemoteUploadTLS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceVerifyStrict,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceMinVersion13,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_OverrideMinVersion12To13,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_CoerceIPCSecure,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectInsecureKubeconfig,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectVerifyNoneCHI,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectVerifyNoneZK,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectInvalidMinVersion,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectExternalZookeeper,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectCHKBypass,
+        RQ_SRS_026_ClickHouseOperator_FIPS_CH_FIPSConfig,
+        RQ_SRS_026_ClickHouseOperator_FIPS_CH_FIPSConfig_ExternalClient,
+        RQ_SRS_026_ClickHouseOperator_FIPS_CH_Rescale,
+        RQ_SRS_026_ClickHouseOperator_FIPS_CH_ConfigUpdate,
+        RQ_SRS_026_ClickHouseOperator_FIPS_CHK_FIPSConfig,
+        RQ_SRS_026_ClickHouseOperator_FIPS_CHK_Rescale,
+        RQ_SRS_026_ClickHouseOperator_FIPS_CHK_ConfigUpdate,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Backup_FIPSBinary,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Backup_FIPSConfig,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Backup_RestoreRoundTrip,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_SecurityCoercion,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_RejectNonCompliantSpecs,
         RQ_SRS_026_ClickHouseOperator_FIPS_Enforced_MinVersionScope,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectCHI,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_AcceptCHI,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectCHK,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RuntimeVersion,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_Permissive,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_ShortCircuit,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_FIPSSuffix,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_AltinityFIPS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_DigestOnly,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_RegistryPath,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Images_TagDetection_CaseInsensitive,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_Listeners,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_Kubernetes,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Images_Required_RejectNonFIPS,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_KubernetesAPI,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_KubernetesAPI,
         RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_ClickHouse,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_Zookeeper,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_IPCSecure,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Gap_OperatorMetricsTLS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_Listeners,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_Kubernetes,
         RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Exporter_ClickHouse,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Gap_ExporterMetricsTLS,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Integrity_OperatorMismatch,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Integrity_ExporterMismatch,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_Operator_KeeperRestriction,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Connect_ClickHouse_KeeperTLS,
+        RQ_SRS_026_ClickHouseOperator_FIPS_Integrity_VerificationMismatch,
         RQ_SRS_026_ClickHouseOperator_FIPS_CAST_OperatorFail,
         RQ_SRS_026_ClickHouseOperator_FIPS_CAST_ExporterFail,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Synthetic_ApprovedCiphers,
-        RQ_SRS_026_ClickHouseOperator_FIPS_Synthetic_RejectedCiphers,
-        RQ_SRS_026_ClickHouseOperator_FIPS_CICD_OperatorImageBuild,
-        RQ_SRS_026_ClickHouseOperator_FIPS_CICD_ExporterImageBuild,
-        RQ_SRS_026_ClickHouseOperator_FIPS_CICD_VulnerabilityScan,
-        RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Operator_Tree,
-        RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Operator_SharedPkg,
-        RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Operator_RegressionGate,
-        RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Exporter_Tree,
-        RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Exporter_SharedPkg,
-        RQ_SRS_026_ClickHouseOperator_FIPS_AIReview_Exporter_RegressionGate,
         RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_WrapperIntegration,
         RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_ConfigGeneration,
-        RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_ExpectedOutputReplay,
-        RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_SuiteCount,
+        RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Operator_SHA2256AFT,
         RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_WrapperIntegration,
         RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_ConfigGeneration,
-        RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_ExpectedOutputReplay,
-        RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_SuiteCount,
+        RQ_SRS_026_ClickHouseOperator_FIPS_ACVP_Exporter_SHA2256AFT,
         ),
     content='''
 # QA-SRS ClickHouse Operator FIPS 140-3
@@ -1738,153 +896,74 @@ Inbound_connection_to_operator_exporter_metrics_endpoint = Specification(
 
 **Author:** Saba Momtselidze
 
-**Date:** May 29, 2026
+**Date:** June 12, 2026
 
 ## Table of Contents
 
 * 1 [Introduction](#introduction)
 * 2 [Configuration Requirements](#configuration-requirements)
-    * 2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Config.ExternalTLS](#rqsrs-026clickhouseoperatorfipsconfigexternaltls)
+    * 2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.HTTPPorts](#rqsrs-026clickhouseoperatorfipshttpports)
 * 3 [Build Verification](#build-verification)
-    * 3.1 [Shipped Binaries](#shipped-binaries)
-        * 3.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries](#rqsrs026clickhouseoperatorfipsbuildshippedbinaries)
-            * 3.1.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.GOFIPS140](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesgofips140)
-            * 3.1.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.FIPSIdentity](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesfipsidentity)
-            * 3.1.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.FIPSVersion](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesfipsversion)
-            * 3.1.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.FIPSEnabled](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesfipsenabled)
-            * 3.1.1.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.StartupBanner](#rqsrs026clickhouseoperatorfipsbuildshippedbinariesstartupbanner)
-* 4 [GODEBUG Strict Mode Smoke Test](#godebug-strict-mode-smoke-test)
-    * 4.1 [RQ.SRS-026.ClickHouseOperator.FIPS.GODEBUG.StrictMode](#rqsrs-026clickhouseoperatorfipsgodebugstrictmode)
-* 5 [FIPS 140-3 Valid TLS Cipher Suites](#fips-140-3-valid-tls-cipher-suites)
-    * 5.1 [Approved TLS Cipher Suites](#approved-tls-cipher-suites)
-        * 5.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
-    * 5.2 [Rejected Cipher Suites and Protocols](#rejected-cipher-suites-and-protocols)
-        * 5.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.RejectedCiphers](#rqsrs-026clickhouseoperatorfipstlsrejectedciphers)
-* 6 [ClickHouse Server and Keeper FIPS Configurations](#clickhouse-server-and-keeper-fips-configurations)
-    * 6.1 [ClickHouse Server](#clickhouse-server)
-        * 6.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.FIPSConfig](#rqsrs026clickhouseoperatorfipsdataplanechfipsconfig)
-        * 6.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHIDeploy](#rqsrs026clickhouseoperatorfipsdataplanechideploy)
-        * 6.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainHTTP](#rqsrs026clickhouseoperatorfipsdataplanechnoplainhttp)
-        * 6.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainNative](#rqsrs026clickhouseoperatorfipsdataplanechnoplainnative)
-        * 6.1.5 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoUnexpectedPorts](#rqsrs026clickhouseoperatorfipsdataplanechnounexpectedports)
-        * 6.1.6 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.InternodeTLS](#rqsrs026clickhouseoperatorfipsdataplanechinternodetls)
-        * 6.1.7 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleUp](#rqsrs026clickhouseoperatorfipsdataplanechscaleup)
-        * 6.1.8 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleDown](#rqsrs026clickhouseoperatorfipsdataplanechscaledown)
-        * 6.1.9 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ConfigUpdate](#rqsrs026clickhouseoperatorfipsdataplanechconfigupdate)
-    * 6.2 [ClickHouse Keeper](#clickhouse-keeper)
-        * 6.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.FIPSConfig](#rqsrs026clickhouseoperatorfipsdataplanechkfipsconfig)
-        * 6.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHKDeploy](#rqsrs026clickhouseoperatorfipsdataplanechkdeploy)
-        * 6.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoPlainClientPort](#rqsrs026clickhouseoperatorfipsdataplanechknoplainclientport)
-        * 6.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoUnexpectedPorts](#rqsrs026clickhouseoperatorfipsdataplanechknounexpectedports)
-        * 6.2.5 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.RaftTLS](#rqsrs026clickhouseoperatorfipsdataplanechkrafttls)
-        * 6.2.6 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleUp](#rqsrs026clickhouseoperatorfipsdataplanechkscaleup)
-        * 6.2.7 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleDown](#rqsrs026clickhouseoperatorfipsdataplanechkscaledown)
-        * 6.2.8 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ConfigUpdate](#rqsrs026clickhouseoperatorfipsdataplanechkconfigupdate)
-    * 6.3 [ClickHouse Backup Sidecar](#clickhouse-backup-sidecar)
-        * 6.3.0 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.VersionString](#rqsrs026clickhouseoperatorfipsdataplanechversionstring)
-        * 6.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.FIPSBinary](#rqsrs026clickhouseoperatorfipsdataplanebackupfipsbinary)
-        * 6.3.2 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.GOFIPS140](#rqsrs026clickhouseoperatorfipsdataplanebackupgofips140)
-        * 6.3.3 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.OnlyTLSPorts](#rqsrs026clickhouseoperatorfipsdataplanebackuponlytlsports)
-        * 6.3.4 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.HTTPSAPI](#rqsrs026clickhouseoperatorfipsdataplanebackuphttpsapi)
-        * 6.3.5 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.ClickHouseOverTLS](#rqsrs026clickhouseoperatorfipsdataplanebackupclickhouseovertls)
-        * 6.3.6 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RestoreRoundTrip](#rqsrs026clickhouseoperatorfipsdataplanebackuprestoreroundtrip)
-        * 6.3.7 [RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RemoteUploadTLS](#rqsrs026clickhouseoperatorfipsdataplanebackupremoteuploadtls)
-* 7 [FIPS Enforcement Mode](#fips-enforcement-mode)
-    * 7.1 [Security Coercion](#security-coercion)
-        * 7.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceVerifyStrict](#rqsrs026clickhouseoperatorfipsenforcedcoerceverifystrict)
-        * 7.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceMinVersion13](#rqsrs026clickhouseoperatorfipsenforcedcoerceminversion13)
-        * 7.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.OverrideMinVersion12To13](#rqsrs-026clickhouseoperatorfipsenforcedoverrideminversion12to13)
-        * 7.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceIPCSecure](#rqsrs026clickhouseoperatorfipsenforcedcoerceipcsecure)
-        * 7.1.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInsecureKubeconfig](#rqsrs026clickhouseoperatorfipsenforcedrejectinsecurekubeconfig)
-        * 7.1.6 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneCHI](#rqsrs026clickhouseoperatorfipsenforcedrejectverifynonechi)
-        * 7.1.7 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneZK](#rqsrs026clickhouseoperatorfipsenforcedrejectverifynonezk)
-        * 7.1.8 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInvalidMinVersion](#rqsrs026clickhouseoperatorfipsenforcedrejectinvalidminversion)
-        * 7.1.9 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectExternalZookeeper](#rqsrs026clickhouseoperatorfipsenforcedrejectexternalzookeeper)
-        * 7.1.10 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectCHKBypass](#rqsrs026clickhouseoperatorfipsenforcedrejectchkbypass)
-    * 7.2 [Image Policy](#image-policy)
-        * 7.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHI](#rqsrs026clickhouseoperatorfipsimagesrequiredrejectchi)
-        * 7.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.AcceptCHI](#rqsrs026clickhouseoperatorfipsimagesrequiredacceptchi)
-        * 7.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHK](#rqsrs026clickhouseoperatorfipsimagesrequiredrejectchk)
-        * 7.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RuntimeVersion](#rqsrs026clickhouseoperatorfipsimagesrequiredruntimeversion)
-        * 7.2.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Permissive](#rqsrs026clickhouseoperatorfipsimagespermissive)
-        * 7.2.6 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.ShortCircuit](#rqsrs026clickhouseoperatorfipsimagesrequiredshortcircuit)
-    * 7.3 [Image Tag Detection](#image-tag-detection)
-        * 7.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.FIPSSuffix](#rqsrs026clickhouseoperatorfipsimagestagdetectionfipssuffix)
-        * 7.3.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.AltinityFIPS](#rqsrs026clickhouseoperatorfipsimagestagdetectionaltinityfips)
-        * 7.3.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.DigestOnly](#rqsrs026clickhouseoperatorfipsimagestagdetectiondigestonly)
-        * 7.3.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.RegistryPath](#rqsrs026clickhouseoperatorfipsimagestagdetectionregistrypath)
-        * 7.3.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.CaseInsensitive](#rqsrs026clickhouseoperatorfipsimagestagdetectioncaseinsensitive)
-* 8 [Operator External Connections](#operator-external-connections)
-    * 8.1 [Operator Runtime Listener Verification](#operator-runtime-listener-verification)
-        * 8.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Listeners](#rqsrs026clickhouseoperatorfipsconnectoperatorlisteners)
-    * 8.2 [Operator to Kubernetes API](#operator-to-kubernetes-api)
-        * 8.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Kubernetes](#rqsrs026clickhouseoperatorfipsconnectoperatorkubernetes)
-    * 8.3 [Operator to ClickHouse Server](#operator-to-clickhouse-server)
-        * 8.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse](#rqsrs026clickhouseoperatorfipsconnectoperatorclickhouse)
-    * 8.4 [Operator to ZooKeeper/Keeper](#operator-to-zookeeperkeeper)
-        * 8.4.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Zookeeper](#rqsrs026clickhouseoperatorfipsconnectoperatorzookeeper)
-    * 8.5 [Operator to metrics-exporter IPC](#operator-to-metrics-exporter-ipc)
-        * 8.5.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.IPCSecure](#rqsrs026clickhouseoperatorfipsconnectoperatoripcsecure)
-    * 8.6 [Operator Prometheus Metrics](#operator-prometheus-metrics)
-        * 8.6.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Gap.OperatorMetricsTLS](#rqsrs026clickhouseoperatorfipsgapoperatormetricstls)
-* 9 [Exporter External Connections](#exporter-external-connections)
-    * 9.1 [Exporter Runtime Listener Verification](#exporter-runtime-listener-verification)
-        * 9.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Listeners](#rqsrs026clickhouseoperatorfipsconnectexporterlisteners)
-    * 9.2 [Exporter to Kubernetes API](#exporter-to-kubernetes-api)
-        * 9.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Kubernetes](#rqsrs026clickhouseoperatorfipsconnectexporterkubernetes)
-    * 9.3 [Exporter to ClickHouse Server](#exporter-to-clickhouse-server)
-        * 9.3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse](#rqsrs026clickhouseoperatorfipsconnectexporterclickhouse)
-    * 9.4 [Exporter Prometheus Metrics](#exporter-prometheus-metrics)
-        * 9.4.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Gap.ExporterMetricsTLS](#rqsrs026clickhouseoperatorfipsgapexportermetricstls)
-* 10 [Integrity Check Failure](#integrity-check-failure)
-    * 10.1 [Operator Integrity Tampering](#operator-integrity-tampering)
-        * 10.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.OperatorMismatch](#rqsrs026clickhouseoperatorfipsintegrityoperatormismatch)
-    * 10.2 [Exporter Integrity Tampering](#exporter-integrity-tampering)
-        * 10.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.ExporterMismatch](#rqsrs026clickhouseoperatorfipsintegrityexportermismatch)
+    * 3.1 [RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries](#rqsrs-026clickhouseoperatorfipsoperatorbuildshippedbinaries)
+    * 3.2 [RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries.StartupLogs](#rqsrs-026clickhouseoperatorfipsoperatorbuildshippedbinariesstartuplogs)
+* 4 [FIPS 140-3 TLS Cipher Suites](#fips-140-3-tls-cipher-suites)
+    * 4.1 [Approved TLS Cipher Suites](#approved-tls-cipher-suites)
+        * 4.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
+    * 4.2 [Rejected Cipher Suites and Protocols](#rejected-cipher-suites-and-protocols)
+        * 4.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.RejectedCiphers](#rqsrs-026clickhouseoperatorfipstlsrejectedciphers)
+* 5 [ClickHouse Server](#clickhouse-server)
+        * 5.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig](#rqsrs-026clickhouseoperatorfipschfipsconfig)
+        * 5.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient](#rqsrs-026clickhouseoperatorfipschfipsconfigexternalclient)
+        * 5.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.Rescale](#rqsrs-026clickhouseoperatorfipschrescale)
+        * 5.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.CH.ConfigUpdate](#rqsrs-026clickhouseoperatorfipschconfigupdate)
+* 6 [ClickHouse Keeper](#clickhouse-keeper)
+        * 6.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CHK.FIPSConfig](#rqsrs-026clickhouseoperatorfipschkfipsconfig)
+        * 6.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.CHK.Rescale](#rqsrs-026clickhouseoperatorfipschkrescale)
+        * 6.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.CHK.ConfigUpdate](#rqsrs-026clickhouseoperatorfipschkconfigupdate)
+* 7 [ClickHouse Backup Sidecar](#clickhouse-backup-sidecar)
+        * 7.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSBinary](#rqsrs-026clickhouseoperatorfipsbackupfipsbinary)
+        * 7.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSConfig](#rqsrs-026clickhouseoperatorfipsbackupfipsconfig)
+        * 7.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Backup.RestoreRoundTrip](#rqsrs-026clickhouseoperatorfipsbackuprestoreroundtrip)
+* 8 [FIPS Enforcement Mode](#fips-enforcement-mode)
+    * 8.1 [Security Coercion](#security-coercion)
+        * 8.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.SecurityCoercion](#rqsrs-026clickhouseoperatorfipsenforcedsecuritycoercion)
+        * 8.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectNonCompliantSpecs](#rqsrs-026clickhouseoperatorfipsenforcedrejectnoncompliantspecs)
+        * 8.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.MinVersionScope](#rqsrs-026clickhouseoperatorfipsenforcedminversionscope)
+    * 8.2 [Image Policy](#image-policy)
+        * 8.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectNonFIPS](#rqsrs-026clickhouseoperatorfipsimagesrequiredrejectnonfips)
+* 9 [Runtime Connection Evidence](#runtime-connection-evidence)
+    * 9.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KubernetesAPI](#rqsrs-026clickhouseoperatorfipsconnectoperatorkubernetesapi)
+    * 9.2 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.KubernetesAPI](#rqsrs-026clickhouseoperatorfipsconnectexporterkubernetesapi)
+    * 9.3 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse](#rqsrs-026clickhouseoperatorfipsconnectoperatorclickhouse)
+    * 9.4 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse](#rqsrs-026clickhouseoperatorfipsconnectexporterclickhouse)
+    * 9.5 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KeeperRestriction](#rqsrs-026clickhouseoperatorfipsconnectoperatorkeeperrestriction)
+    * 9.6 [RQ.SRS-026.ClickHouseOperator.FIPS.Connect.ClickHouse.KeeperTLS](#rqsrs-026clickhouseoperatorfipsconnectclickhousekeepertls)
+* 10 [Integrity Check](#integrity-check)
+    * 10.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.VerificationMismatch](#rqsrs-026clickhouseoperatorfipsintegrityverificationmismatch)
 * 11 [CAST Failure](#cast-failure)
     * 11.1 [Operator CAST Failure](#operator-cast-failure)
-        * 11.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.OperatorFail](#rqsrs026clickhouseoperatorfipscastoperatorfail)
+        * 11.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.OperatorFail](#rqsrs-026clickhouseoperatorfipscastoperatorfail)
     * 11.2 [Exporter CAST Failure](#exporter-cast-failure)
-        * 11.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.ExporterFail](#rqsrs026clickhouseoperatorfipscastexporterfail)
-* 12 [Synthetic TLS Cipher Validation](#synthetic-tls-cipher-validation)
-    * 12.1 [Approved cipher matrix](#approved-cipher-matrix)
-        * 12.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipssyntheticapprovedciphers)
-    * 12.2 [Rejected cipher matrix](#rejected-cipher-matrix)
-        * 12.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.RejectedCiphers](#rqsrs-026clickhouseoperatorfipssyntheticrejectedciphers)
-* 13 [CI/CD Image and Policy Verification](#cicd-image-and-policy-verification)
-    * 13.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CICD.OperatorImageBuild](#rqsrs-026clickhouseoperatorfipscicdoperatorimagebuild)
-    * 13.2 [RQ.SRS-026.ClickHouseOperator.FIPS.CICD.ExporterImageBuild](#rqsrs-026clickhouseoperatorfipscicdexporterimagebuild)
-    * 13.3 [RQ.SRS-026.ClickHouseOperator.FIPS.CICD.VulnerabilityScan](#rqsrs-026clickhouseoperatorfipscicdvulnerabilityscan)
-* 14 [AI Static Code Review](#ai-static-code-review)
-    * 14.1 [Operator Source Review](#operator-source-review)
-        * 14.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.Tree](#rqsrs-026clickhouseoperatorfipsaireviewoperatortree)
-        * 14.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.SharedPkg](#rqsrs-026clickhouseoperatorfipsaireviewoperatorsharedpkg)
-        * 14.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.RegressionGate](#rqsrs-026clickhouseoperatorfipsaireviewoperatorregressiongate)
-    * 14.2 [Exporter Source Review](#exporter-source-review)
-        * 14.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.Tree](#rqsrs-026clickhouseoperatorfipsaireviewexportertree)
-        * 14.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.SharedPkg](#rqsrs-026clickhouseoperatorfipsaireviewexportersharedpkg)
-        * 14.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.RegressionGate](#rqsrs-026clickhouseoperatorfipsaireviewexporterregressiongate)
-* 15 [ACVP Algorithm Validation](#acvp-algorithm-validation)
-    * 15.1 [Operator ACVP Validation](#operator-acvp-validation)
-        * 15.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration](#rqsrs026clickhouseoperatorfipsacvpoperatorwrapperintegration)
-        * 15.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration](#rqsrs026clickhouseoperatorfipsacvpoperatorconfiggeneration)
-        * 15.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ExpectedOutputReplay](#rqsrs026clickhouseoperatorfipsacvpoperatorexpectedoutputreplay)
-        * 15.1.4 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SuiteCount](#rqsrs026clickhouseoperatorfipsacvpoperatorsuitecount)
-    * 15.2 [Exporter ACVP Validation](#exporter-acvp-validation)
-        * 15.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration](#rqsrs026clickhouseoperatorfipsacvpexporterwrapperintegration)
-        * 15.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration](#rqsrs026clickhouseoperatorfipsacvpexporterconfiggeneration)
-        * 15.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ExpectedOutputReplay](#rqsrs026clickhouseoperatorfipsacvpexporterexpectedoutputreplay)
-        * 15.2.4 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SuiteCount](#rqsrs026clickhouseoperatorfipsacvpexportersuitecount)
-* 16 [Terminology](#terminology)
-    * 16.1 [SRS](#srs)
-    * 16.2 [FIPS 140-3](#fips-140-3)
-    * 16.3 [clickhouse-operator](#clickhouse-operator)
-    * 16.4 [metrics-exporter](#metrics-exporter)
-    * 16.5 [CHI](#chi)
-    * 16.6 [CHK](#chk)
-    * 16.7 [ACVP](#acvp)
-    * 16.8 [CMVP](#cmvp)
-    * 16.9 [CAVP](#cavp)
+        * 11.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.CAST.ExporterFail](#rqsrs-026clickhouseoperatorfipscastexporterfail)
+* 12 [ACVP Algorithm Validation](#acvp-algorithm-validation)
+    * 12.1 [Operator ACVP Validation](#operator-acvp-validation)
+        * 12.1.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration](#rqsrs-026clickhouseoperatorfipsacvpoperatorwrapperintegration)
+        * 12.1.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration](#rqsrs-026clickhouseoperatorfipsacvpoperatorconfiggeneration)
+        * 12.1.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SHA2256AFT](#rqsrs-026clickhouseoperatorfipsacvpoperatorsha2256aft)
+    * 12.2 [Exporter ACVP Validation](#exporter-acvp-validation)
+        * 12.2.1 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration](#rqsrs-026clickhouseoperatorfipsacvpexporterwrapperintegration)
+        * 12.2.2 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration](#rqsrs-026clickhouseoperatorfipsacvpexporterconfiggeneration)
+        * 12.2.3 [RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SHA2256AFT](#rqsrs-026clickhouseoperatorfipsacvpexportersha2256aft)
+* 13 [Terminology](#terminology)
+    * 13.1 [SRS](#srs)
+    * 13.2 [FIPS 140-3](#fips-140-3)
+    * 13.3 [clickhouse-operator](#clickhouse-operator)
+    * 13.4 [metrics-exporter](#metrics-exporter)
+    * 13.5 [CHI](#chi)
+    * 13.6 [CHK](#chk)
+    * 13.7 [ACVP](#acvp)
+    * 13.8 [CMVP](#cmvp)
+    * 13.9 [CAVP](#cavp)
 
 ## Introduction
 
@@ -1894,46 +973,32 @@ This specification describes FIPS 140-3 compatibility requirements for the
 The goal is to verify that FIPS-enabled builds of the operator and metrics-exporter:
 - Operate correctly under FIPS constraints
 - Properly enforce cryptographic restrictions
-- Use FIPS-compliant TLS for all inbound and outbound connections
+- Use FIPS-compliant TLS for all outbound connections
 
 Autotests that trace to these requirements live in
-[`tests/e2e/test_operator_fips.py`](../e2e/test_operator_fips.py) and
+[`tests/e2e/test_operator.py`](../e2e/test_operator.py) and
 [`tests/e2e/test_acvp.py`](../e2e/test_acvp.py).
 
 **Boundary:** The operator and metrics-exporter run in the same pod. Internal IPC between
 them is localhost HTTP and is not subject to FIPS TLS requirements. The Prometheus metrics
 endpoints (operator `:9999` and metrics-exporter `:8888`) are also served over plain HTTP
-and remain outside the FIPS TLS scope as a known gap.
+and remain outside the FIPS TLS scope as a known gap. The ClickHouse Keeper readiness probe
+endpoint (`:9182` `/ready`, which reflects Raft quorum status) likewise stays unconditionally
+plaintext HTTP regardless of the secure/insecure knobs and is outside the FIPS TLS scope.
 
 ## Configuration Requirements
 
 Plain HTTP/TCP on any external connection is a configuration error for FIPS compliance.
-TLS must be enabled for all connections to:
 
-- Kubernetes API
-- ClickHouse Server
-- ZooKeeper/Keeper
-- Prometheus scrape endpoints
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.Config.ExternalTLS
+### RQ.SRS-026.ClickHouseOperator.FIPS.HTTPPorts
 version: 1.0
 
-Plain HTTP/TCP on external connections SHALL be treated as a configuration error for FIPS compliance. TLS SHALL be enabled for connections to the [Kubernetes API], [ClickHouse Server], [ZooKeeper/Keeper], and Prometheus scrape endpoints.
+All external connections SHALL require TLS with FIPS-compliant settings, except for localhost IPC between the operator
+and metrics-exporter and the Prometheus metrics endpoints `:9999` and `:8888`.
 
 ## Build Verification
 
-**Objective:** Verify each shipped binary is a FIPS build and linked to Go Cryptographic Module v1.0.0.
-
-**Certificates:**
-- [CMVP #5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247)
-- [CAVP A6650](https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/details?product=19371)
-
-**Build requirement:** `GOFIPS140=v1.0.0` (or `certified`)
-
-
-### Shipped Binaries
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries
+### RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries
 version: 1.0
 
 Each shipped pod binary — `clickhouse-operator` and `metrics-exporter` — SHALL satisfy all of the following:
@@ -1962,217 +1027,239 @@ Examples:
     enabled: true
   ```
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Build.ShippedBinaries.StartupLogs
+### RQ.SRS-026.ClickHouseOperator.FIPS.OperatorBuild.ShippedBinaries.StartupLogs
 version: 1.0
 
-At startup, each binary SHALL emit a FIPS startup banner in logs indicating build and runtime FIPS state.
+At startup, each binary SHALL emit a FIPS startup log line indicating build and runtime FIPS state.
 
-when GODEBUG=fips140=only:
+When `GODEBUG=fips140=only`:
 
 ```text
-FIPS: chopconf.fips.enforced=true \
-build.linked=true \
-module.active=true \
-runtime.enforced=true \
-module=v1.0.0
+FIPS: chopconf.fips.enforced=true build.linked=true module.active=true runtime.enforced=true module=v1.0.0
 ```
 
+## FIPS 140-3 TLS Cipher Suites
 
+### Approved TLS Cipher Suites
 
-## Approved TLS Cipher Suites
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers
+#### RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers
 version: 1.0
 
 TLS-enforced external connections for [clickhouse-operator] and [metrics-exporter]
 SHALL negotiate only TLS 1.3 with the following approved cipher suites.
 
-| Cipher Suite | OpenSSL Name |
-|--------------|--------------|
-| TLS_AES_128_GCM_SHA256 | TLS_AES_128_GCM_SHA256 |
-| TLS_AES_256_GCM_SHA384 | TLS_AES_256_GCM_SHA384 |
-| TLS_AES_128_CCM_SHA256 | TLS_AES_128_CCM_SHA256 |
-| TLS_AES_128_CCM_8_SHA256 | TLS_AES_128_CCM_8_SHA256 |
+* TLS_AES_128_GCM_SHA256
+* TLS_AES_256_GCM_SHA384
+
+Note: `TLS_CHACHA20_POLY1305_SHA256` is TLS v1.3 but not FIPS approved.
 
 ### Rejected Cipher Suites and Protocols
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.TLS.RejectedCiphers
 version: 1.0
 
-TLS connections SHALL reject the following for all TLS-enabled external connections:
-
-- Any TLS cipher suite not explicitly listed in [RQ.SRS-026.ClickHouseOperator.FIPS.TLS.ApprovedCiphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
-- Protocol versions: SSLv2, SSLv3, TLS 1.0, TLS 1.1
-- Cipher suites using non-approved/legacy algorithms (for this profile), including:
-  - ChaCha20-Poly1305
-  - RC4, RC2, DES, 3DES, IDEA, SEED, CAMELLIA, ARIA
-  - NULL encryption / NULL authentication
-  - Anonymous key exchange (`aNULL`, `eNULL`, `ADH`, `AECDH`)
-  - Export/weak suites (`EXP`, `LOW`, `40-bit`, `56-bit`)
-  - MD5- or SHA-1-based legacy suites
+On TLS-enforced external connections for [clickhouse-operator] and [metrics-exporter], any protocol version
+older than TLS 1.3 and any cipher suite not listed in [approved ciphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers)
+SHALL be rejected by the operator in a FIPS-compliant configuration.
 
 
-## ClickHouse Server and Keeper FIPS Configurations
+## ClickHouse Server
 
-**Objective:** Verify the operator generates and maintains FIPS-compliant configurations for ClickHouse servers and Keepers.
-
-
-### ClickHouse Server
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.FIPSConfig
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig
 version: 1.0
 
-Deploying a CHI with FIPS TLS settings SHALL start ClickHouse with FIPS-compliant TLS configuration.
+Operator deploying a `ClickHouseInstallation` with FIPS TLS OpenSSL settings SHALL start a FIPS-compliant ClickHouse server and client.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHIDeploy
+```yaml
+  configuration:
+    clusters:
+      - name: default
+        secure: "yes"
+        insecure: "no"
+        layout:
+          shardsCount: 1
+          replicasCount: 2
+    zookeeper:
+      nodes:
+        - host: chk-test-030003-keeper-0-0
+          port: 2281
+          secure: "yes"
+    settings:
+      http_port: _removed_
+      tcp_port: _removed_
+      interserver_http_port: _removed_
+      mysql_port: _removed_
+      postgresql_port: _removed_
+      https_port: 8443
+      tcp_port_secure: 9440
+      interserver_https_port: 9010
+    files:
+      openssl.xml: |
+        <yandex>
+          <openSSL>
+            <server>
+              <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>
+              <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>
+              <dhParamsFile>/etc/clickhouse-server/secrets.d/dhparam.pem/clickhouse-certs/dhparam.pem</dhParamsFile>
+              <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
+              <verificationMode>none</verificationMode>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+            </server>
+            <client>
+              <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
+              <loadDefaultCAFile>false</loadDefaultCAFile>
+              <verificationMode>strict</verificationMode>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+            </client>
+          </openSSL>
+        </yandex>
+```
+
+The deployed ClickHouse server SHALL use only the following ports:
+
+* HTTPS API port 8443 (instead of 8123)
+* Secure native TCP port 9440 (instead of 9000)
+* Interserver HTTPS port 9010 (instead of interserver HTTP port 9009)
+* Backup sidecar HTTPS API port 7171 (instead of 7180), when backups are enabled
+
+Each exposed port SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites.
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient
 version: 1.0
 
-The operator SHALL deploy FIPS `ClickHouseInstallation` resources to `Completed` with Running pods when configuration is valid.
+External clients connecting to the ClickHouse server SHALL be able to use any enabled TLS protocol version, including TLS 1.2.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainHTTP
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.Rescale
 version: 1.0
 
-When FIPS transport hardening applies, ClickHouse pods SHALL NOT listen on plain HTTP port 8123; HTTPS port 8443 SHALL be used.
+Adding or removing a replica from a FIPS-configured `ClickHouseInstallation` SHALL reconcile successfully and result in the expected number of running pods.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoPlainNative
-version: 1.0
+After rescaling, all replicas SHALL continue to run the FIPS ClickHouse binary and maintain the configured TLS-only OpenSSL settings.
 
-When FIPS transport hardening applies, ClickHouse pods SHALL NOT listen on plain native TCP port 9000; secure native port 9440 SHALL be used.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.NoUnexpectedPorts
-version: 1.0
-
-ClickHouse pods in a FIPS deployment SHALL expose only expected secure listener ports and no additional unexpected ports.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.InternodeTLS
-version: 1.0
-
-ReplicatedMergeTree replicas SHALL communicate over interserver HTTPS (`interserver_https_port`) and data SHALL converge across replicas.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleUp
-version: 1.0
-
-Adding a replica to a FIPS-configured CHI SHALL reconcile to `Completed` and the new replica SHALL run the FIPS ClickHouse binary with TLS-only listeners.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ScaleDown
-version: 1.0
-
-Removing a replica from a FIPS-configured CHI SHALL reconcile to `Completed` and remaining replicas SHALL keep FIPS binary and TLS-only configuration.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.ConfigUpdate
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CH.ConfigUpdate
 version: 1.0
 
 Updating TLS settings on a running CHI SHALL reload ClickHouse with the new FIPS-compliant configuration.
 
 
-### ClickHouse Keeper
+## ClickHouse Keeper
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.FIPSConfig
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CHK.FIPSConfig
 version: 1.0
 
-Deploying a CHK with FIPS TLS settings SHALL start Keeper with FIPS-compliant TLS configuration.
+Operator deploying a `ClickHouseKeeperInstallation` with FIPS TLS OpenSSL settings SHALL start a FIPS-compliant ClickHouse
+Keeper server and client.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHKDeploy
+```yaml
+  configuration:
+    clusters:
+      - name: keeper
+        secure: "yes"
+        insecure: "no"
+        layout:
+          replicasCount: 2
+    settings:
+      keeper_server/log_storage_path: /var/lib/clickhouse/coordination/log
+      keeper_server/snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+      keeper_server/raft_configuration/server/port: 9444
+    files:
+      openssl.xml: |
+        <clickhouse>
+          <openSSL>
+              <server>
+                <certificateFile>/etc/clickhouse-server/secrets.d/server.crt/clickhouse-certs/server.crt</certificateFile>
+                <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>
+                <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
+                <verificationMode>none</verificationMode>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+              </server>
+              <client>
+                <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
+                <loadDefaultCAFile>false</loadDefaultCAFile>
+                <verificationMode>strict</verificationMode>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+              </client>
+          </openSSL>
+        </clickhouse>
+```
+
+The deployed ClickHouse Keeper cluster SHALL use only the following ports:
+
+* Secure client port 2281 (instead of 2181)
+* Secure Raft communication port 9444
+* Plaintext HTTP readiness probe port 9182 (the `/ready` Raft-quorum health check)
+
+Every exposed port except the readiness probe port 9182 and Raft replication port 9444 (which enforces peer-only authentication)
+SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites. Port 9182 SHALL stay 
+unconditionally plaintext HTTP regardless of the secure/insecure configuration (see Boundary).
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CHK.Rescale
 version: 1.0
 
-The operator SHALL deploy FIPS `ClickHouseKeeperInstallation` resources to `Completed` with Running pods when configuration is valid.
+Adding or removing a node from a FIPS-configured `ClickHouseKeeperInstallation` SHALL reconcile successfully and result 
+in the expected number of running pods.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoPlainClientPort
+After rescaling, all Keeper nodes SHALL continue to run the FIPS ClickHouse Keeper binary and maintain the configured 
+TLS-only OpenSSL settings.
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.CHK.ConfigUpdate
 version: 1.0
 
-When FIPS transport hardening applies, Keeper pods SHALL NOT listen on plain client port 2181; secure client port 2281 SHALL be used.
+Updating TLS settings on a running CHK SHALL reload ClickHouse with the new FIPS-compliant configuration.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.NoUnexpectedPorts
+
+## ClickHouse Backup Sidecar
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSBinary
 version: 1.0
 
-Keeper pods in a FIPS deployment SHALL expose only expected secure listener ports.
+The `clickhouse-backup` sidecar SHALL run a FIPS-built binary.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.RaftTLS
+The sidecar binary SHALL satisfy all of the following:
+
+* `clickhouse-backup --version` contains `fips`
+* When inspectable, `go version -m` reports `GOFIPS140=v1.0.0`
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Backup.FIPSConfig
 version: 1.0
 
-Keeper Raft communication SHALL use TLS on the configured secure Raft port.
+Deploying a `ClickHouseInstallation` with a FIPS-configured backup sidecar SHALL start `clickhouse-backup` with a FIPS-compliant TLS configuration.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleUp
+The deployed backup sidecar SHALL only add the following listener ports to the ClickHouse container:
+
+* HTTPS API port 7171 (instead of 7180)
+
+The FIPS-configured backup sidecar SHALL additionally satisfy all of the following:
+
+* Each exposed port SHALL support TLS communication using only FIPS-compliant protocol versions and cipher suites.
+* The `clickhouse-backup` sidecar SHALL connect to ClickHouse using secure native TCP with TLS enabled.
+
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Backup.RestoreRoundTrip
 version: 1.0
 
-Adding a node to a FIPS-configured Keeper cluster SHALL reconcile to `Completed` and the new node SHALL run the FIPS Keeper binary with TLS-only client and Raft listeners.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ScaleDown
-version: 1.0
-
-Removing a node from a FIPS-configured Keeper cluster SHALL reconcile to `Completed` and remaining nodes SHALL keep FIPS configuration.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CHK.ConfigUpdate
-version: 1.0
-
-Updating TLS settings on a running CHK SHALL reload Keeper with the new FIPS-compliant configuration.
-
-
-### ClickHouse Backup Sidecar
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.CH.VersionString
-version: 1.0
-
-A running ClickHouse host under FIPS image policy SHALL report a `version()` string containing `fips` (case-insensitive).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.FIPSBinary
-version: 1.0
-
-The `clickhouse-backup` sidecar SHALL run a FIPS-built binary; `clickhouse-backup --version` SHALL contain `fips` (case-insensitive).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.GOFIPS140
-version: 1.0
-
-When inspectable, the clickhouse-backup sidecar binary SHALL embed `GOFIPS140=v1.0.0` per `go version -m`.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.OnlyTLSPorts
-version: 1.0
-
-The clickhouse-backup sidecar SHALL expose only secure listener ports (including HTTPS API port 7171).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.HTTPSAPI
-version: 1.0
-
-The clickhouse-backup HTTPS API SHALL serve over TLS with CA-trust enforcement: trusted clients accepted, untrusted clients rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.ClickHouseOverTLS
-version: 1.0
-
-The clickhouse-backup sidecar SHALL reach ClickHouse over secure native TCP.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RestoreRoundTrip
-version: 1.0
-
-Backup and restore through the HTTPS API SHALL succeed over TLS.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.DataPlane.Backup.RemoteUploadTLS
-version: 1.0
-
-Remote backup upload to object storage SHALL use FIPS-approved TLS.
-
+Creating a backup and restoring it through the HTTPS API SHALL succeed over TLS.
 
 ## FIPS Enforcement Mode
 
-**Objective:** Verify `security.fips.enforced=true` coerces security settings and rejects non-compliant configurations.
-
+**Objective:** Verify that `security.fips.enforced: "true"` coerces relaxed security settings and rejects non-compliant CHI/CHK specifications and non-FIPS images.
 
 ### Security Coercion
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceVerifyStrict
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.SecurityCoercion
 version: 1.0
 
-With `fips.enforced=true`, unset TLS verify SHALL be coerced to Strict for ClickHouse, ZooKeeper/Keeper, and Kubernetes clients.
+When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL coerce unset or relaxed security settings as follows:
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceMinVersion13
-version: 1.0
+* Unset TLS verify SHALL be coerced to Strict for ClickHouse, ZooKeeper/Keeper, and Kubernetes clients.
+* Unset TLS `minVersion` SHALL be coerced to `"1.3"` for the operator's outbound TLS clients (`security.clickhouse.tls`, `security.zookeeper.tls`, and `security.kubernetes.tls`).
+* Explicit `minVersion: "1.2"` for those TLS clients SHALL be coerced to `"1.3"`.
+* Unset IPC mode SHALL be coerced to Secure.
 
-With `fips.enforced=true`, unset TLS minVersion SHALL be coerced to 1.3 for the
-operator's outbound TLS clients.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.OverrideMinVersion12To13
-version: 1.0
-
-When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL coerce `minVersion` to `"1.3"` for `security.clickhouse.tls`, `security.zookeeper.tls`, and `security.kubernetes.tls`, even when those fields are explicitly set to `"1.2"`.
+Example configuration with explicit `minVersion: "1.2"`:
 
 ```yaml
 spec:
@@ -2190,230 +1277,87 @@ spec:
         minVersion: "1.2"
 ```
 
-After operator configuration normalization, the effective `minVersion` for each component listed above SHALL be `"1.3"`.
+After operator configuration normalization, the effective `minVersion` for each TLS client listed above SHALL be `"1.3"`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.CoerceIPCSecure
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectNonCompliantSpecs
 version: 1.0
 
-With `fips.enforced=true`, unset IPC mode SHALL be coerced to Secure.
+When `security.fips.enforced: "true"` is set in the [ClickHouseOperatorConfiguration], the operator SHALL reject 
+non-compliant CHI and CHK specifications with `FIPSValidationFailed` and SHALL NOT create workload StatefulSets for:
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInsecureKubeconfig
-version: 1.0
-
-The operator SHALL refuse to start when kubeconfig uses `TLSClientConfig.Insecure=true` under strict/FIPS mode.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneCHI
-version: 1.0
-
-CHI with `clickhouse.tls.verify=None` under enforced mode SHALL be rejected with `FIPSValidationFailed`.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectVerifyNoneZK
-version: 1.0
-
-CHI with `zookeeper.tls.verify=None` under enforced mode SHALL be rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectInvalidMinVersion
-version: 1.0
-
-CHI with invalid TLS minVersion under enforced mode SHALL be rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectExternalZookeeper
-version: 1.0
-
-CHI referencing plain external ZooKeeper nodes under enforced mode SHALL be rejected.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.RejectCHKBypass
-version: 1.0
-
-CHK with TLS verify bypass under enforced mode SHALL be rejected.
+* CHI referencing plain external ZooKeeper nodes, including when `secure` is explicitly set to `"false"`.
+* CHI with `clickhouse.tls.verify=None` at spec or cluster level.
+* CHI with `zookeeper.tls.verify=None`.
+* CHI with invalid `clickhouse.tls.minVersion`.
+* CHK with TLS verify bypass at spec level.
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.Enforced.MinVersionScope
 version: 1.0
 
 The `minVersion` coercion SHALL apply only to TLS clients created and managed by the operator.
-They SHALL NOT require ClickHouse Server or ClickHouse Keeper listener endpoints to reject TLS 1.2.
+They SHALL NOT require ClickHouse Server or ClickHouse Keeper listener endpoints to reject TLS 1.2
+(see [RQ.SRS-026.ClickHouseOperator.FIPS.CH.FIPSConfig.ExternalClient](#rqsrs-026clickhouseoperatorfipschfipsconfigexternalclient)).
 
 ### Image Policy
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHI
+#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectNonFIPS
 version: 1.0
 
-With `security.fips.images.policy=Required`, CHI with non-FIPS image tag SHALL be rejected with `FIPSImagePolicyViolation`.
+With `security.fips.images.policy=Required`, non-FIPS images SHALL be rejected with `FIPSImagePolicyViolation` as follows:
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.AcceptCHI
+* CHI with non-FIPS ClickHouse image tag SHALL be rejected at admission.
+* CHK with non-FIPS Keeper image tag SHALL be rejected at admission.
+* CHI with non-FIPS `clickhouse-backup` sidecar image tag SHALL be rejected at admission.
+* CHI with multiple non-FIPS hosts SHALL produce a single policy violation error.
+* Digest-only image references SHALL NOT be detected as FIPS at admission.
+* Registry hostname containing `fips` SHALL NOT satisfy FIPS tag detection.
+* CHI admitted with a FIPS-tagged ClickHouse image whose running binary lacks `fips` in `SELECT version()` SHALL fail at runtime.
+
+## Runtime Connection Evidence
+
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KubernetesAPI
 version: 1.0
 
-With image policy Required, CHI with FIPS-tagged image SHALL reconcile normally.
+The clickhouse-operator SHALL access the Kubernetes API through the HTTPS endpoint on port `443`.
+Plain HTTP requests to the Kubernetes API endpoint SHALL be rejected.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RejectCHK
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.KubernetesAPI
 version: 1.0
 
-With image policy Required, CHK with non-FIPS Keeper image SHALL be rejected.
+The metrics-exporter SHALL access the Kubernetes API through the HTTPS endpoint on port `443`.
+Plain HTTP requests to the Kubernetes API endpoint SHALL be rejected.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.RuntimeVersion
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse
 version: 1.0
 
-With image policy Required, host `SELECT version()` lacking `fips` SHALL fail with `FIPSImagePolicyViolation`.
+The clickhouse-operator SHALL communicate with ClickHouse hosts using HTTPS port `8443`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Permissive
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse
 version: 1.0
 
-With permissive image policy, non-FIPS CHI images SHALL reconcile (default).
+The metrics-exporter SHALL discover ClickHouse hosts using the HTTPS endpoint `8443`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.Required.ShortCircuit
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.KeeperRestriction
 version: 1.0
 
-Multiple non-FIPS hosts SHALL produce a single policy violation error.
+When a Keeper ensemble is configured as TLS-only, the clickhouse-operator SHALL NOT attempt plaintext ZooKeeper/Keeper
+operations against it.
 
-
-### Image Tag Detection
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.FIPSSuffix
+### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.ClickHouse.KeeperTLS
 version: 1.0
 
-Image tags containing `fips` (case-insensitive) SHALL be detected as FIPS.
+ClickHouse replicas SHALL connect to Keeper using secure client port `2281` with `secure=yes`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.AltinityFIPS
+
+## Integrity Check
+
+### RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.VerificationMismatch
 version: 1.0
 
-Image tags containing `altinityfips` SHALL be detected as FIPS.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.DigestOnly
-version: 1.0
-
-Digest-only image references SHALL NOT be detected as FIPS at admission.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.RegistryPath
-version: 1.0
-
-Registry hostname containing `fips` SHALL NOT satisfy FIPS tag detection.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Images.TagDetection.CaseInsensitive
-version: 1.0
-
-Image tags such as `25.3.FIPS` or `25.3.Fips` SHALL be detected as FIPS (case-insensitive match on the tag).
-
-
-## Operator External Connections
-
-**Objective:** Verify all **clickhouse-operator** inbound and outbound connections use FIPS-compliant TLS.
-
-
-### Operator Runtime Listener Verification
-
-In a FIPS deployment, workload containers deployed by the operator (ClickHouse, Keeper, and sidecar containers) SHALL expose only expected TLS listener ports. Verification reads `/proc/net/tcp` and `/proc/net/tcp6` inside each container and parses ports in LISTEN state (`0A`):
-
-```bash
-kubectl exec <pod> -c clickhouse -- sh -c 'cat /proc/net/tcp /proc/net/tcp6'
-```
-
-E2e coverage: [`test_020011`](../e2e/test_operator_fips.py#L200).
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Listeners
-version: 1.0
-
-FIPS workload pods (ClickHouse, Keeper, and sidecar containers) SHALL listen only on expected TLS ports. Plaintext service ports (8123, 9000, 2181) SHALL NOT be open when FIPS transport hardening applies.
-
-
-### Operator to Kubernetes API
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Kubernetes
-version: 1.0
-
-The operator SHALL connect to the Kubernetes API using FIPS-approved TLS ciphers.
-
-
-### Operator to ClickHouse Server
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.ClickHouse
-version: 1.0
-
-The operator SHALL connect to ClickHouse using FIPS-approved TLS ciphers.
-
-
-### Operator to ZooKeeper/Keeper
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.Zookeeper
-version: 1.0
-
-The operator SHALL connect to ZooKeeper/Keeper using FIPS-approved TLS ciphers.
-
-
-### Operator to metrics-exporter IPC
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Operator.IPCSecure
-version: 1.0
-
-Operator IPC with `security.ipc.mode=Secure` SHALL work over localhost HTTP with token auth.
-
-
-### Operator Prometheus Metrics
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Gap.OperatorMetricsTLS
-version: 1.0
-
-Operator Prometheus metrics on :9999 currently expose a known FIPS gap (HTTP-only).
-
-
-## Exporter External Connections
-
-**Objective:** Verify all **metrics-exporter** inbound and outbound connections use FIPS-compliant TLS.
-
-
-### Exporter Runtime Listener Verification
-
-Listener audits use the same `/proc/net/tcp` technique as [Operator Runtime Listener Verification](#operator-runtime-listener-verification). E2e audits the **clickhouse-backup** sidecar in [`test_020011`](../e2e/test_operator_fips.py#L200). The **metrics-exporter** process on `:8888` remains a known gap until metrics TLS is implemented.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Listeners
-version: 1.0
-
-The metrics-exporter process SHALL expose only expected listener ports on `:8888`. Sidecar containers in the same pod SHALL be listener-audited with the same `/proc/net/tcp` procedure.
-
-
-### Exporter to Kubernetes API
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.Kubernetes
-version: 1.0
-
-The exporter SHALL connect to the Kubernetes API using FIPS-approved TLS ciphers.
-
-
-### Exporter to ClickHouse Server
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Connect.Exporter.ClickHouse
-version: 1.0
-
-The exporter SHALL query ClickHouse using FIPS-approved TLS when configured for HTTPS.
-
-
-### Exporter Prometheus Metrics
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Gap.ExporterMetricsTLS
-version: 1.0
-
-Exporter Prometheus metrics on :8888 currently expose a known FIPS gap (HTTP-only).
-
-
-## Integrity Check Failure
-
-**Objective:** Verify FIPS integrity self-test detects binary tampering for each shipped binary independently.
-
-
-### Operator Integrity Tampering
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.OperatorMismatch
-version: 1.0
-
-Tampering with `clickhouse-operator` `.go.fipsinfo` SHALL panic with `fips140: verification mismatch`.
-
-
-### Exporter Integrity Tampering
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Integrity.ExporterMismatch
-version: 1.0
-
-Tampering with `metrics-exporter` `.go.fipsinfo` SHALL panic with `fips140: verification mismatch`.
-
+Each shipped FIPS binary — `clickhouse-operator` and `metrics-exporter` — SHALL perform a software integrity 
+self-test at initialization by verifying its embedded HMAC. If the binary is tampered with or corrupted such that
+the HMAC verification fails, the process SHALL immediately terminate with a `fips140: verification mismatch` panic 
+to prevent the execution of a compromised cryptographic module.
 
 ## CAST Failure
 
@@ -2436,164 +1380,46 @@ version: 1.0
 Running `metrics-exporter` with `GODEBUG=failfipscast=<name>` SHALL terminate with a CAST error.
 
 
-## Synthetic TLS Cipher Validation
-
-**Objective:** Validate FIPS cipher enforcement on all external (to the pod) connections using `openssl s_client` and `openssl s_server`.
-
-Use `openssl` to simulate connections with specific ciphers and verify the operator/exporter accepts FIPS-approved ciphers and rejects non-approved ones.
-
-```bash
-# Operator as TLS client against server offering only approved cipher
-openssl s_server -accept 8443 -cert server.crt -key server.key \
-  -ciphersuites TLS_AES_256_GCM_SHA384
-
-# Operator as TLS client against server offering non-approved cipher
-openssl s_server -accept 8443 -cert server.crt -key server.key \
-  -cipher ECDHE-RSA-CHACHA20-POLY1305
-
-# Inbound connection to operator/exporter metrics endpoint
-openssl s_client -connect localhost:9999 -cipher ECDHE-RSA-AES256-GCM-SHA384
-```
-
-### Approved cipher matrix
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.ApprovedCiphers
-version: 1.0
-
-For each external connection listed below, when exercised as a TLS **client** with `openssl s_server` offering only [approved ciphers](#rqsrs-026clickhouseoperatorfipstlsapprovedciphers), or as a TLS **server** with `openssl s_client` using only approved ciphers, the connection SHALL succeed:
-
-| Connection | Role | Tool |
-|------------|------|------|
-| Operator to Kubernetes API | Client | `openssl s_server` |
-| Operator to ClickHouse Server | Client | `openssl s_server` |
-| Operator to ZooKeeper/Keeper | Client | `openssl s_server` |
-| Operator metrics :9999 | Server | `openssl s_client` |
-| Exporter to Kubernetes API | Client | `openssl s_server` |
-| Exporter to ClickHouse Server | Client | `openssl s_server` |
-| Exporter metrics :8888 | Server | `openssl s_client` |
-
-
-### Rejected cipher matrix
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.Synthetic.RejectedCiphers
-version: 1.0
-
-For each external connection listed below, when the peer offers only [rejected ciphers or protocols](#rqsrs-026clickhouseoperatorfipstlsrejectedciphers), the connection SHALL be rejected:
-
-| Connection | Role | Tool |
-|------------|------|------|
-| Operator to Kubernetes API | Client | `openssl s_server` |
-| Operator to ClickHouse Server | Client | `openssl s_server` |
-| Operator to ZooKeeper/Keeper | Client | `openssl s_server` |
-| Operator metrics :9999 | Server | `openssl s_client` |
-| Exporter to Kubernetes API | Client | `openssl s_server` |
-| Exporter to ClickHouse Server | Client | `openssl s_server` |
-| Exporter metrics :8888 | Server | `openssl s_client` |
-
-
-## CI/CD Image and Policy Verification
-
-**Objective:** Add CI/CD jobs to validate FIPS image build and supply-chain checks.
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.CICD.OperatorImageBuild
-version: 1.0
-
-CI SHALL build the [clickhouse-operator] FIPS image successfully.
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.CICD.ExporterImageBuild
-version: 1.0
-
-CI SHALL build the [metrics-exporter] FIPS image successfully.
-
-### RQ.SRS-026.ClickHouseOperator.FIPS.CICD.VulnerabilityScan
-version: 1.0
-
-FIPS images SHALL pass vulnerability scanning with no Critical, High, or Medium findings.
-
-
-### Operator Source Review
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.Tree
-version: 1.0
-
-Static review of operator-scoped paths SHALL produce no Critical findings; Warning-level findings SHALL be documented.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.SharedPkg
-version: 1.0
-
-Review of shared packages reachable from `cmd/operator` SHALL produce no Critical findings.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Operator.RegressionGate
-version: 1.0
-
-A signed-off review artifact SHALL be stored with the build record before release.
-
-### Exporter Source Review
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.Tree
-version: 1.0
-
-Static review of exporter-scoped paths SHALL produce no Critical findings; Warning-level findings SHALL be documented.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.SharedPkg
-version: 1.0
-
-Review of shared packages reachable from `cmd/metrics_exporter` SHALL produce no Critical findings.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.AIReview.Exporter.RegressionGate
-version: 1.0
-
-A signed-off review artifact SHALL be stored with the build record before release.
-
 ## ACVP Algorithm Validation
 
-**Objective:** Reproduce ACVP expected-output checks for each FIPS binary using the tracked public-scope config in [`pkg/util/fips/acvp/`](../../../pkg/util/fips/acvp/).
+**Objective:** Verify that each FIPS binary can be built with the ACVP wrapper enabled and that the embedded ACVP responder works through the modulewrapper stdin/stdout protocol.
 
+These requirements cover the e2e ACVP smoke tests only. They do not claim full ACVP expected-output replay or suite-count validation from `pkg/util/fips/acvp/run.sh`.
 
 ### Operator ACVP Validation
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.WrapperIntegration
 version: 1.0
 
-Building clickhouse-operator with `-tags acvp_wrapper` SHALL expose a working ACVP responder via argv0 dispatch.
+Building `clickhouse-operator` with `-tags acvp_wrapper` SHALL produce a binary whose ACVP responder is reachable through argv0 dispatch when executed as `clickhouse-operator-acvp`.
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ConfigGeneration
 version: 1.0
 
-The clickhouse-operator ACVP responder SHALL answer `getConfig` with supported capabilities.
+The `clickhouse-operator` ACVP responder SHALL answer a `getConfig` request successfully. The returned payload SHALL be valid JSON, SHALL advertise `SHA2-256` and `ACVP-AES-GCM`, and SHALL NOT advertise `ML-KEM` or `ML-DSA`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.ExpectedOutputReplay
+#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SHA2256AFT
 version: 1.0
 
-`bash pkg/util/fips/acvp/run.sh` SHALL match all configured expected outputs for the operator.
-
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Operator.SuiteCount
-version: 1.0
-
-The tracked ACVP config SHALL report 38 matched expectations for clickhouse-operator.
-
+The `clickhouse-operator` ACVP responder SHALL answer a `SHA2-256` algorithm functional test request for input `abc` with the digest matching `hashlib.sha256(b"abc").digest()`.
 
 ### Exporter ACVP Validation
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.WrapperIntegration
 version: 1.0
 
-Building metrics-exporter with `-tags acvp_wrapper` SHALL expose a working ACVP responder.
+Building `metrics-exporter` with `-tags acvp_wrapper` SHALL produce a binary whose ACVP responder is reachable through argv0 dispatch when executed as `metrics-exporter-acvp`.
 
 #### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ConfigGeneration
 version: 1.0
 
-The metrics-exporter ACVP responder SHALL answer `getConfig` with supported capabilities.
+The `metrics-exporter` ACVP responder SHALL answer a `getConfig` request successfully. The returned payload SHALL be valid JSON, SHALL advertise `SHA2-256` and `ACVP-AES-GCM`, and SHALL NOT advertise `ML-KEM` or `ML-DSA`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.ExpectedOutputReplay
+#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SHA2256AFT
 version: 1.0
 
-`BINARY=metrics-exporter bash pkg/util/fips/acvp/run.sh` SHALL match all expected outputs.
+The `metrics-exporter` ACVP responder SHALL answer a `SHA2-256` algorithm functional test request for input `abc` with the digest matching `hashlib.sha256(b"abc").digest()`.
 
-#### RQ.SRS-026.ClickHouseOperator.FIPS.ACVP.Exporter.SuiteCount
-version: 1.0
-
-The tracked ACVP config SHALL report 38 matched expectations for metrics-exporter.
 
 ## Terminology
 

--- a/tests/requirements/fips_test_plan.md
+++ b/tests/requirements/fips_test_plan.md
@@ -1,0 +1,516 @@
+# QA-STP FIPS 140-3 Compatibility
+# Software Test Plan
+
+(c) 2026 Altinity Inc. All Rights Reserved.
+
+**Author:** vzakaznikov
+
+**Date:** May 19, 2026
+
+## Table of Contents
+
+* 1 [Introduction](#introduction)
+* 2 [Configuration Requirements](#configuration-requirements)
+* 3 [Build Verification](#build-verification)
+* 4 [GODEBUG Strict Mode Smoke Test](#godebug-strict-mode-smoke-test)
+* 5 [FIPS 140-3 Valid TLS Cipher Suites](#fips-140-3-valid-tls-cipher-suites)
+* 6 [ClickHouse Server and Keeper FIPS Configurations](#clickhouse-server-and-keeper-fips-configurations)
+* 7 [FIPS Enforcement Mode](#fips-enforcement-mode)
+* 8 [clickhouse-operator Connections](#clickhouse-operator-connections)
+* 9 [metrics-exporter Connections](#metrics-exporter-connections)
+* 10 [clickhouse-backup Sidecar](#clickhouse-backup-sidecar)
+* 11 [Integrity Check Failure](#integrity-check-failure)
+* 12 [CAST Failure](#cast-failure)
+* 13 [Synthetic TLS Cipher Validation](#synthetic-tls-cipher-validation)
+* 14 [CI/CD Image and Policy Verification](#cicd-image-and-policy-verification)
+* 15 [(Optional) ACVP Algorithm Validation](#optional-acvp-algorithm-validation)
+## Introduction
+
+This test plan covers FIPS 140-3 compatibility testing for the
+**clickhouse-operator**, **metrics-exporter**, and **clickhouse-backup**
+components used within ClickHouse deployments.
+
+The goal is to verify that FIPS-enabled components:
+
+- Operate correctly under FIPS constraints
+- Properly enforce cryptographic restrictions
+- Use FIPS-compliant TLS for all inbound and outbound connections
+
+**Boundary:** The operator and metrics-exporter run in the same pod. Internal IPC between
+them is localhost HTTP and is not subject to FIPS TLS requirements. The Prometheus metrics
+endpoints (operator `:9999` and metrics-exporter `:8888`) are also served over plain HTTP
+and remain outside the FIPS TLS scope as a known gap. The ClickHouse Keeper readiness probe
+endpoint (`:9182` `/ready`, which reflects Raft quorum status) likewise stays unconditionally
+plaintext HTTP regardless of the secure/insecure knobs and is outside the FIPS TLS scope.
+
+```mermaid
+flowchart LR
+
+    subgraph operator_pod["clickhouse-operator Pod"]
+        op["clickhouse-operator"]
+        me["metrics-exporter"]
+
+        op <-->|"HTTP localhost + IPC token"| me
+    end
+
+    k8s["Kubernetes API"]
+    prom["Prometheus"]
+    ext["External ClickHouse client"]
+
+    subgraph ch_cluster["ClickHouse cluster"]
+        ch0["CHI pod 0"]
+        ch1["CHI pod 1"]
+        backup["clickhouse-backup"]
+
+        ch0 <-->|"interserver HTTPS :9010"| ch1
+
+        backup -->|"HTTPS :8443 / native TLS :9440"| ch0
+    end
+
+    subgraph keeper["ClickHouse Keeper cluster"]
+        k0["Keeper-0"]
+        k1["Keeper-1"]
+
+        k0 <-->|"Raft :9444"| k1
+    end
+
+    %% Kubernetes
+    op -->|"HTTPS :443 / client-go"| k8s
+    me -->|"HTTPS :443 / in-cluster SA"| k8s
+
+    %% ClickHouse cluster
+    op -->|"HTTPS :8443"| ch_cluster
+    me -->|"HTTPS :8443"| ch_cluster
+
+    %% External access
+    ext -->|"native TLS :9440"| ch_cluster
+    ext -->|"HTTPS :7171"| backup
+
+    %% Keeper
+    ch_cluster -->|"TLS :2281"| keeper
+
+    op -.->|"Skips plaintext ZK root-path helper\nwhen Keeper is TLS-only"| keeper
+
+    %% Monitoring
+    prom -->|"HTTP :9999"| op
+    prom -->|"HTTP :8888"| me
+```
+
+## Configuration Requirements
+
+Plain HTTP/TCP on any external connection is a configuration error for FIPS compliance.
+TLS must be enabled for all connections to:
+
+- Kubernetes API
+- ClickHouse Server
+- ZooKeeper/Keeper
+
+*Note:* Prometheus scrape endpoints (:9999 and :8888) remain outside FIPS TLS scope as a documented boundary gap.
+
+## Build Verification
+
+**Objective:** Verify binaries are FIPS builds and linked to Go Cryptographic Module v1.0.0.
+
+**Certificates:**
+- [CMVP #5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247)
+- [CAVP A6650](https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/details?product=19371)
+
+**Build requirement:** `GOFIPS140=v1.0.0` (or `certified`)
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Operator version | Run `clickhouse-operator --version` or check logs | Output includes FIPS indicator |
+| Metrics exporter version | Run `metrics-exporter --version` or check logs | Output includes FIPS indicator |
+| Build flag | Run `go version -m <binary>` | Shows `GOFIPS140=v1.0.0` |
+| FIPS version | Check `crypto/fips140.Version()` | Returns `v1.0.0` |
+| FIPS enabled | Check `crypto/fips140.Enabled()` | Returns `true` |
+
+## GODEBUG Strict Mode Smoke Test
+
+**Objective:** Verify the project test suite runs in strict FIPS mode.
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Strict mode smoke test | Run all e2e tests with `GODEBUG=fips140=only` enabled | No panic/crash and no test regressions caused by strict FIPS mode |
+
+## FIPS 140-3 Valid TLS Cipher Suites
+
+**Objective:** Verify the FIPS TLS profile used by operator-managed clients and FIPS listener probes.
+
+The approved TLS 1.3 cipher suites for this test plan are:
+
+| Cipher Suite | OpenSSL Name |
+|--------------|--------------|
+| TLS_AES_128_GCM_SHA256 | TLS_AES_128_GCM_SHA256 |
+| TLS_AES_256_GCM_SHA384 | TLS_AES_256_GCM_SHA384 |
+
+### Scope
+
+This section has two separate scopes:
+
+1. **Operator-managed clients**  
+   When `security.fips.enforced=true`, operator-managed TLS clients are coerced to:
+   - `verify=Strict`
+   - `minVersion=1.3`
+
+   This applies to operator/client configuration for:
+   - Kubernetes API
+   - ClickHouse
+   - ZooKeeper/Keeper
+
+2. **Server listener probes**  
+   The e2e listener probes verify that FIPS-configured listeners accept approved TLS 1.3 AES-GCM traffic and reject selected disallowed protocol/cipher combinations.
+
+   Covered listeners:
+   - ClickHouse HTTPS `8443`
+   - ClickHouse native TLS `9440`
+   - ClickHouse interserver HTTPS `9010`
+   - Keeper secure client port `2281`
+   - clickhouse-backup HTTPS API `7171`
+
+### Positive TLS listener checks
+
+| Endpoint | Positive check | Expected Result |
+|----------|----------------|-----------------|
+| ClickHouse HTTPS `8443` | OpenSSL TLS 1.3 with `TLS_AES_128_GCM_SHA256` | Cipher negotiates successfully |
+| ClickHouse native TLS `9440` | Secure native ClickHouse query | Query succeeds over TLS |
+| ClickHouse interserver HTTPS `9010` | OpenSSL TLS 1.3 with `TLS_AES_128_GCM_SHA256` | Cipher negotiates successfully |
+| Keeper secure client `2281` | OpenSSL TLS 1.3 with `TLS_AES_128_GCM_SHA256` | Cipher negotiates successfully |
+| Backup HTTPS API `7171` | curl TLS 1.3 with `TLS_AES_128_GCM_SHA256` | HTTPS request succeeds |
+
+### Negative TLS listener checks
+
+| Rejected Case | Covered Endpoints | Expected Result |
+|---------------|-------------------|-----------------|
+| TLS 1.3 `TLS_CHACHA20_POLY1305_SHA256` | `8443`, `9440`, `9010`, `2281`, `7171` | TLS handshake fails |
+| TLS 1.1 protocol | `8443`, `9440`, `9010`, `2281`, `7171` | TLS handshake fails |
+
+### Important TLS 1.2 boundary
+
+Do **not** treat TLS 1.2 as globally rejected on all ClickHouse, Keeper, or backup listener endpoints.
+
+ClickHouse and Keeper OpenSSL server configuration disables:
+
+```text
+sslv2, sslv3, tlsv1, tlsv1_1
+```
+Operator does not disable TLS 1.2 by default.
+Therefore:
+
+* operator-managed clients must be coerced to TLS 1.3 under FIPS enforcement;
+* listener probes must reject TLS 1.1 and non-approved TLS 1.3 cipher suites;
+* external ClickHouse clients may still use TLS 1.2 when the server OpenSSL configuration enables it.
+
+
+## ClickHouse Server and Keeper FIPS Configurations
+
+**Objective:** Verify operator generates and maintains FIPS-compliant configurations for ClickHouse servers and Keepers.
+
+**ClickHouse Server:**
+
+| Test Assertion | Description                                               | Expected Result                           |
+|----------------|-----------------------------------------------------------|-------------------------------------------|
+| FIPS config applied | Deploy CHI with FIPS TLS settings                         | ClickHouse starts with FIPS-compliant TLS |
+| No plain HTTP port | Verify HTTP port (8123) disabled when FIPS enforced       | Only HTTPS port (8443) listening          |
+| No plain TCP port | Verify native TCP port (9000) disabled when FIPS enforced | Only secure TCP port (9440) listening     |
+| No unexpected ports | Verify no other inbound/outbound ports opened             | Only expected secure ports listening      |
+| Internode TLS | Verify native interserver_https_port port (9009) disabled | Replicas communicate over TLS port (9010) |
+| Scale up | Add replica to FIPS-configured cluster                    | New replica has FIPS config               |
+| Scale down | Remove replica from FIPS-configured cluster               | Remaining replicas keep FIPS config       |
+| Config update | Update TLS settings on running CHI                        | ClickHouse reloads with new FIPS config   |
+
+**ClickHouse Keeper:**
+
+| Test Assertion | Description | Expected Result                                                |
+|----------------|-------------|----------------------------------------------------------------|
+| FIPS config applied | Deploy CHK with FIPS TLS settings | Keeper starts with FIPS-compliant TLS                          |
+| No plain client port | Verify client port (2181) disabled when FIPS enforced | Only secure client port (2281) listening                       |
+| No unexpected ports | Verify no other inbound/outbound ports opened | Only expected secure ports listening                           |
+| Raft peer port | Verify Keeper Raft port `9444` is configured and listening | Port `9444` is present as a Keeper Raft peer port; generic client TLS probing is not required and is not part of this test scope |
+| /ready endpoint | CHK readiness probe works on plain HTTP port (9182) | /ready returns 200 OK regardless of FIPS config                  |
+| Scale up | Add node to FIPS-configured Keeper cluster | New node has FIPS config                                       |
+| Scale down | Remove node from FIPS-configured Keeper cluster | Remaining nodes keep FIPS config                               |
+| Config update | Update TLS settings on running CHK | Keeper reloads with new FIPS config                            |
+
+## clickhouse-backup Sidecar
+
+**Objective:** Verify clickhouse-backup sidecar operates correctly in FIPS mode and uses FIPS-compliant TLS for ClickHouse backup and restore operations.
+
+**Connection Overview:**
+
+| Direction | Target                               | Protocol         | Default Port | TLS Support                    |
+| --------- | ------------------------------------ | ---------------- | ------------ | ------------------------------ |
+| Outbound  | ClickHouse Server                    | HTTPS/native TLS | 8443/9440    | Yes, via ClickHouse TLS config |
+| Inbound   | Backup API                           | HTTPS            | 7171         | Yes                            |
+| Storage   | Local mounted ClickHouse data volume | filesystem       | N/A          | N/A                            |
+
+| Test Assertion               | Description                                                                 | Expected Result                                 |
+|------------------------------|-----------------------------------------------------------------------------| ----------------------------------------------- |
+| Backup FIPS binary           | Run `clickhouse-backup --version` in sidecar                                | Output contains `fips`                          |
+| Backup GOFIPS140 module      | Run `go version -m` against `clickhouse-backup` binary                      | Output contains `GOFIPS140=v1.0.0`              |
+| Backup sidecar starts        | Deploy CHI with FIPS ClickHouse image and FIPS clickhouse-backup sidecar    | Backup sidecar starts successfully
+| Backup only expected ports   | Inspect listening ports in backup sidecar                                   | Only expected secure ports (`8443`, `9440`, `9010`, `7171`) are exposed in the shared network namespace |
+| Backup API HTTPS             | Connect to backup API on `7171` with trusted CA                             | HTTPS connection succeeds                       |
+| Backup API rejects plaintext | Send plain HTTP request to backup API port `7171`                           | Request is rejected or TLS handshake fails      |
+| Backup to ClickHouse TLS     | Create backup using ClickHouse secure endpoint                              | Backup completes over TLS                       |
+| Restore to ClickHouse TLS    | Restore backup using ClickHouse secure endpoint                             | Restore completes over TLS                      |
+| Backup round trip            | Create table, insert data, create backup, drop data, restore backup         | Restored data matches original data             |
+| TLS 1.3 approved cipher      | Connect backup API using approved TLS 1.3 AES-GCM cipher                    | Connection succeeds                             |
+| Non-approved TLS rejected    | Try TLS 1.2 or non-approved cipher against backup API                       | Connection is rejected                          |
+
+## FIPS Enforcement Mode
+
+**Objective:** Verify `security.fips.enforced=true` coerces security settings and rejects non-compliant configurations.
+
+**Security Coercion (`security.fips.enforced=true`):**
+
+| Test Assertion | Description | Expected Result (Observable Outcome) |
+|----------------|-------------|-----------------|
+| **Coerce ClickHouse verify to Strict** | Deploy Chopconf with `fips.enforced=true` and `security.clickhouse.tls.verify=None` | Log: `FIPS strict: coerced security.clickhouse.tls.verify: None → Strict` |
+| **Coerce ZooKeeper/Keeper verify to Strict** | Deploy Chopconf with `fips.enforced=true` and `security.zookeeper.tls.verify=None` | Log: `FIPS strict: coerced security.zookeeper.tls.verify: None → Strict` |
+| **Coerce Kubernetes verify to Strict** | Deploy Chopconf with `fips.enforced=true` and `security.kubernetes.tls.verify=None` or relaxed Kubernetes TLS verification | Log: `FIPS strict: coerced security.kubernetes.tls.verify: None → Strict` |
+| **Coerce TLS minVersion to 1.3** | Deploy Chopconf with `fips.enforced=true` and ClickHouse, ZooKeeper/Keeper, and Kubernetes TLS `minVersion=1.2` | Logs show each client coerced to `minVersion: 1.2 → 1.3` |
+| **Coerce IPC mode to Secure** | Deploy Chopconf with `fips.enforced=true` and `ipc.mode=Plain` | Log: `FIPS strict: coerced security.ipc.mode: Plain → Secure` |
+| **Reject verify=None (CHI)** | Apply CHI with `clickhouse.tls.verify=None` under enforced mode | `chi.status.status` = **Aborted**; `chi.status.errors` contains `FIPSValidationFailed` |
+| **Reject ZK verify=None (CHI)** | Apply CHI with `zookeeper.tls.verify=None` under enforced mode | `chi.status.status` = **Aborted**; `chi.status.errors` contains `FIPSValidationFailed` |
+| **Reject invalid minVersion** | Apply CHI with `minVersion: "1.1"` under enforced mode | `chi.status.status` = **Aborted**; `chi.status.errors` contains `FIPSValidationFailed` |
+| **Reject external ZooKeeper** | Apply CHI referencing plain ZK nodes under enforced mode | `chi.status.status` = **Aborted**; `chi.status.errors` contains `FIPSValidationFailed` |
+| **Reject CHK TLS bypass** | Apply CHK with spec-level `verify: None` under enforced mode | `chk.status.status` = **Aborted**; `chk.status.errors` contains `FIPSValidationFailed` |
+
+**Image Policy (`security.fips.images.policy`):**
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Required + non-fips image | CHI with ClickHouse image lacking "fips" tag | CHI rejected with FIPSImagePolicyViolation |
+| Required + fips image | CHI with ClickHouse image containing "fips" tag | CHI reconciles normally |
+| Required + non-fips Keeper image | CHK with Keeper image lacking "fips" tag | CHK rejected with FIPSImagePolicyViolation |
+| Required + non-fips backup sidecar image | CHI with clickhouse-backup sidecar image lacking "fips" tag | CHI rejected with FIPSImagePolicyViolation |
+| Required + version check | Host `SELECT version()` lacks "fips" | Host marked failed with FIPSImagePolicyViolation |
+| Permissive + non-fips | CHI with any image | CHI reconciles (default behavior) |
+| Multiple hosts violation | CHI with multiple non-fips hosts | Single error, short-circuits at first |
+
+**Image Tag Detection:**
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Tag with "fips" suffix | `altinity/clickhouse-server:25.3.fips` | Detected as FIPS |
+| Tag with "altinityfips" | `altinity/clickhouse-server:25.3.8.30001.altinityfips` | Detected as FIPS |
+| Case insensitive | `...:25.3.FIPS` or `...:25.3.Fips` | Detected as FIPS |
+| Digest-only reference | `repo@sha256:...` | Not detected (no tag) |
+| Registry with "fips" in path | `fips-registry.example.com/image:latest` | Not detected (tag only) |
+
+## clickhouse-operator Connections
+
+**Objective:** Verify all clickhouse-operator outbound connections use FIPS-compliant TLS.
+
+**Connection Overview:**
+
+| Direction | Target | Protocol | Default Port | TLS Support                                                |
+|-----------|--------|----------|--------------|------------------------------------------------------------|
+| Outbound | Kubernetes API Server | HTTPS | 443 | Yes (client-go), configurable via `security.kubernetes.tls` |
+| Outbound | ClickHouse Server | HTTP/HTTPS | 8123/8443 | Yes, configurable via `security.clickhouse.tls`            |
+| Outbound | ZooKeeper/Keeper | TCP | 2181/2281 | Yes, configurable via `security.zookeeper.tls`       |
+| Outbound | metrics-exporter (IPC) | HTTP | 8888 | No (same pod, localhost)                                   |
+| Inbound | Prometheus scrape | HTTP | 9999 | No (known gap)                                             |
+
+**Operator to Kubernetes API**
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Operator FIPS cipher to K8s | Operator connects with FIPS-approved cipher | Connection succeeds |
+| Operator non-FIPS cipher to K8s | K8s API only offers non-approved cipher | Operator rejects connection |
+| `security.kubernetes.tls.minVersion=1.3` | Enforce TLS 1.3 minimum | TLS 1.2 rejected |
+
+**Operator to ClickHouse Server**
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Operator FIPS cipher to CH | Operator connects with FIPS-approved cipher | Connection succeeds |
+| Operator non-FIPS cipher to CH | Server only offers non-approved cipher | Operator rejects connection |
+| `security.clickhouse.tls.minVersion=1.3` | Enforce TLS 1.3 minimum | TLS 1.2 rejected |
+
+**Operator to ZooKeeper/Keeper**
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Operator FIPS cipher to ZK | Operator connects with FIPS-approved cipher | Connection succeeds |
+| Operator non-FIPS cipher to ZK | ZK only offers non-approved cipher | Operator rejects connection |
+| `security.zookeeper.tls.minVersion=1.3` | Enforce TLS 1.3 minimum | TLS 1.2 rejected |
+
+**Operator to metrics-exporter (IPC)**
+
+> Same pod, localhost - HTTP acceptable. Token auth via `security.ipc.mode=Secure`.
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Operator IPC + `security.ipc.mode=Secure` | HTTP with token auth enabled | Works correctly |
+
+**Operator Prometheus Metrics (:9999)**
+
+> **FIPS Gap:** HTTP-only
+
+| Test Assertion        | Description                | Expected Result |
+|-----------------------|----------------------------|-----------------|
+| Operator metrics port | Verify connection on :9999 | curl succeeds   |
+
+## metrics-exporter Connections
+
+**Objective:** Verify all metrics-exporter inbound and outbound connections use FIPS-compliant TLS.
+
+**Connection Overview:**
+
+| Direction | Target | Protocol | Default Port | TLS Support                        |
+|-----------|--------|----------|--------------|------------------------------------|
+| Outbound | Kubernetes API Server | HTTPS | 443 | Yes (client-go)                    |
+| Outbound | ClickHouse Server | HTTP/HTTPS | 8123/8443 | Yes, inherits from `chop.Config()` |
+| Inbound | Prometheus scrape | HTTP | 8888 `/metrics` | No, (known gap)        |
+| Inbound | Operator IPC | HTTP | 8888 `/chi` | No (same pod, localhost)           |
+
+**Exporter to Kubernetes API**
+
+> Uses client-go defaults. No minVersion control exposed.
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Exporter FIPS cipher to K8s | Exporter connects with FIPS-approved cipher | Connection succeeds |
+| Exporter non-FIPS cipher to K8s | K8s API only offers non-approved cipher | Exporter rejects connection |
+
+**Exporter to ClickHouse Server**
+
+> TLS supported via `chop.Config()`, but `ChSchemeAuto` prefers HTTP if both ports available.
+> Must configure `scheme: https` explicitly for FIPS compliance.
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Exporter FIPS cipher to CH | Exporter queries with FIPS-approved cipher | Connection succeeds |
+| Exporter non-FIPS cipher to CH | Server only offers non-approved cipher | Exporter rejects connection |
+
+**Exporter Prometheus Metrics (:8888/metrics)**
+
+> **FIPS Gap:** HTTP-only.
+
+| Test Assertion | Description                | Expected Result |
+|----------------|----------------------------|-----------------|
+| Exporter metrics port | Verify connection on :8888 | curl succeeds   |
+
+**Exporter IPC Endpoint (:8888/chi)**
+
+> Covered by Operator IPC tests above. Same pod, localhost.
+
+## Integrity Check Failure
+
+**Objective:** Verify FIPS integrity self-test detects binary tampering.
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Corrupted binary | XOR byte in `.go.fipsinfo` section and execute | Panic: `fips140: verification mismatch` |
+
+**Procedure:**
+
+Flip one byte in the `.go.fipsinfo` embedded HMAC to trigger integrity check failure at init:
+
+1. Locate `.go.fipsinfo` section offset: `readelf -S -W <binary>`
+2. XOR byte at offset+16 (first byte of 32-byte HMAC after 16-byte magic)
+3. Run tampered binary - expect panic: `fips140: verification mismatch`
+
+Requires: `readelf` (binutils), `python3`
+
+## CAST Failure
+
+**Objective:** Verify FIPS Cryptographic Algorithm Self-Test (CAST) detects failures.
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| CAST failure | Trigger known-answer test failure via `GODEBUG=failfipscast=<name>` | Process terminates with CAST error |
+
+**Procedure:**
+
+Use `GODEBUG=failfipscast=<name>` to simulate CAST failures.
+
+Available CAST names: see `$GOROOT/src/crypto/internal/fips140test/cast_test.go` (`allCASTs` variable).
+
+## Synthetic TLS Cipher Validation
+
+**Objective:** Provide supplementary TLS cipher evidence for operator pod container connections to Kubernetes API and ClickHouse HTTPS endpoints under FIPS enforced mode.
+
+This scenario validates that both containers in the operator pod can negotiate an approved TLS 1.3 with real runtime endpoints, and that a TLS peer offering only a non-approved cipher is rejected when the client is restricted to an approved cipher.
+
+
+### Scope
+
+| Source                          | Target                  | Endpoint                             | Cipher / Peer Configuration                                                               | Expected Result                                                |
+| ------------------------------- | ----------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `clickhouse-operator` container | Kubernetes API          | `https://kubernetes.default.svc:443` | Client forces `TLS_AES_256_GCM_SHA384` over TLS 1.3                                       | TLS 1.3 handshake succeeds and API request returns `HTTP 200`  |
+| `metrics-exporter` container    | Kubernetes API          | `https://kubernetes.default.svc:443` | Client forces `TLS_AES_256_GCM_SHA384` over TLS 1.3                                       | TLS 1.3 handshake succeeds and API request returns `HTTP 200`  |
+| `clickhouse-operator` container | ClickHouse HTTPS        | CHI pod `:8443` `/ping`              | Client forces `TLS_AES_256_GCM_SHA384` over TLS 1.3                                       | TLS 1.3 handshake succeeds and `/ping` returns `HTTP 200`      |
+| `metrics-exporter` container    | ClickHouse HTTPS        | CHI pod `:8443` `/ping`              | Client forces `TLS_AES_256_GCM_SHA384` over TLS 1.3                                       | TLS 1.3 handshake succeeds and `/ping` returns `HTTP 200`      |
+| `clickhouse-operator` container | Fake OpenSSL TLS server | `fake-openssl-server:8443`           | Server offers only `TLS_CHACHA20_POLY1305_SHA256`; client forces `TLS_AES_256_GCM_SHA384` | TLS handshake fails because there is no shared approved cipher |
+| `metrics-exporter` container    | Fake OpenSSL TLS server | `fake-openssl-server:8443`           | Server offers only `TLS_CHACHA20_POLY1305_SHA256`; client forces `TLS_AES_256_GCM_SHA384` | TLS handshake fails because there is no shared approved cipher |
+
+
+### Test Matrix
+
+| Connection                                                      | Tool                                | Test                                                                                           | Expected Result                                    |
+| --------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `clickhouse-operator` container → Kubernetes API                | `curl` against real K8s API         | Force TLS 1.3 with `TLS_AES_256_GCM_SHA384`                                                    | TLS handshake succeeds; request returns `HTTP 200` |
+| `metrics-exporter` container → Kubernetes API                   | `curl` against real K8s API         | Force TLS 1.3 with `TLS_AES_256_GCM_SHA384`                                                    | TLS handshake succeeds; request returns `HTTP 200` |
+| `clickhouse-operator` container → ClickHouse HTTPS              | `curl` against real CHI pod `:8443` | Force TLS 1.3 with `TLS_AES_256_GCM_SHA384`                                                    | TLS handshake succeeds; `/ping` returns `HTTP 200` |
+| `metrics-exporter` container → ClickHouse HTTPS                 | `curl` against real CHI pod `:8443` | Force TLS 1.3 with `TLS_AES_256_GCM_SHA384`                                                    | TLS handshake succeeds; `/ping` returns `HTTP 200` |
+| `clickhouse-operator` container → fake rejected-cipher TLS peer | Fake `openssl s_server`             | Server offers only `TLS_CHACHA20_POLY1305_SHA256`; client allows only `TLS_AES_256_GCM_SHA384` | TLS handshake fails                                |
+| `metrics-exporter` container → fake rejected-cipher TLS peer    | Fake `openssl s_server`             | Server offers only `TLS_CHACHA20_POLY1305_SHA256`; client allows only `TLS_AES_256_GCM_SHA384` | TLS handshake fails                                |
+
+### Explicit Exclusions
+
+| Excluded Target                        | Reason                                                                                                                                                                                                                        |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ClickHouse Keeper / CHK                | The operator does not normally establish a runtime TLS client session to ClickHouse Keeper. CHK is only deployed because the CHI manifest depends on Keeper. Keeper TLS is covered by real CHK listener/configuration checks. |
+| Operator metrics `:9999`               | Plain HTTP Prometheus endpoint; outside FIPS TLS scope by documented boundary.                                                                                                                                                |
+| Exporter metrics `:8888`               | Plain HTTP Prometheus/IPC endpoint; outside FIPS TLS scope by documented boundary.                                                                                                                                            |
+
+### Interpretation
+
+This scenario provides supplementary cipher-negotiation evidence.
+
+It proves:
+
+* both containers in the operator pod can negotiate approved TLS 1.3 AES-256-GCM with real Kubernetes API and real ClickHouse HTTPS endpoints;
+* a peer that offers only the non-approved TLS 1.3 ChaCha cipher cannot be used when the client is restricted to the approved AES-256 cipher.
+
+It does not claim that the fake OpenSSL server is a protocol-compatible replacement for Kubernetes or ClickHouse.
+
+## CI/CD Image and Policy Verification
+
+**Objective:** Add CI/CD jobs to validate FIPS image build and supply-chain checks.
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| Operator FIPS image build | Build clickhouse-operator with FIPS tags | Image builds successfully |
+| Exporter FIPS image build | Build metrics-exporter with FIPS tags | Image builds successfully |
+| Image vulnerability scan | Scan images with Grype | No Critical, High, or Medium vulnerabilities |
+
+> **Note:** Image policy enforcement tests covered in [FIPS Enforcement Mode](#fips-enforcement-mode).
+
+## (Optional) ACVP Algorithm Validation
+
+**Objective:** Reproduce ACVP expected-output checks using the same public-scope config
+pattern used in [clickhouse-backup PR #1364](https://github.com/Altinity/clickhouse-backup/pull/1364).
+
+> **Note:** ACVP tests the cryptographic library as compiled into the shipped binary.
+> In Go, crypto primitives are statically linked — the bytes ACVP exercises are the exact bytes users run.
+> Reference config:
+> [`pkg/acvpwrapper/acvp_test_fips140v1.26.public.config.json`](https://github.com/Altinity/clickhouse-backup/blob/master/pkg/acvpwrapper/acvp_test_fips140v1.26.public.config.json)
+> (public-API scope; excludes ML-KEM/ML-DSA).
+
+| Test Assertion | Description | Expected Result |
+|----------------|-------------|-----------------|
+| ACVP wrapper integration | Add `acvp` subcommand to operator/exporter | ACVP subcommand responds |
+| ACVP config generation | Run `<binary> acvp getConfig` | Returns supported capabilities |
+| ACVP expected-output replay | Run pinned ACVP replay against tracked config | All configured suites match expected output |
+| ACVP suite count | Validate configured suite count from tracked config | `38 ACVP tests matched expectations` |
+
+Covered suite families from the tracked config (38 total):
+- SHA-2 (6), SHA-3 (4), SHAKE/cSHAKE (4)
+- HMAC-SHA-2 (6), HMAC-SHA-3 (4)
+- AES-CBC/CTR/GCM and CMAC-AES (4)
+- KDA/PBKDF/KDF components (3), DRBG (2)
+- ECDSA/EdDSA/RSA (3), TLS 1.2/1.3 (2)


### PR DESCRIPTION
This PR aligns the FIPS 140-3 test plan, generated requirements, and e2e operator test coverage.

Main changes:

- Add the FIPS software test plan under `tests/requirements/fips_test_plan.md`.
- Restructure and consolidate FIPS requirements in `tests/requirements/fips.md`.
- Regenerate/update `tests/requirements/fips.py` from the updated requirement definitions.
- Update FIPS e2e scenarios in `test_operator.py` to reference the corrected/consolidated requirements.
- Refine FIPS helper steps in `steps_fips.py` to better match what is actually testable.
- Update ACVP-related requirements/tests for the metrics-exporter wrapper behavior and expected algorithm coverage.

## Details

This PR makes the three layers consistent:

1. **Test plan**
   - Adds the FIPS test plan as an explicit tracked artifact.
   - Documents the intended FIPS coverage and known scope boundaries.

2. **Requirements**
   - Consolidates duplicate or overly-specific requirements into broader testable requirements.
   - Clarifies FIPS enforcement behavior such as TLS verification coercion, TLS 1.3 minVersion coercion, IPC secure mode, image policy handling, and operator-managed TLS client scope.
   - Adds/updates connection requirements for operator/exporter communication with Kubernetes API, ClickHouse, and Keeper-related paths.

3. **Tests**
   - Updates scenario requirement links to match the revised requirement structure.
   - Improves TLS checks around real endpoints:
     - Kubernetes API `:443`
     - ClickHouse HTTPS `:8443`
   - Verifies TLS 1.3 negotiation with approved AES-GCM cipher suites where applicable.
   - Avoids pretending the operator performs runtime TLS client sessions to Keeper when it normally does not.
   - Keeps checks focused on observable behavior instead of synthetic assumptions that do not represent the real operator data path.



## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
