### PR TITLE
Add full non FIPS approved cipher checks 

### DIFF
--- a/tests/e2e/manifests/chi/test-030003.yaml
+++ b/tests/e2e/manifests/chi/test-030003.yaml
@@ -43,14 +43,14 @@ spec:
               <dhParamsFile>/etc/clickhouse-server/secrets.d/dhparam.pem/clickhouse-certs/dhparam.pem</dhParamsFile>
               <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
               <verificationMode>none</verificationMode>
-              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_2</disableProtocols>
               <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
             </server>
             <client>
               <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
               <loadDefaultCAFile>false</loadDefaultCAFile>
               <verificationMode>strict</verificationMode>
-              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+              <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_2</disableProtocols>
               <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
             </client>
           </openSSL>

--- a/tests/e2e/manifests/chk/test-030003.yaml
+++ b/tests/e2e/manifests/chk/test-030003.yaml
@@ -26,14 +26,14 @@ spec:
                 <privateKeyFile>/etc/clickhouse-server/secrets.d/server.key/clickhouse-certs/server.key</privateKeyFile>
                 <!-- Server-auth TLS only: clients validate this certificate; the server does not require client certificates (not mTLS). -->
                 <verificationMode>none</verificationMode>
-                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_2</disableProtocols>
                 <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
               </server>
               <client>
                 <caConfig>/etc/clickhouse-server/secrets.d/ca.crt/clickhouse-certs/ca.crt</caConfig>
                 <loadDefaultCAFile>false</loadDefaultCAFile>
                 <verificationMode>strict</verificationMode>
-                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1</disableProtocols>
+                <disableProtocols>sslv2,sslv3,tlsv1,tlsv1_1,tlsv1_2</disableProtocols>
                 <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
               </client>
           </openSSL>

--- a/tests/e2e/steps_fips.py
+++ b/tests/e2e/steps_fips.py
@@ -1933,9 +1933,13 @@ def fips_wait_table_removed_from_dropped_tables(
         f"{database}.{table} still present in system.dropped_tables after {timeout}s"
     )
 
-@TestStep(Then)
-def check_fips_cast_failure(self, binary_path, binary, cast_name="HMAC-SHA2-256"):
-    """Assert binary exits non-zero when FIPS CAST is forced to fail."""
+@TestStep(When)
+def run_binary_with_forced_fips_cast_failure(
+    self,
+    binary_path,
+    cast_name,
+):
+    """Run binary with GODEBUG forcing the named FIPS CAST/PCT to fail."""
     result = subprocess.run(
         [
             "env",
@@ -1948,16 +1952,36 @@ def check_fips_cast_failure(self, binary_path, binary, cast_name="HMAC-SHA2-256"
         check=False,
     )
 
+    return result
+
+
+@TestStep(Check)
+def check_fips_cast_failure_result(
+    self,
+    result,
+    binary,
+    cast_name,
+    failure_kind="CAST",
+):
+    """Assert binary exits non-zero with the expected forced FIPS CAST/PCT failure."""
     output = f"{result.stdout}\n{result.stderr}"
 
     assert result.returncode != 0, error(
-        f"{binary}: expected CAST failure exit, got {result.returncode}\n{output}"
+        f"{binary}: expected {failure_kind} failure exit, got {result.returncode}\n{output}"
     )
+
     assert f"FIPS 140-3 self-test failed: {cast_name}" in output, error(
-        f"{binary}: expected CAST failure for {cast_name}\n{output}"
+        f"{binary}: expected {failure_kind} failure for {cast_name}\n{output}"
     )
-    assert "simulated CAST failure" in output, error(
-        f"{binary}: expected simulated CAST failure message\n{output}"
+
+    expected_simulated_message = (
+        "simulated PCT failure"
+        if "PCT" in cast_name or failure_kind == "PCT"
+        else "simulated CAST failure"
+    )
+
+    assert expected_simulated_message in output, error(
+        f"{binary}: expected {expected_simulated_message!r}\n{output}"
     )
 
 def _free_local_port():
@@ -1976,29 +2000,31 @@ def check_fips_integrity_failure(self, binary_path, binary_label):
     match = re.search(r"\.go\.fipsinfo\s+\w+\s+\w+\s+([0-9a-fA-F]+)", readelf_out)
     assert match, error(f"{binary_label}: .go.fipsinfo section not found in ELF headers")
 
-    section_offset = int(match.group(1), 16)
-    hmac_byte_offset = section_offset + 16
+    with Given("I edit the binary to corrupt the .go.fipsinfo HMAC"):
+        section_offset = int(match.group(1), 16)
+        hmac_byte_offset = section_offset + 16
 
-    corrupted_bin = f"{binary_path}.corrupted"
-    shutil.copy2(binary_path, corrupted_bin)
+        corrupted_bin = f"{binary_path}.corrupted"
+        shutil.copy2(binary_path, corrupted_bin)
 
-    with open(corrupted_bin, "rb+") as f:
-        f.seek(hmac_byte_offset)
-        original_byte = f.read(1)
-        corrupted_byte = bytes([original_byte[0] ^ 0xFF])
-        f.seek(hmac_byte_offset)
-        f.write(corrupted_byte)
+        with open(corrupted_bin, "rb+") as f:
+            f.seek(hmac_byte_offset)
+            original_byte = f.read(1)
+            corrupted_byte = bytes([original_byte[0] ^ 0xFF])
+            f.seek(hmac_byte_offset)
+            f.write(corrupted_byte)
 
-    result = subprocess.run(
-        [corrupted_bin, "--version"],
-        env={"GODEBUG": "fips140=on"},
-        capture_output=True,
-        text=True,
-        check=False
-    )
+    with When("I execute --version on a corrupted bin file"):
+        result = subprocess.run(
+            [corrupted_bin, "--version"],
+            env={"GODEBUG": "fips140=on"},
+            capture_output=True,
+            text=True,
+            check=False
+        )
 
-    output = f"{result.stdout}\n{result.stderr}"
-    note(output)
+        output = f"{result.stdout}\n{result.stderr}"
+        note(output)
 
     with Then("the process must terminate with a verification mismatch panic"):
         assert result.returncode != 0, error(

--- a/tests/e2e/steps_fips.py
+++ b/tests/e2e/steps_fips.py
@@ -210,6 +210,17 @@ FIPS_LISTENER_REJECTED_TLS_CASES = (
     *fips_rejected_cipher_cases_from_ciphers_by_protocol(),
 )
 
+FIPS_OPERATOR_APPROVED_TLS13_CIPHER = "TLS_AES_256_GCM_SHA384"
+FIPS_OPERATOR_APPROVED_TLS13_CIPHER_SUITES = ":".join(approved_tls1_3_ciphers)
+
+OPERATOR_CONTAINER_TLS_FAILURE_NEEDLES = (
+    "handshake failure",
+    "no shared cipher",
+    "alert handshake failure",
+    "TLS connect error",
+    "HTTP:000",
+)
+
 # ---------------------------------------------------------------------------
 # Build verification
 # ---------------------------------------------------------------------------
@@ -1081,6 +1092,44 @@ def openssl_cipher_args(tls_version, cipher_suite):
         return ["-ciphersuites", cipher_suite]
 
     return ["-cipher", cipher_suite]
+
+
+def fake_openssl_s_server_command(tls_version="1.3", cipher_suite=None):
+    """Build ``openssl s_server`` argv for the fake TLS server pod."""
+    command = [
+        "openssl", "s_server",
+        "-accept", "18443",
+        "-cert", "/tls/server.crt",
+        "-key", "/tls/server.key",
+    ]
+    command.extend(openssl_tls_version_args(tls_version))
+    command.extend(openssl_cipher_args(tls_version, cipher_suite))
+    command.extend(["-www", "-state"])
+    return command
+
+
+def curl_tls_version_args(tls_version, cipher_suite=None):
+    """Build curl TLS version/cipher flags for operator-container probes."""
+    if tls_version == "1.3":
+        args = ["--tlsv1.3"]
+        if cipher_suite:
+            args.extend(["--tls13-ciphers", cipher_suite])
+        return args
+
+    if tls_version == "1.2":
+        # --tlsv1.2 alone is a minimum; cap the max so curl cannot upgrade to 1.3.
+        args = ["--tls-max", "1.2", "--tlsv1.2"]
+    elif tls_version == "1.1":
+        args = ["--tls-max", "1.1", "--tlsv1.1"]
+    elif tls_version == "1.0":
+        args = ["--tls-max", "1.0", "--tlsv1.0"]
+    else:
+        raise ValueError(f"unsupported TLS version for curl: {tls_version}")
+
+    if cipher_suite:
+        args.extend(["--ciphers", cipher_suite])
+
+    return args
 
 
 def openssl_s_client_negotiated_cipher(output):
@@ -2433,11 +2482,18 @@ def fips_delete_fake_openssl_server(self, ns=None):
 
 
 @TestStep(Given)
-def fips_create_fake_openssl_server(self, cipher_suite, ns=None):
-    """Create fake TLS 1.3 server restricted to one cipher suite."""
+def fips_create_fake_openssl_server(self, ns=None):
+    """Create fake TLS 1.3 server offering only FIPS-approved cipher suites."""
     ns = ns or current().context.test_namespace
 
     fips_delete_fake_openssl_server(ns=ns)
+
+    server_command = " ".join(
+        shlex.quote(arg) for arg in fake_openssl_s_server_command(
+            tls_version="1.3",
+            cipher_suite=FIPS_OPERATOR_APPROVED_TLS13_CIPHER_SUITES,
+        )
+    )
 
     manifest = f"""
 apiVersion: v1
@@ -2454,14 +2510,7 @@ spec:
     command: ["sh", "-lc"]
     args:
     - |
-      openssl s_server \\
-        -accept 18443 \\
-        -cert /tls/server.crt \\
-        -key /tls/server.key \\
-        -tls1_3 \\
-        -ciphersuites {cipher_suite} \\
-        -www \\
-        -state
+      {server_command}
     ports:
     - containerPort: 18443
     volumeMounts:
@@ -2506,23 +2555,26 @@ spec:
 
 
 @TestStep(When)
-def fips_curl_tls13_from_operator_container(
+def fips_curl_tls_from_operator_container(
     self,
     container,
     url,
-    cipher_suite,
+    tls_version="1.3",
+    cipher_suite=None,
     ns=None,
 ):
-    """Run curl from one operator pod container with forced TLS 1.3 cipher."""
+    """Run curl from one operator pod container with forced TLS version/cipher."""
     ns = ns or current().context.operator_namespace
     operator_pod = kubectl.get_operator_pod(ns=ns)
+    curl_tls_flags = " ".join(
+        shlex.quote(arg) for arg in curl_tls_version_args(tls_version, cipher_suite)
+    )
 
     return kubectl.launch(
         f"exec {operator_pod} -c {container} -- "
         "sh -c '"
         "curl -k -sS -v "
-        "--tlsv1.3 "
-        f"--tls13-ciphers {cipher_suite} "
+        f"{curl_tls_flags} "
         f"{url} "
         "-o /dev/null "
         "-w \"HTTP:%{http_code}\" "
@@ -2533,35 +2585,96 @@ def fips_curl_tls13_from_operator_container(
     )
 
 
+@TestStep(When)
+def fips_curl_tls13_from_operator_container(
+    self,
+    container,
+    url,
+    cipher_suite,
+    ns=None,
+):
+    """Run curl from one operator pod container with forced TLS 1.3 cipher."""
+    return fips_curl_tls_from_operator_container(
+        container=container,
+        url=url,
+        tls_version="1.3",
+        cipher_suite=cipher_suite,
+        ns=ns,
+    )
+
+
+@TestStep(Then)
+def fips_assert_operator_containers_tls_fails(
+    self,
+    url,
+    tls_version="1.3",
+    cipher_suite=None,
+    case_name=None,
+    ns=None,
+):
+    """Assert both operator pod containers fail with the requested TLS probe."""
+    ns = ns or current().context.operator_namespace
+    label = case_name or cipher_suite or f"TLS {tls_version} protocol"
+
+    for container in ("clickhouse-operator", "metrics-exporter"):
+        with Then(f"{container} fails to negotiate {label} to {url}"):
+            out = fips_curl_tls_from_operator_container(
+                container=container,
+                url=url,
+                tls_version=tls_version,
+                cipher_suite=cipher_suite,
+                ns=ns,
+            )
+
+            assert any(
+                needle in out for needle in OPERATOR_CONTAINER_TLS_FAILURE_NEEDLES
+            ), error(
+                f"{container}: expected TLS handshake failure for {label}\n{out}"
+            )
+
+
 @TestStep(Then)
 def fips_assert_operator_containers_tls13_fails(
     self,
     url,
     cipher_suite,
+    case_name=None,
     ns=None,
 ):
     """Assert both operator pod containers fail with the requested TLS 1.3 cipher."""
-    ns = ns or current().context.operator_namespace
-
-    failure_needles = (
-        "handshake failure",
-        "no shared cipher",
-        "alert handshake failure",
-        "TLS connect error",
-        "HTTP:000",
+    fips_assert_operator_containers_tls_fails(
+        url=url,
+        tls_version="1.3",
+        cipher_suite=cipher_suite,
+        case_name=case_name,
+        ns=ns,
     )
 
-    for container in ("clickhouse-operator", "metrics-exporter"):
-        with Then(f"{container} fails to negotiate {cipher_suite} to {url}"):
-            out = fips_curl_tls13_from_operator_container(
-                container=container,
-                url=url,
-                cipher_suite=cipher_suite,
-                ns=ns,
-            )
 
-            assert any(needle in out for needle in failure_needles), error(
-                f"{container}: expected TLS handshake failure for {cipher_suite}\n{out}"
+@TestStep(Check)
+def fips_assert_rejected_tls_cases_on_fake_openssl_server(
+    self,
+    rejected_cases=None,
+    ns=None,
+):
+    """Assert operator clients fail all rejected TLS probes against approved fake server."""
+    operator_ns = current().context.operator_namespace
+    fake_url = f"https://{FAKE_OPENSSL_SERVER}:8443/ping"
+    rejected_cases = rejected_cases or FIPS_LISTENER_REJECTED_TLS_CASES
+
+    with Given(
+        "fake OpenSSL server offers only approved TLS 1.3 AES-GCM cipher suites"
+    ):
+        fips_create_fake_openssl_server(ns=ns)
+
+    for case in rejected_cases:
+        with Check(f"operator clients fail {case['name']} against approved-only fake server"):
+            fips_assert_operator_containers_tls_fails(
+                url=fake_url,
+                tls_version=case["tls_version"],
+                cipher_suite=case["cipher_suite"],
+                case_name=case["name"],
+                ns=operator_ns,
             )
 
 
@@ -2570,28 +2683,15 @@ def fips_assert_connection_rejected_on_non_approved_cipher(
     self,
     ns=None,
 ):
-    """Assert fake ChaCha-only TLS server rejects approved AES-only clients.
+    """Assert operator clients fail all rejected TLS probes against approved fake server.
 
-    This is the synthetic negative control for rejected cipher behavior.
+    Deploy one fake ``openssl s_server`` pod that offers only the approved TLS 1.3
+    AES-GCM cipher suites, then verify both operator containers fail every rejected
+    protocol/cipher client probe from ``FIPS_LISTENER_REJECTED_TLS_CASES``.
     """
     ns = ns or current().context.test_namespace
 
-    approved_cipher = "TLS_AES_256_GCM_SHA384"
-    rejected_cipher = "TLS_CHACHA20_POLY1305_SHA256"
-    fake_url = f"https://{FAKE_OPENSSL_SERVER}:8443/ping"
-
-    with Given("fake OpenSSL server offers only non-approved ChaCha TLS 1.3 cipher"):
-        fips_create_fake_openssl_server(
-            cipher_suite=rejected_cipher,
-            ns=ns,
-        )
-
-    with Then("operator pod containers restricted to approved AES-256 fail the handshake"):
-        fips_assert_operator_containers_tls13_fails(
-            url=fake_url,
-            cipher_suite=approved_cipher,
-            ns=ns,
-        )
-
-    with Finally("delete fake OpenSSL server"):
+    try:
+        fips_assert_rejected_tls_cases_on_fake_openssl_server(ns=ns)
+    finally:
         fips_delete_fake_openssl_server(ns=ns)

--- a/tests/e2e/steps_fips.py
+++ b/tests/e2e/steps_fips.py
@@ -34,6 +34,181 @@ import e2e.kubectl as kubectl
 
 
 FAKE_OPENSSL_SERVER = "fake-openssl-server"
+TLS_REJECT_MARKERS = (
+    "Cipher is (NONE)",
+    "Cipher    : 0000",
+    "handshake failure",
+    "alert handshake failure",
+    "no shared cipher",
+    "no protocols available",
+    "unsupported protocol",
+    "wrong version number",
+    "tlsv1 alert protocol version",
+    "no peer certificate available",
+)
+
+approved_tls1_3_ciphers = [
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_AES_128_GCM_SHA256",
+]
+ciphers_by_protocol = {
+    "TLSv1.3": [
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_AES_128_GCM_SHA256",
+    ],
+    "TLSv1.2": [
+        "ECDHE-ECDSA-AES256-GCM-SHA384",
+        "ECDHE-RSA-AES256-GCM-SHA384",
+        "DHE-DSS-AES256-GCM-SHA384",
+        "DHE-RSA-AES256-GCM-SHA384",
+        "ECDHE-ECDSA-CHACHA20-POLY1305",
+        "ECDHE-RSA-CHACHA20-POLY1305",
+        "DHE-RSA-CHACHA20-POLY1305",
+        "ECDHE-ECDSA-AES256-CCM",
+        "DHE-RSA-AES256-CCM",
+        "ECDHE-ECDSA-ARIA256-GCM-SHA384",
+        "ECDHE-ARIA256-GCM-SHA384",
+        "DHE-DSS-ARIA256-GCM-SHA384",
+        "DHE-RSA-ARIA256-GCM-SHA384",
+        "ADH-AES256-GCM-SHA384",
+        "ECDHE-ECDSA-AES128-GCM-SHA256",
+        "ECDHE-RSA-AES128-GCM-SHA256",
+        "DHE-DSS-AES128-GCM-SHA256",
+        "DHE-RSA-AES128-GCM-SHA256",
+        "ECDHE-ECDSA-AES128-CCM",
+        "DHE-RSA-AES128-CCM",
+        "ECDHE-ECDSA-ARIA128-GCM-SHA256",
+        "ECDHE-ARIA128-GCM-SHA256",
+        "DHE-DSS-ARIA128-GCM-SHA256",
+        "DHE-RSA-ARIA128-GCM-SHA256",
+        "ADH-AES128-GCM-SHA256",
+        "ECDHE-ECDSA-AES256-CCM8",
+        "ECDHE-ECDSA-AES128-CCM8",
+        "DHE-RSA-AES256-CCM8",
+        "DHE-RSA-AES128-CCM8",
+        "ECDHE-ECDSA-AES256-SHA384",
+        "ECDHE-RSA-AES256-SHA384",
+        "DHE-RSA-AES256-SHA256",
+        "DHE-DSS-AES256-SHA256",
+        "ECDHE-ECDSA-CAMELLIA256-SHA384",
+        "ECDHE-RSA-CAMELLIA256-SHA384",
+        "DHE-RSA-CAMELLIA256-SHA256",
+        "DHE-DSS-CAMELLIA256-SHA256",
+        "ADH-AES256-SHA256",
+        "ADH-CAMELLIA256-SHA256",
+        "ECDHE-ECDSA-AES128-SHA256",
+        "ECDHE-RSA-AES128-SHA256",
+        "DHE-RSA-AES128-SHA256",
+        "DHE-DSS-AES128-SHA256",
+        "ECDHE-ECDSA-CAMELLIA128-SHA256",
+        "ECDHE-RSA-CAMELLIA128-SHA256",
+        "DHE-RSA-CAMELLIA128-SHA256",
+        "DHE-DSS-CAMELLIA128-SHA256",
+        "ADH-AES128-SHA256",
+        "ADH-CAMELLIA128-SHA256",
+        "RSA-PSK-AES256-GCM-SHA384",
+        "DHE-PSK-AES256-GCM-SHA384",
+        "RSA-PSK-CHACHA20-POLY1305",
+        "DHE-PSK-CHACHA20-POLY1305",
+        "ECDHE-PSK-CHACHA20-POLY1305",
+        "DHE-PSK-AES256-CCM",
+        "RSA-PSK-ARIA256-GCM-SHA384",
+        "DHE-PSK-ARIA256-GCM-SHA384",
+        "AES256-GCM-SHA384",
+        "AES256-CCM",
+        "ARIA256-GCM-SHA384",
+        "PSK-AES256-GCM-SHA384",
+        "PSK-CHACHA20-POLY1305",
+        "PSK-AES256-CCM",
+        "PSK-ARIA256-GCM-SHA384",
+        "RSA-PSK-AES128-GCM-SHA256",
+        "DHE-PSK-AES128-GCM-SHA256",
+        "DHE-PSK-AES128-CCM",
+        "RSA-PSK-ARIA128-GCM-SHA256",
+        "DHE-PSK-ARIA128-GCM-SHA256",
+        "AES128-GCM-SHA256",
+        "AES128-CCM",
+        "ARIA128-GCM-SHA256",
+        "PSK-AES128-GCM-SHA256",
+        "PSK-AES128-CCM",
+        "PSK-ARIA128-GCM-SHA256",
+        "DHE-PSK-AES256-CCM8",
+        "DHE-PSK-AES128-CCM8",
+        "AES256-CCM8",
+        "AES128-CCM8",
+        "PSK-AES256-CCM8",
+        "PSK-AES128-CCM8",
+        "AES256-SHA256",
+        "CAMELLIA256-SHA256",
+        "AES128-SHA256",
+        "CAMELLIA128-SHA256",
+    ],
+    "TLSv1": [
+        "ECDHE-ECDSA-AES256-SHA",
+        "ECDHE-RSA-AES256-SHA",
+        "AECDH-AES256-SHA",
+        "ECDHE-ECDSA-AES128-SHA",
+        "ECDHE-RSA-AES128-SHA",
+        "AECDH-AES128-SHA",
+        "ECDHE-PSK-AES256-CBC-SHA384",
+        "ECDHE-PSK-AES256-CBC-SHA",
+        "RSA-PSK-AES256-CBC-SHA384",
+        "DHE-PSK-AES256-CBC-SHA384",
+        "ECDHE-PSK-CAMELLIA256-SHA384",
+        "RSA-PSK-CAMELLIA256-SHA384",
+        "DHE-PSK-CAMELLIA256-SHA384",
+        "PSK-AES256-CBC-SHA384",
+        "PSK-CAMELLIA256-SHA384",
+        "ECDHE-PSK-AES128-CBC-SHA256",
+        "ECDHE-PSK-AES128-CBC-SHA",
+        "RSA-PSK-AES128-CBC-SHA256",
+        "DHE-PSK-AES128-CBC-SHA256",
+        "ECDHE-PSK-CAMELLIA128-SHA256",
+        "RSA-PSK-CAMELLIA128-SHA256",
+        "DHE-PSK-CAMELLIA128-SHA256",
+        "PSK-AES128-CBC-SHA256",
+        "PSK-CAMELLIA128-SHA256",
+    ],
+}
+
+_OPENSSL_NEGOTIATED_CIPHER = re.compile(
+    r"(?:^|\n)Cipher is (?!\(NONE\))(?P<cipher>\S+)",
+    re.IGNORECASE,
+)
+
+CIPHERS_PROTOCOL_TLS_VERSION = {
+    "TLSv1.3": "1.3",
+    "TLSv1.2": "1.2",
+    "TLSv1": "1.0",
+}
+
+FIPS_REJECTED_PROTOCOL_CASES = (
+    {"name": "TLS 1.0 protocol", "tls_version": "1.0", "cipher_suite": None},
+    {"name": "TLS 1.1 protocol", "tls_version": "1.1", "cipher_suite": None},
+    {"name": "TLS 1.2 protocol", "tls_version": "1.2", "cipher_suite": None},
+)
+
+
+def fips_rejected_cipher_cases_from_ciphers_by_protocol():
+    """Every cipher in ciphers_by_protocol except approved TLS 1.3 suites."""
+    cases = []
+    for protocol, tls_version in CIPHERS_PROTOCOL_TLS_VERSION.items():
+        for cipher in ciphers_by_protocol[protocol]:
+            if protocol == "TLSv1.3" and cipher in approved_tls1_3_ciphers:
+                continue
+            cases.append({
+                "name": f"TLS {tls_version} {cipher}",
+                "tls_version": tls_version,
+                "cipher_suite": cipher,
+            })
+    return tuple(cases)
+
+
+FIPS_LISTENER_REJECTED_TLS_CASES = (
+    *FIPS_REJECTED_PROTOCOL_CASES,
+    *fips_rejected_cipher_cases_from_ciphers_by_protocol(),
+)
 
 # ---------------------------------------------------------------------------
 # Build verification
@@ -881,6 +1056,41 @@ def fips_wait_cluster_topology(
     note(f"{pod} sees {replica_count} hosts in cluster {cluster_name!r}")
 
 
+def openssl_tls_version_args(tls_version):
+    if tls_version == "1.3":
+        return ["-tls1_3"]
+    if tls_version == "1.2":
+        return ["-tls1_2"]
+    if tls_version == "1.1":
+        return ["-tls1_1"]
+    if tls_version == "1.0":
+        return ["-tls1"]
+    if tls_version == "ssl3":
+        return ["-ssl3"]
+    if tls_version == "ssl2":
+        return ["-ssl2"]
+
+    raise ValueError(f"unsupported TLS/SSL version: {tls_version}")
+
+
+def openssl_cipher_args(tls_version, cipher_suite):
+    if not cipher_suite:
+        return []
+
+    if tls_version == "1.3":
+        return ["-ciphersuites", cipher_suite]
+
+    return ["-cipher", cipher_suite]
+
+
+def openssl_s_client_negotiated_cipher(output):
+    """Return the negotiated cipher name when s_client completed a handshake."""
+    match = _OPENSSL_NEGOTIATED_CIPHER.search(output)
+    if match:
+        return match.group("cipher")
+    return None
+
+
 @TestStep(When)
 def fips_run_openssl_s_client_on_pod_port(
     self,
@@ -896,83 +1106,75 @@ def fips_run_openssl_s_client_on_pod_port(
     ca_crt = self.context.tls["ca_crt"]
     local_port = _free_local_port()
 
-    pf = subprocess.Popen(
-        [
-            "kubectl",
-            "-n", ns,
-            "port-forward",
-            f"pod/{pod}",
-            f"{local_port}:{port}",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-    try:
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            if pf.poll() is not None:
-                out, err = pf.communicate()
-                assert False, error(
-                    "kubectl port-forward exited early\n"
-                    f"stdout:\n{out}\n"
-                    f"stderr:\n{err}"
-                )
-
-            try:
-                socket.create_connection(
-                    ("127.0.0.1", int(local_port)), timeout=0.5
-                ).close()
-                break
-            except OSError:
-                time.sleep(0.2)
-        else:
-            assert False, error(
-                f"kubectl port-forward to {pod}:{port} "
-                f"did not become ready on 127.0.0.1:{local_port}"
-            )
-
-        command = [
-            "openssl", "s_client",
-            "-connect", f"127.0.0.1:{local_port}",
-            "-servername", "localhost",
-            "-CAfile", ca_crt,
-            "-verify_return_error",
-        ]
-
-        if tls_version == "1.3":
-            command.append("-tls1_3")
-            if cipher_suite:
-                command.extend(["-ciphersuites", cipher_suite])
-        elif tls_version == "1.2":
-            command.append("-tls1_2")
-            if cipher_suite:
-                command.extend(["-cipher", cipher_suite])
-        elif tls_version == "1.1":
-            command.append("-tls1_1")
-            if cipher_suite:
-                command.extend(["-cipher", cipher_suite])
-        else:
-            raise ValueError(f"unsupported TLS version: {tls_version}")
-
-        result = subprocess.run(
-            command,
-            input="Q\n",
+    with Given(f"port-forward from localhost:{local_port} to {pod}:{port}"):
+        pf = subprocess.Popen(
+            [
+                "kubectl",
+                "-n", ns,
+                "port-forward",
+                f"pod/{pod}",
+                f"{local_port}:{port}",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            capture_output=True,
-            check=False,
         )
 
-        output = f"{result.stdout}\n{result.stderr}"
+    try:
+        with When("port-forward is ready on localhost"):
+            deadline = time.time() + 10
+            while time.time() < deadline:
+                if pf.poll() is not None:
+                    out, err = pf.communicate()
+                    assert False, error(
+                        "kubectl port-forward exited early\n"
+                        f"stdout:\n{out}\n"
+                        f"stderr:\n{err}"
+                    )
+
+                try:
+                    socket.create_connection(
+                        ("127.0.0.1", int(local_port)), timeout=0.5
+                    ).close()
+                    break
+                except OSError:
+                    time.sleep(0.2)
+            else:
+                assert False, error(
+                    f"kubectl port-forward to {pod}:{port} "
+                    f"did not become ready on 127.0.0.1:{local_port}"
+                )
+
+        with And("openssl s_client runs against the forwarded port"):
+            command = [
+                "openssl", "s_client",
+                "-connect", f"127.0.0.1:{local_port}",
+                "-servername", "localhost",
+                "-CAfile", ca_crt,
+                "-verify_return_error",
+            ]
+
+            command.extend(openssl_tls_version_args(tls_version))
+            command.extend(openssl_cipher_args(tls_version, cipher_suite))
+
+            result = subprocess.run(
+                command,
+                input="Q\n",
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            output = f"{result.stdout}\n{result.stderr}"
 
         if not ok_to_fail:
-            assert result.returncode == 0, error(
-                f"{pod}:{port}: openssl s_client failed for "
-                f"tls={tls_version}, cipher={cipher_suite}\n"
-                f"exit code: {result.returncode}\n"
-                f"output:\n{output}"
-            )
+            with Then("openssl s_client handshake succeeds"):
+                assert result.returncode == 0, error(
+                    f"{pod}:{port}: openssl s_client failed for "
+                    f"tls={tls_version}, cipher={cipher_suite}\n"
+                    f"exit code: {result.returncode}\n"
+                    f"output:\n{output}"
+                )
 
         return output
 
@@ -983,64 +1185,78 @@ def fips_run_openssl_s_client_on_pod_port(
         except subprocess.TimeoutExpired:
             pf.kill()
 
-@TestStep(Then)
-def fips_assert_rejected_tls_probes(
+@TestStep(Check)
+def fips_assert_rejected_tls_cases_on_endpoint(
+    self,
+    label,
+    pod,
+    port,
+    rejected_cases,
+    ns=None,
+):
+    """Assert rejected TLS protocol/cipher cases fail on one endpoint."""
+    ns = ns or self.context.test_namespace
+
+    for case in rejected_cases:
+        with Check(f"{label} {pod}:{port} rejects {case['name']}"):
+            output = fips_run_openssl_s_client_on_pod_port(
+                pod=pod,
+                port=port,
+                tls_version=case["tls_version"],
+                cipher_suite=case["cipher_suite"],
+                ok_to_fail=True,
+                ns=ns,
+            )
+
+            output_lower = output.lower()
+
+            negotiated_cipher = openssl_s_client_negotiated_cipher(output)
+            assert negotiated_cipher is None, error(
+                f"{label} {pod}:{port}: server negotiated disallowed {case['name']}\n"
+                f"negotiated cipher: {negotiated_cipher}\n"
+                f"tls_version={case['tls_version']}\n"
+                f"cipher_suite={case['cipher_suite']}\n"
+                f"output:\n{output}"
+            )
+
+            assert any(
+                marker.lower() in output_lower
+                for marker in TLS_REJECT_MARKERS
+            ), error(
+                f"{label} {pod}:{port}: expected TLS rejection for {case['name']}\n"
+                f"tls_version={case['tls_version']}\n"
+                f"cipher_suite={case['cipher_suite']}\n"
+                f"output:\n{output}"
+            )
+
+
+@TestStep(Check)
+def fips_assert_all_rejected_tls_cases_on_all_endpoints(
     self,
     chi_pods,
     chk_pods,
     ns=None,
 ):
-    """Assert rejected TLS protocol/cipher combinations fail handshake."""
+    """Assert all rejected TLS cases fail on every FIPS TLS endpoint."""
     ns = ns or self.context.test_namespace
-
-    rejected_cases = (
-        {
-            "name": "TLS 1.3 ChaCha20-Poly1305",
-            "tls_version": "1.3",
-            "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
-        },
-        {
-            "name": "TLS 1.1 protocol",
-            "tls_version": "1.1",
-            "cipher_suite": None,
-        },
-    )
+    rejected_cases = FIPS_LISTENER_REJECTED_TLS_CASES
 
     endpoints = (
         ("ClickHouse HTTPS", chi_pods[0], 8443),
         ("ClickHouse native TLS", chi_pods[0], 9440),
         ("ClickHouse interserver HTTPS", chi_pods[0], 9010),
         ("Keeper secure client", chk_pods[0], 2281),
-        ("Backup API HTTPS", chi_pods[0], 7171),
     )
 
-    rejected_markers = (
-        "Cipher is (NONE)",
-        "handshake failure",
-        "no protocols available",
-        "no shared cipher",
-    )
+    for label, pod, port in endpoints:
+        fips_assert_rejected_tls_cases_on_endpoint(
+            label=label,
+            pod=pod,
+            port=port,
+            rejected_cases=rejected_cases,
+            ns=ns,
+        )
 
-    for case in rejected_cases:
-        for label, pod, port in endpoints:
-            with Then(f"{label} {pod}:{port} rejects {case['name']}"):
-                output = fips_run_openssl_s_client_on_pod_port(
-                    pod=pod,
-                    port=port,
-                    tls_version=case["tls_version"],
-                    cipher_suite=case["cipher_suite"],
-                    ok_to_fail=True,
-                    ns=ns,
-                )
-
-                assert any(
-                    marker.lower() in output.lower()
-                    for marker in rejected_markers
-                ), error(
-                    f"{label} {pod}:{port}: expected rejected TLS probe to fail "
-                    f"for {case['name']}\n"
-                    f"output:\n{output}"
-                )
 
 @TestStep(Then)
 def fips_assert_aes256_tls13_probes(

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -7851,8 +7851,8 @@ def test_030003(self):
             chk_pods=chk_pods,
         )
 
-    with Check("rejected TLS protocol and cipher combinations fail negotiation"):
-        fips_assert_rejected_tls_probes(
+    with Check("all rejected TLS protocol and cipher cases fail on every FIPS TLS endpoint"):
+        fips_assert_all_rejected_tls_cases_on_all_endpoints(
             chi_pods=chi_pods,
             chk_pods=chk_pods,
         )
@@ -8831,7 +8831,7 @@ def test_030016(self):
             ns=self.context.test_namespace,
         )
 
-    with Check("ClickHouse native TLS accepts the approved TLS 1.2 AES-GCM cipher"):
+    with Then("check ClickHouse native TLS accepts the approved TLS 1.2 AES-GCM cipher"):
         out = fips_run_openssl_s_client_on_pod_port(
             pod=chi_pod,
             port=9440,
@@ -8843,7 +8843,7 @@ def test_030016(self):
         assert "Protocol  : TLSv1.2" in out, error(out)
         assert "Cipher    : ECDHE-RSA-AES256-GCM-SHA384" in out, error(out)
 
-    with Check("ClickHouse native TLS rejects the disallowed TLS 1.2 ChaCha20 cipher"):
+    with Then("check ClickHouse native TLS rejects the disallowed TLS 1.2 ChaCha20 cipher"):
         out = fips_run_openssl_s_client_on_pod_port(
             pod=chi_pod,
             port=9440,
@@ -8873,7 +8873,7 @@ def cleanup_chis(self):
 
 
 @TestModule
-@Name("test_operator")
+@Name("e2e.test_operator")
 @Requirements(RQ_SRS_026_ClickHouseOperator_CustomResource_APIVersion("1.0"),
               RQ_SRS_026_ClickHouseOperator("1.0"))
 def test(self):

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -7721,10 +7721,10 @@ def test_030001(self):
     op_bin = self.context.fips_op_bin
     me_bin = self.context.fips_me_bin
 
-    with Then("check go version -m <binary> version for operator"):
+    with Check("operator binary embeds GOFIPS140 build metadata"):
         check_binary_go_version(binary_path=op_bin, version=gofips140_needle)
 
-    with And("check runtime FIPS modes for operator"):
+    with Check("operator reports expected runtime FIPS modes"):
         check_fips_runtime_modes(
             binary_path=op_bin,
             binary="clickhouse-operator",
@@ -7733,10 +7733,10 @@ def test_030001(self):
             godebug_default=godebug_default,
         )
 
-    with Then("check go version -m <binary> version for metrics exporter"):
+    with Check("metrics-exporter binary embeds GOFIPS140 build metadata"):
         check_binary_go_version(binary_path=me_bin, version=gofips140_needle)
 
-    with And("check runtime FIPS modes for metrics-exporter"):
+    with Check("metrics-exporter reports expected runtime FIPS modes"):
         check_fips_runtime_modes(
             binary_path=me_bin,
             binary="metrics-exporter",
@@ -7794,23 +7794,23 @@ def test_030003(self):
     with Check("operator pod passes essential FIPS checks"):
         run_operator_fips_checks()
 
-    with When("test TLS secret is installed"):
+    with Given("test TLS secret is installed for ClickHouse and Keeper hosts"):
         create_tls_secret_for_fips_hosts(chi=chi, chk=chk)
 
     with And("external ClickHouse client container is started"):
         start_external_ch_container()
 
-    with And("FIPS ClickHouse Keeper is deployed with TLS settings"):
+    with When("FIPS ClickHouse Keeper is deployed with TLS settings"):
         fips_apply_manifest(
             manifest_path=chk_manifest,
             replica_count=2,
             kind="chk",
         )
 
-    with Then("check Keeper cluster passes essential FIPS checks"):
+    with Then("Keeper cluster passes essential FIPS checks"):
         chk_pods = run_chk_fips_checks(workload=chk, replica_count=2)
 
-    with When("FIPS ClickHouse is deployed with TLS settings"):
+    with When("FIPS ClickHouse is deployed with TLS settings and backup template"):
         fips_apply_manifest(
             manifest_path=chi_manifest,
             replica_count=chi_replica_count,
@@ -7818,31 +7818,31 @@ def test_030003(self):
             apply_templates=[backup_template],
         )
 
-    with Check("operator outbound connections to CHI and CHK after reconcile"):
+    with Check("operator uses TLS-compliant outbound paths after reconcile"):
         run_operator_reconcile_fips_checks()
 
-    with Check("metrics-exporter discovers ClickHouse using HTTPS"):
+    with Check("metrics-exporter discovers ClickHouse through HTTPS"):
         check_metrics_exporter_discovers_clickhouse_https()
 
-    with Check("ClickHouse replicas connect to Keeper using secure client port"):
+    with Check("ClickHouse replicas use Keeper secure client port"):
         check_clickhouse_uses_secure_keeper_port(chi=chi)
 
-    with Then("check ClickHouse cluster passes essential FIPS checks"):
+    with Then("ClickHouse cluster passes essential FIPS checks"):
         chi_pods = run_chi_fips_checks(
             workload=chi,
             replica_count=chi_replica_count,
         )
 
-    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+    with Then("clickhouse-backup sidecar passes essential FIPS checks"):
         backup_pods = run_backup_fips_checks(
             workload=chi,
             replica_count=chi_replica_count,
         )
 
-    with Check("ReplicatedMergeTree data converges over the TLS setup"):
+    with Check("ReplicatedMergeTree data converges over TLS"):
         fips_check_replication_across_replicas(chi_pods=chi_pods)
 
-    with Check("backup and restore succeeds through HTTPS API"):
+    with Check("backup and restore succeed through HTTPS API"):
         check_clickhouse_backup_restore_roundtrip_https(pod=backup_pods[0])
 
     with Check("approved AES-256 TLS 1.3 cipher is negotiated"):
@@ -7851,10 +7851,10 @@ def test_030003(self):
             chk_pods=chk_pods,
         )
 
-    with Check("rejected TLS protocol and cipher combinations are not negotiated"):
+    with Check("rejected TLS protocol and cipher combinations fail negotiation"):
         fips_assert_rejected_tls_probes(
             chi_pods=chi_pods,
-            chk_pods=chk_pods
+            chk_pods=chk_pods,
         )
 
 @TestScenario
@@ -7884,7 +7884,7 @@ def test_030004(self):
     with Given("strict FIPS operator configuration is applied"):
         util.apply_operator_config(chopconf)
 
-    with And("test TLS secret covers up to 3 CHI replicas"):
+    with And("test TLS secret covers up to 3 CHI and CHK replicas"):
         create_tls_secret_for_fips_hosts(chi=chi, chk=chk, replicas=3)
 
     with And("external ClickHouse client container is started"):
@@ -7897,7 +7897,7 @@ def test_030004(self):
             kind="chk",
         )
 
-    with And("FIPS ClickHouse is deployed with 2 replicas"):
+    with And("FIPS ClickHouse is deployed with 2 replicas and backup sidecars"):
         chi_manifest_2 = fips_edit_manifest(
             source_manifest=chi_manifest,
             replicas_count=2,
@@ -7910,19 +7910,19 @@ def test_030004(self):
             apply_templates=[backup_template],
         )
 
-    with Then("check 2-replica cluster passes essential FIPS checks"):
+    with Then("2-replica ClickHouse cluster passes essential FIPS checks"):
         chi_pods = run_chi_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("check clickhouse-backup sidecar passes essential FIPS checks"):
+    with Check("clickhouse-backup sidecars pass essential FIPS checks"):
         run_backup_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("check ReplicatedMergeTree data converges across 2 replicas"):
+    with Check("ReplicatedMergeTree data converges across 2 replicas"):
         fips_check_replication_across_replicas(chi_pods=chi_pods)
 
     with When("CHI is upscaled to 3 replicas"):
@@ -7937,19 +7937,19 @@ def test_030004(self):
             kind="chi",
         )
 
-    with Then("check 3-replica cluster passes essential FIPS checks"):
+    with Then("3-replica ClickHouse cluster passes essential FIPS checks"):
         chi_pods = run_chi_fips_checks(
             workload=chi,
             replica_count=3,
         )
 
-    with And("check clickhouse-backup sidecar passes essential FIPS checks"):
+    with Check("clickhouse-backup sidecars pass essential FIPS checks"):
         run_backup_fips_checks(
             workload=chi,
             replica_count=3,
         )
 
-    with And("check ReplicatedMergeTree data converges across 3 replicas"):
+    with Check("ReplicatedMergeTree data converges across 3 replicas"):
         fips_check_replication_across_replicas(
             chi_pods=chi_pods,
             table="repl_scale_test_3",
@@ -7967,19 +7967,19 @@ def test_030004(self):
             kind="chi",
         )
 
-    with Then("single-replica cluster passes essential FIPS checks"):
+    with Check("single-replica ClickHouse cluster passes essential FIPS checks"):
         run_chi_fips_checks(
             workload=chi,
             replica_count=1,
         )
 
-    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+    with Check("clickhouse-backup sidecar passes essential FIPS checks"):
         run_backup_fips_checks(
             workload=chi,
             replica_count=1,
         )
 
-    with When("CHI OpenSSL cipher suites are updated"):
+    with When("CHI OpenSSL cipher suites are updated to allow only AES-128 TLS 1.3"):
         chi_manifest_update = fips_edit_manifest(
             source_manifest=chi_manifest,
             replicas_count=1,
@@ -7994,7 +7994,7 @@ def test_030004(self):
             apply_templates=[backup_template],
         )
 
-    with Then("removed ClickHouse cipher is no longer negotiated"):
+    with Check("removed AES-256 TLS 1.3 cipher is rejected on ClickHouse native TLS port"):
         chi_pods = sorted(kubectl.get_pod_names(chi))
 
         check_tls13_cipher_fails(
@@ -8031,7 +8031,7 @@ def test_030005(self):
     with Given("strict FIPS operator configuration is applied"):
         util.apply_operator_config(chopconf)
 
-    with And("test TLS secret covers up to 3 CHI and CHK replicas"):
+    with And("TLS secret covers up to 3 CHI and CHK replicas"):
         create_tls_secret_for_fips_hosts(chi=chi, chk=chk, replicas=3)
 
     with And("external ClickHouse client container is started"):
@@ -8049,13 +8049,13 @@ def test_030005(self):
             kind="chk",
         )
 
-    with Then("2-replica Keeper cluster passes essential FIPS checks"):
+    with Check("2-replica Keeper cluster passes essential FIPS checks"):
         run_chk_fips_checks(
             workload=chk,
             replica_count=2,
         )
 
-    with And("FIPS ClickHouse is deployed with 2 replicas"):
+    with When("FIPS ClickHouse is deployed with 2 replicas"):
         chi_manifest_2 = fips_edit_manifest(
             source_manifest=chi_manifest,
             replicas_count=2,
@@ -8068,22 +8068,22 @@ def test_030005(self):
             apply_templates=[backup_template],
         )
 
-    with And("2-replica ClickHouse cluster passes essential FIPS checks"):
+    with Then("2-replica ClickHouse cluster passes essential FIPS checks"):
         chi_pods = run_chi_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+    with Check("clickhouse-backup sidecars pass essential FIPS checks"):
         run_backup_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("ReplicatedMergeTree data converges across 2 ClickHouse replicas"):
+    with Check("ReplicatedMergeTree data converges across 2 ClickHouse replicas"):
         fips_check_replication_across_replicas(chi_pods=chi_pods)
 
-    with When("CHK is upscaled to 3 replicas"):
+    with When("Keeper is upscaled to 3 replicas"):
         chk_manifest_3 = fips_edit_manifest(
             source_manifest=chk_manifest,
             replicas_count=3,
@@ -8095,31 +8095,31 @@ def test_030005(self):
             kind="chk",
         )
 
-    with Then("3-replica Keeper cluster passes essential FIPS checks"):
+    with Check("3-replica Keeper cluster passes essential FIPS checks"):
         run_chk_fips_checks(
             workload=chk,
             replica_count=3,
         )
 
-    with And("ClickHouse remains healthy after Keeper upscale"):
+    with Then("ClickHouse cluster remains healthy after Keeper upscale"):
         chi_pods = run_chi_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+    with Check("clickhouse-backup sidecars pass essential FIPS checks after Keeper upscale"):
         run_backup_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("ReplicatedMergeTree data still converges after Keeper upscale"):
+    with Check("ReplicatedMergeTree data converges after Keeper upscale"):
         fips_check_replication_across_replicas(
             chi_pods=chi_pods,
             table="repl_chk_scale_test_3",
         )
 
-    with When("CHK is downscaled to 1 replica"):
+    with When("Keeper is downscaled to 1 replica"):
         chk_manifest_1 = fips_edit_manifest(
             source_manifest=chk_manifest,
             replicas_count=1,
@@ -8131,31 +8131,31 @@ def test_030005(self):
             kind="chk",
         )
 
-    with Then("single-replica Keeper cluster passes essential FIPS checks"):
+    with Check("single-replica Keeper cluster passes essential FIPS checks"):
         run_chk_fips_checks(
             workload=chk,
             replica_count=1,
         )
 
-    with And("ClickHouse remains healthy after Keeper downscale"):
+    with Then("ClickHouse cluster remains healthy after Keeper downscale"):
         chi_pods = run_chi_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("clickhouse-backup sidecar passes essential FIPS checks"):
+    with Check("clickhouse-backup sidecars pass essential FIPS checks after Keeper downscale"):
         run_backup_fips_checks(
             workload=chi,
             replica_count=2,
         )
 
-    with And("ReplicatedMergeTree data still converges after Keeper downscale"):
+    with Check("ReplicatedMergeTree data converges after Keeper downscale"):
         fips_check_replication_across_replicas(
             chi_pods=chi_pods,
             table="repl_chk_scale_test_1",
         )
 
-    with When("CHK OpenSSL cipher suites are updated"):
+    with When("Keeper OpenSSL cipher suites are updated"):
         chk_manifest_update = fips_edit_manifest(
             source_manifest=chk_manifest,
             replicas_count=1,
@@ -8169,7 +8169,7 @@ def test_030005(self):
             kind="chk",
         )
 
-    with Then("removed Keeper cipher is no longer negotiated"):
+    with Check("removed Keeper TLS 1.3 cipher is no longer negotiated"):
         chi_pods = sorted(kubectl.get_pod_names(chi))
         chk_pods = kubectl.get_chk_pod_names(chk)
 
@@ -8247,89 +8247,89 @@ def test_030007(self):
     with Given("strict FIPS operator configuration is applied"):
         util.apply_operator_config(chopconf)
 
-    with When("CHI references plain-text external ZooKeeper"):
+    with When("CHI with plain-text external ZooKeeper is applied"):
         chi_zk = yaml_manifest.get_name(util.get_full_path(chi_zk_rejected))
         fips_apply_manifest_raw(manifest_path=chi_zk_rejected)
 
-    with Then("CHI is aborted with FIPSValidationFailed"):
+    with Check("CHI is aborted with FIPSValidationFailed and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_zk,
             reason="FIPSValidationFailed",
             expect_no_sts=True,
         )
 
-    with When("CHI sets external ZooKeeper secure=false explicitly"):
+    with When("CHI with external ZooKeeper secure=false is applied"):
         chi_zk_explicit = yaml_manifest.get_name(
             util.get_full_path(chi_zk_rejected_explicit_false)
         )
         fips_apply_manifest_raw(manifest_path=chi_zk_rejected_explicit_false)
 
-    with Then("CHI is aborted with FIPSValidationFailed"):
+    with Check("CHI is aborted with FIPSValidationFailed and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_zk_explicit,
             reason="FIPSValidationFailed",
             expect_no_sts=True,
         )
 
-    with When("CHI sets spec.security.clickhouse.tls.verify=None"):
+    with When("CHI with spec.security.clickhouse.tls.verify=None is applied"):
         chi_bypass = yaml_manifest.get_name(
             util.get_full_path(chi_bypass_rejected)
         )
         fips_apply_manifest_raw(manifest_path=chi_bypass_rejected)
 
-    with Then("CHI is aborted with FIPSValidationFailed"):
+    with Check("CHI is aborted with FIPSValidationFailed and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_bypass,
             reason="FIPSValidationFailed",
             expect_no_sts=True,
         )
 
-    with When("CHI sets cluster.security.clickhouse.tls.verify=None"):
+    with When("CHI with cluster.security.clickhouse.tls.verify=None is applied"):
         chi_cluster_bypass = yaml_manifest.get_name(
             util.get_full_path(chi_cluster_verify_none)
         )
         fips_apply_manifest_raw(manifest_path=chi_cluster_verify_none)
 
-    with Then("CHI is aborted with FIPSValidationFailed"):
+    with Check("CHI is aborted with FIPSValidationFailed and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_cluster_bypass,
             reason="FIPSValidationFailed",
             expect_no_sts=True,
         )
 
-    with When("CHI sets clickhouse.tls.minVersion to an invalid value"):
+    with When("CHI with invalid clickhouse.tls.minVersion is applied"):
         chi_minversion = yaml_manifest.get_name(
             util.get_full_path(chi_invalid_minversion)
         )
         fips_apply_manifest_raw(manifest_path=chi_invalid_minversion)
 
-    with Then("CHI is aborted with FIPSValidationFailed"):
+    with Check("CHI is aborted with FIPSValidationFailed and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_minversion,
             reason="FIPSValidationFailed",
             expect_no_sts=True,
         )
 
-    with When("CHI sets zookeeper.tls.verify=None"):
+    with When("CHI with zookeeper.tls.verify=None is applied"):
         chi_zk_verify = yaml_manifest.get_name(
             util.get_full_path(chi_zk_verify_none)
         )
         fips_apply_manifest_raw(manifest_path=chi_zk_verify_none)
 
-    with Then("CHI is aborted with FIPSValidationFailed"):
+    with Check("CHI is aborted with FIPSValidationFailed and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_zk_verify,
             reason="FIPSValidationFailed",
             expect_no_sts=True,
         )
 
-    with When("CHK sets spec-level security bypass"):
+    with When("CHK with spec-level security bypass is applied"):
         chk_bypass = yaml_manifest.get_name(
             util.get_full_path(chk_bypass_rejected)
         )
         fips_apply_manifest_raw(manifest_path=chk_bypass_rejected)
 
-    with Then("CHK is aborted with FIPSValidationFailed"):
+    with Check("CHK is aborted with FIPSValidationFailed and no StatefulSet is created"):
         fips_assert_chk_aborted(
             chk=chk_bypass,
             reason="FIPSValidationFailed",
@@ -8415,13 +8415,13 @@ def test_030008(self):
         util.get_full_path(chi_permissive_manifest)
     )
 
-    with Given("FIPS image policy Required is applied"):
+    with Given("FIPSRequired image policy is applied"):
         util.apply_operator_config(chopconf)
 
-    with When("CHI with non-fips image tag is applied"):
+    with When("CHI with non-FIPS image tag is applied"):
         fips_apply_manifest_raw(manifest_path=chi_non_fips_manifest)
 
-    with Then("CHI is aborted at admission with FIPSImagePolicyViolation"):
+    with Check("CHI is aborted with leading FIPSImagePolicyViolation and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_non_fips,
             reason="FIPSImagePolicyViolation",
@@ -8429,17 +8429,17 @@ def test_030008(self):
             expect_reason_leading=True,
         )
 
-    with When("CHK with non-fips image tag is applied"):
+    with When("CHK with non-FIPS image tag is applied"):
         fips_apply_manifest_raw(manifest_path=chk_non_fips_manifest)
 
-    with Then("CHK is aborted at admission with FIPSImagePolicyViolation"):
+    with Check("CHK is aborted with FIPSImagePolicyViolation and no StatefulSet is created"):
         fips_assert_chk_aborted(
             chk=chk_non_fips,
             reason="FIPSImagePolicyViolation",
             expect_no_sts=True,
         )
 
-    with And("aborted non-fips CHK is deleted before switching image policy"):
+    with When("aborted non-FIPS CHK is deleted before switching image policy"):
         kubectl.launch(
             f"delete chk {chk_non_fips}",
             ns=self.context.test_namespace,
@@ -8447,7 +8447,7 @@ def test_030008(self):
             ok_to_fail=True,
         )
 
-    with When("CHI with two non-fips replicas is applied"):
+    with When("CHI with two non-FIPS replicas is applied"):
         fips_apply_manifest_raw(manifest_path=chi_shortcircuit_manifest)
 
     with Then("CHI is aborted with a single FIPSImagePolicyViolation"):
@@ -8466,17 +8466,17 @@ def test_030008(self):
     with When("CHI with digest-only image reference is applied"):
         fips_apply_manifest_raw(manifest_path=chi_digest_only_manifest)
 
-    with Then("CHI is aborted because digest-only is not detected as FIPS"):
+    with Check("CHI is aborted with FIPSImagePolicyViolation and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_digest_only,
             reason="FIPSImagePolicyViolation",
             expect_no_sts=True,
         )
 
-    with When("CHI with fips in registry hostname but not in tag is applied"):
+    with When("CHI with fips only in registry hostname is applied"):
         fips_apply_manifest_raw(manifest_path=chi_registry_path_manifest)
 
-    with Then("CHI is aborted because registry path does not satisfy FIPS tag detection"):
+    with Check("CHI is aborted with FIPSImagePolicyViolation and no StatefulSet is created"):
         fips_assert_chi_aborted(
             chi=chi_registry_path,
             reason="FIPSImagePolicyViolation",
@@ -8490,28 +8490,28 @@ def test_030008(self):
             kind="chi",
         )
 
-    with Then("CHI reconciles without image policy violation"):
+    with Then("check CHI has no FIPSImagePolicyViolation after reconcile"):
         errors = kubectl.get_field("chi", chi_fips, ".status.errors")
         assert "FIPSImagePolicyViolation" not in errors, error(
             f"unexpected FIPSImagePolicyViolation in status.errors, got {errors}"
         )
 
-    with When("CHI with fips-suffix tag is applied"):
+    with When("CHI with fips-suffix image tag is applied"):
         fips_apply_manifest_raw(manifest_path=chi_fips_suffix_manifest)
 
-    with Then("CHI passes image-policy admission because tag contains fips"):
+    with Check("CHI is admitted because the image tag contains fips"):
         fips_assert_chi_admitted(chi=chi_fips_suffix)
 
-    with And("fips-suffix CHI is deleted after admission-only check"):
+    with Finally("fips-suffix CHI admission-only resources are deleted"):
         fips_cleanup_admission_only_chi(chi=chi_fips_suffix)
 
-    with When("CHI with uppercase FIPS tag is applied"):
+    with When("CHI with uppercase FIPS image tag is applied"):
         fips_apply_manifest_raw(manifest_path=chi_case_insensitive_manifest)
 
-    with Then("CHI passes image-policy admission because tag detection is case-insensitive"):
+    with Check("CHI is admitted because image tag detection is case-insensitive"):
         fips_assert_chi_admitted(chi=chi_case_insensitive)
 
-    with And("case-insensitive CHI is deleted after admission-only check"):
+    with Finally("case-insensitive CHI admission-only resources are deleted"):
         fips_cleanup_admission_only_chi(chi=chi_case_insensitive)
 
     with When("runtime decoy image alias is prepared"):
@@ -8542,10 +8542,10 @@ def test_030008(self):
                 f"minikube image load failed ({load_result.stderr.strip()})"
             )
         else:
-            with When("CHI with fips tag but non-fips binary is applied"):
+            with When("CHI with FIPS-looking tag but non-FIPS binary is applied"):
                 fips_apply_manifest_raw(manifest_path=chi_runtime_decoy_manifest)
 
-            with Then("CHI is aborted at runtime with FIPSImagePolicyViolation"):
+            with Then("check CHI is aborted at runtime with FIPSImagePolicyViolation"):
                 kubectl.wait_chi_status(chi_decoy, "Aborted")
                 errors = kubectl.get_field("chi", chi_decoy, ".status.errors")
                 assert "FIPSImagePolicyViolation" in errors, error(
@@ -8562,10 +8562,10 @@ def test_030008(self):
 
         util.apply_operator_config(chi_permissive_chopconf)
 
-    with And("a non-fips CHI is applied under Permissive policy"):
+    with When("non-FIPS CHI is applied under Permissive policy"):
         fips_apply_manifest_raw(manifest_path=chi_permissive_manifest)
 
-    with Then("non-fips CHI is admitted without FIPSImagePolicyViolation"):
+    with Check("non-FIPS CHI is admitted without FIPSImagePolicyViolation"):
         fips_assert_chi_admitted(chi=chi_permissive)
 
 
@@ -8601,40 +8601,40 @@ def test_030009(self):
     with And("test TLS secret is installed"):
         create_tls_secret_for_fips_hosts(chi=chi_tls12, chk=chk)
 
-    with And("normal CHK is applied"):
+    with And("TLS 1.3-capable Keeper cluster is deployed"):
         fips_apply_manifest(
             manifest_path=chk_manifest,
             replica_count=2,
             kind="chk",
         )
 
-    with Then("normal CHK becomes healthy"):
+    with Check("TLS 1.3-capable Keeper cluster passes essential FIPS checks"):
         run_chk_fips_checks(
             workload=chk,
             replica_count=2,
         )
 
-    with When("CHI server disables TLS 1.3"):
+    with When("TLS 1.2-only CHI is applied"):
         fips_apply_manifest(
             manifest_path=chi_tls12_manifest,
             kind="chi",
             expected_status="InProgress",
         )
 
-    with Then("operator rejects CHI because TLS 1.3 cannot be negotiated"):
+    with Check("operator rejects CHI because TLS 1.3 cannot be negotiated"):
         fips_assert_chi_tls_rejected(
             chi=chi_tls12,
             min_version="1.3",
         )
 
-    with When("CHK server disables TLS 1.3"):
+    with When("TLS 1.2-only CHK is applied"):
         fips_apply_manifest(
             manifest_path=chk_tls12_manifest,
             kind="chk",
             expected_status="InProgress",
         )
 
-    with Then("operator rejects CHK because TLS 1.3 cannot be negotiated"):
+    with Check("operator rejects CHK because TLS 1.3 cannot be negotiated"):
         fips_assert_chk_tls_rejected(
             chk=chk_tls12,
             min_version="1.3",
@@ -8671,7 +8671,7 @@ def test_030010(self):
     with And("test TLS secret is installed"):
         create_tls_secret_for_fips_hosts(chi=chi, chk=chk)
 
-    with And("FIPS ClickHouse Keeper is deployed as CHI dependency"):
+    with And("FIPS ClickHouse Keeper dependency is deployed"):
         fips_apply_manifest(
             manifest_path=chk_manifest,
             replica_count=2,
@@ -8686,7 +8686,7 @@ def test_030010(self):
             apply_templates=[backup_template],
         )
 
-    with Then("ClickHouse cluster pods are ready"):
+    with Then("ClickHouse pod names are collected after cluster readiness"):
         kubectl.wait_chi_status(chi, "Completed")
         kubectl.wait_objects(
             chi,
@@ -8698,12 +8698,12 @@ def test_030010(self):
         )
         chi_pods = sorted(kubectl.get_pod_names(chi))
 
-    with Then("operator pod containers negotiate AES-256 TLS 1.3 to K8s and CHI"):
+    with Check("operator pod containers negotiate AES-256 TLS 1.3 with Kubernetes API and ClickHouse HTTPS"):
         check_synthetic_tls13_smoke_from_operator_pod(
             chi_pod=chi_pods[0],
         )
 
-    with Then("operator pod containers reject fake openSSL server with non approved cipher"):
+    with Check("operator pod containers restricted to AES-256 fail against a ChaCha-only TLS server"):
         fips_assert_connection_rejected_on_non_approved_cipher()
 
 
@@ -8724,13 +8724,13 @@ def test_030011(self):
     with Given("operator and metrics-exporter binaries are extracted"):
         fips_extract_shipped_binaries()
 
-    with Then("clickhouse-operator detects tampering"):
+    with Check("clickhouse-operator detects tampering"):
         check_fips_integrity_failure(
             binary_path=self.context.fips_op_bin,
             binary_label="clickhouse-operator"
         )
 
-    with And("metrics-exporter detects tampering"):
+    with Check("metrics-exporter detects tampering"):
         check_fips_integrity_failure(
             binary_path=self.context.fips_me_bin,
             binary_label="metrics-exporter"
@@ -8744,19 +8744,32 @@ def test_030011(self):
 )
 def test_030015(self):
     """Verify forced FIPS CAST failure terminates each shipped binary independently."""
-    fips_extract_shipped_binaries()
 
-    with Then("clickhouse-operator terminates with CAST failure"):
-        check_fips_cast_failure(
-            binary_path=self.context.fips_op_bin,
-            binary="clickhouse-operator",
-        )
+    CAST_FAILURE_CASES = (
+        "HMAC-SHA2-256",
+        "HKDF-SHA2-256",
+    )
 
-    with Then("metrics-exporter terminates with CAST failure"):
-        check_fips_cast_failure(
-            binary_path=self.context.fips_me_bin,
-            binary="metrics-exporter",
-        )
+    with Given("operator and metrics-exporter binaries are extracted"):
+        fips_extract_shipped_binaries()
+
+    for binary, binary_path in (
+            ("clickhouse-operator", self.context.fips_op_bin),
+            ("metrics-exporter", self.context.fips_me_bin),
+    ):
+        for cast_name in CAST_FAILURE_CASES:
+            with When(f"{binary} is run with forced FIPS CAST failure {cast_name}"):
+                result = run_binary_with_forced_fips_cast_failure(
+                    binary_path=binary_path,
+                    cast_name=cast_name,
+                )
+
+            with Check(f"{binary} terminates with FIPS CAST failure {cast_name}"):
+                check_fips_cast_failure_result(
+                    result=result,
+                    binary=binary,
+                    cast_name=cast_name,
+                )
 
 @TestScenario
 @Tags("HEAVY")
@@ -8787,7 +8800,7 @@ def test_030016(self):
     with Given("strict FIPS operator configuration is applied"):
         util.apply_operator_config(chopconf)
 
-    with And("test TLS secret is installed"):
+    with And("test TLS secret is installed for the single CHI pod"):
         create_tls_secret_for_fips_hosts(
             chi=chi,
             chk=chk_dummy,
@@ -8801,7 +8814,7 @@ def test_030016(self):
             kind="chi",
         )
 
-    with Then("ClickHouse pod should be running"):
+    with Then("single ClickHouse pod is running"):
         kubectl.wait_object(
             "pod",
             "",
@@ -8818,7 +8831,7 @@ def test_030016(self):
             ns=self.context.test_namespace,
         )
 
-    with Then("ClickHouse native TLS accepts approved TLS 1.2 AES-GCM cipher"):
+    with Check("ClickHouse native TLS accepts the approved TLS 1.2 AES-GCM cipher"):
         out = fips_run_openssl_s_client_on_pod_port(
             pod=chi_pod,
             port=9440,
@@ -8830,7 +8843,7 @@ def test_030016(self):
         assert "Protocol  : TLSv1.2" in out, error(out)
         assert "Cipher    : ECDHE-RSA-AES256-GCM-SHA384" in out, error(out)
 
-    with Then("ClickHouse native TLS rejects disallowed TLS 1.2 ChaCha20 cipher"):
+    with Check("ClickHouse native TLS rejects the disallowed TLS 1.2 ChaCha20 cipher"):
         out = fips_run_openssl_s_client_on_pod_port(
             pod=chi_pod,
             port=9440,
@@ -8860,7 +8873,7 @@ def cleanup_chis(self):
 
 
 @TestModule
-@Name("e2e.test_operator")
+@Name("test_operator")
 @Requirements(RQ_SRS_026_ClickHouseOperator_CustomResource_APIVersion("1.0"),
               RQ_SRS_026_ClickHouseOperator("1.0"))
 def test(self):

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -8703,7 +8703,7 @@ def test_030010(self):
             chi_pod=chi_pods[0],
         )
 
-    with Check("operator pod containers restricted to AES-256 fail against a ChaCha-only TLS server"):
+    with Check("operator pod containers fail all rejected TLS protocol/cipher probes against an approved-only fake server"):
         fips_assert_connection_rejected_on_non_approved_cipher()
 
 

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -8714,12 +8714,6 @@ def test_030010(self):
 )
 def test_030011(self):
     """Verify that corrupting the embedded FIPS HMAC causes binaries to panic at startup.
-
-    Procedure:
-    1. Extract FIPS binaries from release images.
-    2. Locate the '.go.fipsinfo' ELF section.
-    3. Flip bits in the HMAC header.
-    4. Verify the binary panics with 'fips140: verification mismatch'.
     """
     with Given("operator and metrics-exporter binaries are extracted"):
         fips_extract_shipped_binaries()
@@ -8780,14 +8774,6 @@ def test_030015(self):
 )
 def test_030016(self):
     """Verify external clickhouse-client can use TLS 1.2 cipher policy to CH native TLS.
-
-    This intentionally uses:
-    - operator
-    - one ClickHouse pod
-    - external Docker clickhouse-client
-    - native secure port 9440
-    - no Keeper
-    - no backup sidecar
     """
     chopconf = "manifests/chopconf/test-030002-chopconf.yaml"
     chi_manifest = "manifests/chi/test-030016.yaml"


### PR DESCRIPTION
Expand FIPS negative TLS coverage: probe every rejected protocol/cipher from the static OpenSSL cipher list against all real listener endpoints (test_030003).

Add synthetic operator negative checks via a single fake TLS 1.3 server (approved AES-GCM only), with client-side curls for all rejected cases (test_030010).

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [X] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [X] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [X] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)
