### PR TITLE
Expose /debug/pprof on operator and metrics-exporter HTTP servers

### DIFF
--- a/cmd/operator/app/main.go
+++ b/cmd/operator/app/main.go
@@ -24,9 +24,12 @@ import (
 	"syscall"
 
 	log "github.com/altinity/clickhouse-operator/pkg/announcer"
+	metricspprof "github.com/altinity/clickhouse-operator/pkg/metrics/pprof"
 	"github.com/altinity/clickhouse-operator/pkg/util/fips"
 	"github.com/altinity/clickhouse-operator/pkg/version"
 )
+
+const defaultPprofEndpoint = "127.0.0.1:6060"
 
 // CLI parameter variables
 var (
@@ -42,6 +45,12 @@ var (
 	// debugRequest defines request for clickhouse-operator debug run
 	debugRequest bool
 
+	// pprofRequest enables a loopback-only pprof endpoint.
+	pprofRequest bool
+
+	// pprofEndpoint defines pprof listen address.
+	pprofEndpoint string
+
 	// chopConfigFile defines path to clickhouse-operator config file to be used
 	chopConfigFile string
 
@@ -56,8 +65,10 @@ func init() {
 	flag.BoolVar(&versionRequest, "version", false, "Display clickhouse-operator version and exit")
 	flag.BoolVar(&fipsInfoRequest, "fips-info", false, "Display FIPS build/runtime info and exit (no Go toolchain required).")
 	flag.BoolVar(&debugRequest, "debug", false, "Debug run")
+	flag.BoolVar(&pprofRequest, "pprof", false, "Enable loopback-only pprof server for heap, allocs, and goroutine profiles.")
 	flag.StringVar(&chopConfigFile, "config", "", "Path to clickhouse-operator config file.")
 	flag.StringVar(&masterURL, "master", "", "The address of custom Kubernetes API server. Makes sense if runs outside of the cluster and not being specified in kube config file only.")
+	flag.StringVar(&pprofEndpoint, "pprof-endpoint", defaultPprofEndpoint, "The loopback-only pprof endpoint.")
 }
 
 // Run is an entry point of the application
@@ -87,6 +98,12 @@ func Run() {
 	defer log.E().P()
 
 	log.F().Info("Starting clickhouse-operator. Version:%s GitSHA:%s BuiltAt:%s", version.Version, version.GitSHA, version.BuiltAt)
+	if pprofRequest {
+		if err := metricspprof.StartServer(pprofEndpoint); err != nil {
+			log.Fatalf("Unable to start pprof server at %s: %v", pprofEndpoint, err)
+		}
+		log.Warning("pprof server enabled at %s; expose it only with kubectl port-forward", pprofEndpoint)
+	}
 
 	// Create main context with cancel
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/pkg/metrics/clickhouse/rest_server.go
+++ b/pkg/metrics/clickhouse/rest_server.go
@@ -192,9 +192,16 @@ func StartMetricsREST(
 		log.Infof("IPC: Secure mode — binding /chi to %s, requiring %s header", ipc.BindHost, api.IPCHeaderToken)
 	}
 
-	// Setup HTTP handlers
-	http.Handle(metricsPath, promhttp.Handler())
-	http.Handle(chiListPath, chiHandler)
+	// Setup HTTP handlers on private muxes so unrelated DefaultServeMux
+	// registrations are never exposed on public metrics listeners.
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle(metricsPath, promhttp.Handler())
+	if metricsAddress == chiListAddress {
+		metricsMux.Handle(chiListPath, chiHandler)
+	}
+
+	chiMux := http.NewServeMux()
+	chiMux.Handle(chiListPath, chiHandler)
 
 	// Start HTTP servers. Prometheus /metrics ALWAYS binds the original address
 	// (typically all-interfaces) so ServiceMonitor scrapes from outside the Pod
@@ -204,9 +211,9 @@ func StartMetricsREST(
 	// listener — instead the middleware enforces remoteAddr=loopback at request
 	// time. If a custom config splits the two addresses, the /chi listener is
 	// bound to BindHost in Secure mode.
-	go http.ListenAndServe(metricsAddress, nil)
+	go http.ListenAndServe(metricsAddress, metricsMux)
 	if metricsAddress != chiListAddress {
-		go http.ListenAndServe(ipc.secureBindAddress(chiListAddress), nil)
+		go http.ListenAndServe(ipc.secureBindAddress(chiListAddress), chiMux)
 	}
 
 	return exporter

--- a/pkg/metrics/operator/machinery.go
+++ b/pkg/metrics/operator/machinery.go
@@ -106,8 +106,9 @@ func serveMetrics(addr, path string) {
 	handler := promhttp.HandlerFor(prom.DefaultGatherer, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.ContinueOnError,
 	})
-	http.Handle(path, handler)
-	err := http.ListenAndServe(addr, nil)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	err := http.ListenAndServe(addr, mux)
 	if err != nil {
 		fmt.Printf("error serving http: %v", err)
 	}

--- a/pkg/metrics/pprof/server.go
+++ b/pkg/metrics/pprof/server.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pprof
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"runtime/pprof"
+	"strconv"
+)
+
+var servedProfiles = []string{"heap", "allocs", "goroutine"}
+
+// StartServer starts a private, loopback-only pprof server without registering
+// any handlers on http.DefaultServeMux.
+func StartServer(addr string) error {
+	if err := validateLoopbackAddress(addr); err != nil {
+		return err
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	server := &http.Server{
+		Addr:    listener.Addr().String(),
+		Handler: NewMux(),
+	}
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	return nil
+}
+
+// NewMux builds the pprof mux. It intentionally serves only OOM-relevant
+// profiles and omits CPU profile and trace endpoints.
+func NewMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", index)
+	for _, name := range servedProfiles {
+		profileName := name
+		mux.HandleFunc("/debug/pprof/"+profileName, func(w http.ResponseWriter, r *http.Request) {
+			serveProfile(w, r, profileName)
+		})
+	}
+	return mux
+}
+
+func index(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/debug/pprof/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprintln(w, "<html><body><h1>Available profiles</h1><ul>")
+	for _, name := range servedProfiles {
+		_, _ = fmt.Fprintf(w, `<li><a href="/debug/pprof/%[1]s">%[1]s</a></li>`+"\n", name)
+	}
+	_, _ = fmt.Fprintln(w, "</ul></body></html>")
+}
+
+func serveProfile(w http.ResponseWriter, r *http.Request, name string) {
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	debug, err := strconv.Atoi(r.URL.Query().Get("debug"))
+	if err != nil {
+		debug = 0
+	}
+
+	if debug == 0 {
+		w.Header().Set("Content-Type", "application/octet-stream")
+	} else {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	}
+	_ = profile.WriteTo(w, debug)
+}
+
+func validateLoopbackAddress(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid pprof endpoint %q: %w", addr, err)
+	}
+	if host == "" {
+		return fmt.Errorf("invalid pprof endpoint %q: host must be loopback, for example 127.0.0.1:6060", addr)
+	}
+	if host == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("invalid pprof endpoint %q: host must be loopback", addr)
+	}
+	return nil
+}

--- a/pkg/metrics/pprof/server_test.go
+++ b/pkg/metrics/pprof/server_test.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pprof
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMuxServesMemoryAndGoroutineProfilesOnly(t *testing.T) {
+	mux := NewMux()
+
+	for _, path := range []string{
+		"/debug/pprof/",
+		"/debug/pprof/heap",
+		"/debug/pprof/allocs",
+		"/debug/pprof/goroutine?debug=1",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+
+		mux.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, path)
+	}
+
+	for _, path := range []string{
+		"/debug/pprof/profile",
+		"/debug/pprof/trace",
+		"/debug/pprof/cmdline",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+
+		mux.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code, path)
+	}
+}
+
+func TestValidateLoopbackAddress(t *testing.T) {
+	for _, addr := range []string{
+		"127.0.0.1:6060",
+		"localhost:6060",
+		"[::1]:6060",
+	} {
+		require.NoError(t, validateLoopbackAddress(addr), addr)
+	}
+
+	for _, addr := range []string{
+		":6060",
+		"0.0.0.0:6060",
+		"192.0.2.1:6060",
+		"bad",
+	} {
+		require.Error(t, validateLoopbackAddress(addr), addr)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Altinity/clickhouse-operator/issues/2016

Hi team, I'd like to register `pprof` endpoint for profiling purpose, which is useful to understand production issues such as OOM.