### PR TITLE
Add replica restart fix for operator when remote_servers configmap is propagated

### DIFF
--- a/pkg/controller/chi/worker-reconciler-chi.go
+++ b/pkg/controller/chi/worker-reconciler-chi.go
@@ -360,6 +360,8 @@ func (w *worker) reconcileCRAuxObjectsFinal(ctx context.Context, cr *api.ClickHo
 	cr.GetRuntime().UnlockCommonConfig()
 
 	w.includeAllHostsIntoCluster(ctx, cr)
+	w.restartCreatedHosts(ctx, cr)
+
 	return err
 }
 
@@ -368,6 +370,34 @@ func (w *worker) includeAllHostsIntoCluster(ctx context.Context, cr *api.ClickHo
 	cr.WalkHosts(func(host *api.Host) error {
 		if host.ShouldIncludeIntoCluster() {
 			_ = w.waitHostIsInCluster(ctx, host)
+		}
+		return nil
+	})
+}
+
+// restartCreatedHosts restarts, once, each host that was created during the current reconcile.
+func (w *worker) restartCreatedHosts(ctx context.Context, cr *api.ClickHouseInstallation) {
+	if util.IsContextDone(ctx) {
+		log.V(1).Info("Reconcile is aborted. Restart created hosts: %s ", cr.GetName())
+		return
+	}
+
+	cr.WalkHosts(func(host *api.Host) error {
+		// Only hosts created during this reconcile
+		if !host.GetReconcileAttributes().GetStatus().Is(types.ObjectStatusCreated) {
+			return nil
+		}
+		// Skip single-host clusters - remote_servers references only localhost, which always resolves
+		if host.GetCluster().HostsCount() < 2 {
+			w.a.V(1).M(host).F().Info("Skip post-include restart of created host in single-host cluster. Host: %s", host.GetName())
+			return nil
+		}
+
+		w.a.V(1).M(host).F().Info("Restart created host after final remote_servers propagation. Host: %s", host.GetName())
+		w.task.WaitForConfigMapPropagation(ctx, host)
+
+		if err := w.hostSoftwareRestart(ctx, host); err != nil {
+			w.a.V(1).M(host).F().Warning("Failed to restart created host after final remote_servers propagation. Host: %s err: %v", host.GetName(), err)
 		}
 		return nil
 	})


### PR DESCRIPTION


Restart hosts created during the current reconcile once, right after the final remote_servers (with all hosts) has been published and propagated, so the new replica's boot loads with the full cluster defined. Scoped to the new host only, one-shot (host becomes Same on next reconcile), and skipped for single-host clusters. Closes the scale-up CLUSTER_DOESNT_EXIST race (Altinity/clickhouse-operator#2013).


## Important items to consider before making a Pull Request
Please check items PR complies to:
* [X] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [X] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [X] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


