### PR TITLE
Add configurable MaxConcurrentReconciles for CHK controller

### DIFF
--- a/cmd/operator/app/thread_keeper.go
+++ b/cmd/operator/app/thread_keeper.go
@@ -17,7 +17,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	//	ctrl "sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlController "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse-keeper.altinity.com/v1"
 	"github.com/altinity/clickhouse-operator/pkg/chop"
@@ -84,6 +84,9 @@ func initKeeper(ctx context.Context) error {
 			builder.WithPredicates(keeperPredicate()),
 		).
 		Owns(&apps.StatefulSet{}).
+		WithOptions(ctrlController.Options{
+			MaxConcurrentReconciles: chop.Config().Reconcile.Runtime.ReconcileCHKsThreadsNumber,
+		}).
 		Complete(
 			&controller.Controller{
 				Client:    manager.GetClient(),

--- a/config/config-dev.yaml
+++ b/config/config-dev.yaml
@@ -316,6 +316,8 @@ reconcile:
   runtime:
     # Max number of concurrent CHI reconciles in progress
     reconcileCHIsThreadsNumber: 1
+    # Max number of concurrent CHK reconciles in progress
+    reconcileCHKsThreadsNumber: 1
 
     # The operator reconciles shards concurrently in each CHI with the following limitations:
     #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -419,6 +419,8 @@ reconcile:
   runtime:
     # Max number of concurrent CHI reconciles in progress
     reconcileCHIsThreadsNumber: 10
+    # Max number of concurrent CHK reconciles in progress
+    reconcileCHKsThreadsNumber: 1
 
     # The operator reconciles shards concurrently in each CHI with the following limitations:
     #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently

--- a/deploy/builder/templates-config/config.yaml
+++ b/deploy/builder/templates-config/config.yaml
@@ -413,6 +413,8 @@ reconcile:
   runtime:
     # Max number of concurrent CHI reconciles in progress
     reconcileCHIsThreadsNumber: 10
+    # Max number of concurrent CHK reconciles in progress
+    reconcileCHKsThreadsNumber: 1
 
     # The operator reconciles shards concurrently in each CHI with the following limitations:
     #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-01-section-crd-02-chopconf.yaml
@@ -339,6 +339,11 @@ spec:
                           minimum: 1
                           maximum: 65535
                           description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                        reconcileCHKsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                         reconcileShardsThreadsNumber:
                           type: integer
                           minimum: 1

--- a/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -339,6 +339,11 @@ spec:
                           minimum: 1
                           maximum: 65535
                           description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                        reconcileCHKsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                         reconcileShardsThreadsNumber:
                           type: integer
                           minimum: 1

--- a/deploy/helm/clickhouse-operator/values.schema.json
+++ b/deploy/helm/clickhouse-operator/values.schema.json
@@ -480,6 +480,9 @@
                                                 "reconcileCHIsThreadsNumber": {
                                                     "type": "integer"
                                                 },
+                                                "reconcileCHKsThreadsNumber": {
+                                                    "type": "integer"
+                                                },
                                                 "reconcileShardsMaxConcurrencyPercent": {
                                                     "type": "integer"
                                                 },

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -699,6 +699,8 @@ configs:
         runtime:
           # Max number of concurrent CHI reconciles in progress
           reconcileCHIsThreadsNumber: 10
+          # Max number of concurrent CHK reconciles in progress
+          reconcileCHKsThreadsNumber: 1
           # The operator reconciles shards concurrently in each CHI with the following limitations:
           #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently
           #      can not be greater than 'reconcileShardsThreadsNumber'.

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -4052,6 +4052,11 @@ spec:
                           minimum: 1
                           maximum: 65535
                           description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                        reconcileCHKsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                         reconcileShardsThreadsNumber:
                           type: integer
                           minimum: 1
@@ -6105,7 +6110,9 @@ data:
       runtime:
         # Max number of concurrent CHI reconciles in progress
         reconcileCHIsThreadsNumber: 10
-    
+        # Max number of concurrent CHK reconciles in progress
+        reconcileCHKsThreadsNumber: 1
+
         # The operator reconciles shards concurrently in each CHI with the following limitations:
         #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently
         #      can not be greater than 'reconcileShardsThreadsNumber'.

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -4019,6 +4019,11 @@ spec:
                       minimum: 1
                       maximum: 65535
                       description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                    reconcileCHKsThreadsNumber:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                      description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                     reconcileShardsThreadsNumber:
                       type: integer
                       minimum: 1
@@ -6304,6 +6309,8 @@ data:
       runtime:
         # Max number of concurrent CHI reconciles in progress
         reconcileCHIsThreadsNumber: 10
+        # Max number of concurrent CHK reconciles in progress
+        reconcileCHKsThreadsNumber: 1
 
         # The operator reconciles shards concurrently in each CHI with the following limitations:
         #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -4045,6 +4045,11 @@ spec:
                           minimum: 1
                           maximum: 65535
                           description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                        reconcileCHKsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                         reconcileShardsThreadsNumber:
                           type: integer
                           minimum: 1
@@ -6364,7 +6369,9 @@ data:
       runtime:
         # Max number of concurrent CHI reconciles in progress
         reconcileCHIsThreadsNumber: 10
-    
+        # Max number of concurrent CHK reconciles in progress
+        reconcileCHKsThreadsNumber: 1
+
         # The operator reconciles shards concurrently in each CHI with the following limitations:
         #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently
         #      can not be greater than 'reconcileShardsThreadsNumber'.

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -4019,6 +4019,11 @@ spec:
                       minimum: 1
                       maximum: 65535
                       description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                    reconcileCHKsThreadsNumber:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                      description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                     reconcileShardsThreadsNumber:
                       type: integer
                       minimum: 1
@@ -6051,6 +6056,8 @@ data:
       runtime:
         # Max number of concurrent CHI reconciles in progress
         reconcileCHIsThreadsNumber: 10
+        # Max number of concurrent CHK reconciles in progress
+        reconcileCHKsThreadsNumber: 1
 
         # The operator reconciles shards concurrently in each CHI with the following limitations:
         #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -4045,6 +4045,11 @@ spec:
                           minimum: 1
                           maximum: 65535
                           description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                        reconcileCHKsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                         reconcileShardsThreadsNumber:
                           type: integer
                           minimum: 1
@@ -6098,7 +6103,9 @@ data:
       runtime:
         # Max number of concurrent CHI reconciles in progress
         reconcileCHIsThreadsNumber: 10
-    
+        # Max number of concurrent CHK reconciles in progress
+        reconcileCHKsThreadsNumber: 1
+
         # The operator reconciles shards concurrently in each CHI with the following limitations:
         #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently
         #      can not be greater than 'reconcileShardsThreadsNumber'.

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -4052,6 +4052,11 @@ spec:
                           minimum: 1
                           maximum: 65535
                           description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                        reconcileCHKsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                         reconcileShardsThreadsNumber:
                           type: integer
                           minimum: 1
@@ -6105,7 +6110,9 @@ data:
       runtime:
         # Max number of concurrent CHI reconciles in progress
         reconcileCHIsThreadsNumber: 10
-    
+        # Max number of concurrent CHK reconciles in progress
+        reconcileCHKsThreadsNumber: 1
+
         # The operator reconciles shards concurrently in each CHI with the following limitations:
         #   1. Number of shards being reconciled (and thus having hosts down) in each CHI concurrently
         #      can not be greater than 'reconcileShardsThreadsNumber'.

--- a/deploy/operator/parts/crd.yaml
+++ b/deploy/operator/parts/crd.yaml
@@ -8589,6 +8589,11 @@ spec:
                           minimum: 1
                           maximum: 65535
                           description: "How many goroutines will be used to reconcile CHIs in parallel, 10 by default"
+                        reconcileCHKsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "How many goroutines will be used to reconcile CHKs in parallel, 1 by default"
                         reconcileShardsThreadsNumber:
                           type: integer
                           minimum: 1

--- a/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go
@@ -115,6 +115,10 @@ const (
 	// Used in case no other specified in config
 	defaultReconcileCHIsThreadsNumber = 1
 
+	// defaultReconcileCHKsThreadsNumber specifies default number of CHK controller threads running concurrently.
+	// Used in case no other specified in config
+	defaultReconcileCHKsThreadsNumber = 1
+
 	// defaultReconcileShardsThreadsNumber specifies the default number of threads usable for concurrent shard reconciliation
 	// within a single cluster reconciliation. Defaults to 1, which means strictly sequential shard reconciliation.
 	defaultReconcileShardsThreadsNumber = 1
@@ -663,6 +667,7 @@ type OperatorConfigReconcileRecoveryCompletedScope struct {
 
 type OperatorConfigReconcileRuntime struct {
 	ReconcileCHIsThreadsNumber           int `json:"reconcileCHIsThreadsNumber"           yaml:"reconcileCHIsThreadsNumber"`
+	ReconcileCHKsThreadsNumber           int `json:"reconcileCHKsThreadsNumber"           yaml:"reconcileCHKsThreadsNumber"`
 	ReconcileShardsThreadsNumber         int `json:"reconcileShardsThreadsNumber"         yaml:"reconcileShardsThreadsNumber"`
 	ReconcileShardsMaxConcurrencyPercent int `json:"reconcileShardsMaxConcurrencyPercent" yaml:"reconcileShardsMaxConcurrencyPercent"`
 
@@ -1398,6 +1403,9 @@ func (c *OperatorConfig) normalizeSectionReconcileRuntime() {
 	}
 	if c.Reconcile.Runtime.ReconcileCHIsThreadsNumber == 0 {
 		c.Reconcile.Runtime.ReconcileCHIsThreadsNumber = defaultReconcileCHIsThreadsNumber
+	}
+	if c.Reconcile.Runtime.ReconcileCHKsThreadsNumber == 0 {
+		c.Reconcile.Runtime.ReconcileCHKsThreadsNumber = defaultReconcileCHKsThreadsNumber
 	}
 	if c.Reconcile.Runtime.ReconcileShardsThreadsNumber == 0 {
 		c.Reconcile.Runtime.ReconcileShardsThreadsNumber = defaultReconcileShardsThreadsNumber


### PR DESCRIPTION
## Summary

Adds a `reconcileCHKsThreadsNumber` config option to control the number of concurrent ClickHouseKeeperInstallation reconciliations.

The CHK controller currently uses controller-runtime's default `MaxConcurrentReconciles=1`, meaning all CHK resources are reconciled serially. This becomes a significant bottleneck at scale — with 1,000+ CHK resources and ~30-40 seconds per reconciliation (due to force restarts and hardcoded sleeps), a full reconciliation cycle takes 9-12 hours. During this time, newly created CHK resources are added to the back of the FIFO queue and can wait hours before the operator begins reconciling them.

The new setting mirrors the existing `reconcileCHIsThreadsNumber` for CHI resources. Defaults to 1 to preserve existing behavior.

### Changes

- `cmd/operator/app/thread_keeper.go`: Add `.WithOptions(controller.Options{MaxConcurrentReconciles: ...})` to the controller-runtime builder chain
- `pkg/apis/clickhouse.altinity.com/v1/type_configuration_chop.go`: Add `ReconcileCHKsThreadsNumber` field to `OperatorConfigReconcileRuntime` struct, default constant, and normalization logic

### Config YAML

```yaml
reconcile:
  runtime:
    reconcileCHIsThreadsNumber: 10
    reconcileCHKsThreadsNumber: 10  # <-- new
    reconcileShardsThreadsNumber: 5
    reconcileShardsMaxConcurrencyPercent: 50
```

Closes #2032

Signed-off-by: miguel-signoz <miguel@signoz.io>