### PR TITLE
pkg/xml: escape reserved characters in element text

### DIFF
--- a/pkg/xml/xml.go
+++ b/pkg/xml/xml.go
@@ -254,5 +254,15 @@ func (n *xmlNode) writeTag(w io.Writer, indent uint8, attributes string, openTag
 
 // writeValue prints XML value into io.Writer
 func (n *xmlNode) writeValue(w io.Writer, value string) {
-	util.Fprintf(w, "%s", value)
+	// Element text is injected verbatim by default, which produces invalid
+	// XML when a value contains the reserved characters &, < or > (e.g. a
+	// generated password). Escape those so the rendered document stays
+	// well-formed. 	, \n and \r are intentionally left untouched to keep
+	// existing multi-line values working.
+	escaped := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+	).Replace(value)
+	util.Fprintf(w, "%s", escaped)
 }

--- a/pkg/xml/xml_test.go
+++ b/pkg/xml/xml_test.go
@@ -1,0 +1,50 @@
+package xml
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteValueEscapesReservedCharacters(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ampersand is escaped",
+			input:    "p%X&word",
+			expected: "p%X&amp;word",
+		},
+		{
+			name:     "less-than is escaped",
+			input:    "a<b",
+			expected: "a&lt;b",
+		},
+		{
+			name:     "greater-than is escaped",
+			input:    "a>b",
+			expected: "a&gt;b",
+		},
+		{
+			name:     "generated password with mixed special chars",
+			input:    "l%XubpKqz2y!QsKlsynEEE6#Thknj&fG",
+			expected: "l%XubpKqz2y!QsKlsynEEE6#Thknj&amp;fG",
+		},
+		{
+			name:     "plain value is unchanged",
+			input:    "plainpassword",
+			expected: "plainpassword",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sb strings.Builder
+			(&xmlNode{}).writeValue(&sb, tc.input)
+			if sb.String() != tc.expected {
+				t.Errorf("writeValue() = %q, expected %q", sb.String(), tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
writeValue injected element text verbatim, so passwords or values containing &, < or > produced invalid users.xml and ClickHouse failed to start. Escape those characters so the rendered document stays well-formed.

Used AI to help identify and draft this fix — reviewed and tested before submitting.