### PR TITLE
Raft-safe ClickHouseKeeperInstallation rescale

### DIFF
--- a/cmd/operator/app/thread_keeper.go
+++ b/cmd/operator/app/thread_keeper.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"os"
 
 	"github.com/go-logr/logr"
 
@@ -20,6 +21,7 @@ import (
 	ctrlController "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse-keeper.altinity.com/v1"
+	deployment "github.com/altinity/clickhouse-operator/pkg/apis/deployment"
 	"github.com/altinity/clickhouse-operator/pkg/chop"
 	controller "github.com/altinity/clickhouse-operator/pkg/controller/chk"
 )
@@ -67,6 +69,13 @@ func initKeeper(ctx context.Context) error {
 		// pkg/metrics/operator, and the CHK reconcile counters worth exposing are surfaced
 		// through that path, not through controller-runtime's manager-default exposition.
 		Metrics: metricsserver.Options{BindAddress: "0"},
+		// Serialize CHK reconciliation across operator replicas/restarts.
+		// The Lease lives in the operator's own namespace (empty value falls
+		// back to controller-runtime's in-cluster namespace detection).
+		LeaderElection:                true,
+		LeaderElectionID:              "clickhouse-keeper-operator.altinity.com",
+		LeaderElectionNamespace:       os.Getenv(deployment.OPERATOR_POD_NAMESPACE),
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		logger.Error(err, "init keeper - unable to ctrlRuntime.NewManager")

--- a/config/chk/keeper_config.d/01-keeper-01-default-config.xml
+++ b/config/chk/keeper_config.d/01-keeper-01-default-config.xml
@@ -35,7 +35,7 @@
             stricter list can override this value, but they must keep `ruok` if they
             also use the default operator probes.
         -->
-        <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+        <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
     </keeper_server>
     <listen_host>::</listen_host>
     <listen_host>0.0.0.0</listen_host>

--- a/deploy/builder/templates-config/chk/keeper_config.d/01-keeper-01-default-config.xml
+++ b/deploy/builder/templates-config/chk/keeper_config.d/01-keeper-01-default-config.xml
@@ -29,7 +29,7 @@
             stricter list can override this value, but they must keep `ruok` if they
             also use the default operator probes.
         -->
-        <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+        <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
     </keeper_server>
     <listen_host>::</listen_host>
     <listen_host>0.0.0.0</listen_host>

--- a/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-02-section-rbac-02-role.yaml
+++ b/deploy/builder/templates-install-bundle/clickhouse-operator-install-yaml-template-02-section-rbac-02-role.yaml
@@ -88,6 +88,23 @@ rules:
       - list
 
   #
+  # coordination.k8s.io resources
+  #
+
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  #
   # apps.* resources
   #
 

--- a/deploy/helm/clickhouse-operator/templates/generated/ClusterRole-clickhouse-operator-kube-system.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/ClusterRole-clickhouse-operator-kube-system.yaml
@@ -14,6 +14,19 @@ metadata:
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 rules:
+  # coordination.k8s.io resources (leader election)
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   #
   # Core API group
   #

--- a/deploy/helm/clickhouse-operator/templates/generated/Role-clickhouse-operator.yaml
+++ b/deploy/helm/clickhouse-operator/templates/generated/Role-clickhouse-operator.yaml
@@ -14,6 +14,19 @@ metadata:
   labels: {{ include "altinity-clickhouse-operator.labels" . | nindent 4 }}
   annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
 rules:
+  # coordination.k8s.io resources (leader election)
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   #
   # Core API group
   #

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -6750,7 +6750,7 @@ data:
                 stricter list can override this value, but they must keep `ruok` if they
                 also use the default operator probes.
             -->
-            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
         </keeper_server>
         <listen_host>::</listen_host>
         <listen_host>0.0.0.0</listen_host>

--- a/deploy/operator/clickhouse-operator-install-ansible.yaml
+++ b/deploy/operator/clickhouse-operator-install-ansible.yaml
@@ -5497,6 +5497,23 @@ rules:
       - list
 
   #
+  # coordination.k8s.io resources
+  #
+
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  #
   # apps.* resources
   #
 

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -5365,7 +5365,6 @@ metadata:
   namespace: kube-system
   labels:
     clickhouse.altinity.com/chop: 0.27.2
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -5451,6 +5450,21 @@ rules:
     verbs:
       - get
       - list
+  #
+  # coordination.k8s.io resources
+  #
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   #
   # apps.* resources
   #
@@ -5618,7 +5632,6 @@ subjects:
   - kind: ServiceAccount
     name: clickhouse-operator
     namespace: kube-system
-
 # Template Parameters:
 #
 # NAMESPACE=kube-system
@@ -5704,6 +5717,21 @@ rules:
     verbs:
       - get
       - list
+  #
+  # coordination.k8s.io resources
+  #
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   #
   # apps.* resources
   #

--- a/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle-v1beta1.yaml
@@ -6951,7 +6951,7 @@ data:
                 stricter list can override this value, but they must keep `ruok` if they
                 also use the default operator probes.
             -->
-            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
         </keeper_server>
         <listen_host>::</listen_host>
         <listen_host>0.0.0.0</listen_host>

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -7026,7 +7026,7 @@ data:
                 stricter list can override this value, but they must keep `ruok` if they
                 also use the default operator probes.
             -->
-            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
         </keeper_server>
         <listen_host>::</listen_host>
         <listen_host>0.0.0.0</listen_host>

--- a/deploy/operator/clickhouse-operator-install-bundle.yaml
+++ b/deploy/operator/clickhouse-operator-install-bundle.yaml
@@ -5490,6 +5490,23 @@ rules:
       - list
 
   #
+  # coordination.k8s.io resources
+  #
+
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  #
   # apps.* resources
   #
 
@@ -5754,6 +5771,23 @@ rules:
     verbs:
       - get
       - list
+
+  #
+  # coordination.k8s.io resources
+  #
+
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 
   #
   # apps.* resources

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -6684,7 +6684,7 @@ data:
                 stricter list can override this value, but they must keep `ruok` if they
                 also use the default operator probes.
             -->
-            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
         </keeper_server>
         <listen_host>::</listen_host>
         <listen_host>0.0.0.0</listen_host>

--- a/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
+++ b/deploy/operator/clickhouse-operator-install-template-v1beta1.yaml
@@ -5365,7 +5365,6 @@ metadata:
   namespace: ${OPERATOR_NAMESPACE}
   labels:
     clickhouse.altinity.com/chop: 0.27.2
-
 # Template Parameters:
 #
 # NAMESPACE=${OPERATOR_NAMESPACE}
@@ -5451,6 +5450,21 @@ rules:
     verbs:
       - get
       - list
+  #
+  # coordination.k8s.io resources
+  #
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   #
   # apps.* resources
   #

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -5490,6 +5490,23 @@ rules:
       - list
 
   #
+  # coordination.k8s.io resources
+  #
+
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  #
   # apps.* resources
   #
 

--- a/deploy/operator/clickhouse-operator-install-template.yaml
+++ b/deploy/operator/clickhouse-operator-install-template.yaml
@@ -6743,7 +6743,7 @@ data:
                 stricter list can override this value, but they must keep `ruok` if they
                 also use the default operator probes.
             -->
-            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
         </keeper_server>
         <listen_host>::</listen_host>
         <listen_host>0.0.0.0</listen_host>

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -6750,7 +6750,7 @@ data:
                 stricter list can override this value, but they must keep `ruok` if they
                 also use the default operator probes.
             -->
-            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro</four_letter_word_white_list>
+            <four_letter_word_white_list>conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rqld</four_letter_word_white_list>
         </keeper_server>
         <listen_host>::</listen_host>
         <listen_host>0.0.0.0</listen_host>

--- a/deploy/operator/clickhouse-operator-install-tf.yaml
+++ b/deploy/operator/clickhouse-operator-install-tf.yaml
@@ -5497,6 +5497,23 @@ rules:
       - list
 
   #
+  # coordination.k8s.io resources
+  #
+
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  #
   # apps.* resources
   #
 

--- a/pkg/apis/clickhouse.altinity.com/v1/interface.go
+++ b/pkg/apis/clickhouse.altinity.com/v1/interface.go
@@ -66,6 +66,30 @@ type ICustomResource interface {
 	YAML(opts types.CopyCROptions) string
 }
 
+// CRHasEstablishedCluster reports whether the CR's cluster already existed on a
+// prior successful reconcile — i.e. the last-completed (ancestor) spec already
+// carried hosts.
+//
+// This is the STABLE signal for classifying a Keeper host as joining an
+// established cluster vs bootstrapping a fresh one. It must NOT be derived from
+// the mutable per-host reconcile statuses (Requested/Found/...), which flip
+// during the sequential host loop (host 0 becomes Created mid-loop) and are
+// re-derived every reconcile pass: keying off them makes a fresh 3-node install
+// mis-classify later hosts as "joining" (deadlock) and re-stages
+// already-committed voters on a retry pass (committed-voter churn). The ancestor
+// host count is invariant across the whole reconcile. See
+// docs/chk-rescale-raft-safety-v3.md.
+func CRHasEstablishedCluster(cr ICustomResource) bool {
+	if cr == nil {
+		return false
+	}
+	ancestor := cr.GetAncestor()
+	if ancestor == nil {
+		return false
+	}
+	return ancestor.HostsCount() > 0
+}
+
 type ICRSpec interface {
 	GetNamespaceDomainPattern() *types.String
 	GetDefaults() *Defaults

--- a/pkg/apis/common/types/reconcile_attributes.go
+++ b/pkg/apis/common/types/reconcile_attributes.go
@@ -96,6 +96,9 @@ func (a *ReconcileAttributes) SetExclude() *ReconcileAttributes {
 	if a == nil {
 		return a
 	}
+	if a.tags == nil {
+		a.tags = NewTags()
+	}
 	a.tags.Set(TagExclude)
 	return a
 }
@@ -121,6 +124,9 @@ func (a *ReconcileAttributes) IsExclude() bool {
 func (a *ReconcileAttributes) SetLowPriority() *ReconcileAttributes {
 	if a == nil {
 		return a
+	}
+	if a.tags == nil {
+		a.tags = NewTags()
 	}
 	a.tags.Set(TagLowPriority)
 	return a

--- a/pkg/apis/common/types/reconcile_attributes_test.go
+++ b/pkg/apis/common/types/reconcile_attributes_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileAttributesTagSetters(t *testing.T) {
+	a := NewReconcileAttributes()
+	require.False(t, a.IsExclude())
+	a.SetExclude()
+	require.True(t, a.IsExclude())
+	a.UnsetExclude()
+	require.False(t, a.IsExclude())
+
+	b := NewReconcileAttributes()
+	b.SetLowPriority()
+	require.True(t, b.IsLowPriority())
+}

--- a/pkg/controller/chk/controller.go
+++ b/pkg/controller/chk/controller.go
@@ -112,7 +112,11 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	w.reconcileCR(ctx, nil, new)
+	if err := w.reconcileCR(ctx, nil, new); err != nil {
+		// Fail-safe requeue: barriers re-checked on the next pass.
+		log.V(1).M(new).F().Warning("reconcile failed, requeue: %v", err)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/controller/chk/worker-deleter.go
+++ b/pkg/controller/chk/worker-deleter.go
@@ -50,6 +50,22 @@ func (w *worker) clean(ctx context.Context, cr api.ICustomResource) {
 	w.a.V(1).M(cr).F().Info("List of existing objects:\n%s", objs)
 	objs.Subtract(need)
 	w.a.V(1).M(cr).F().Info("List of non-reconciled objects:\n%s", objs)
+
+	// Raft safety barrier: a StatefulSet/PVC of a Keeper member may only be
+	// deleted once every published member reports committed Raft membership
+	// equal to the published set (v3 invariant 3). The gate is keyed off what
+	// `objs` actually contains, not off the transient ActionPlan — see
+	// raftSafeToPurge. On timeout, or while the cluster is stopped/
+	// unreachable: skip the purge entirely (fail-safe stuck) — a
+	// removed-but-alive pod is safe; a deleted voting member is not. The
+	// reconcile is then failed by the convergence gate and requeued, and the
+	// purge is retried (and only then completed) once membership actually
+	// converges.
+	if !w.raftSafeToPurge(ctx, cr, objs) {
+		w.a.V(1).M(cr).F().Warning("skip purge: committed raft membership has not converged to the desired set")
+		return
+	}
+
 	if w.purge(ctx, cr, objs, w.task.RegistryFailed()) > 0 {
 		util.WaitContextDoneOrTimeout(ctx, 1*time.Minute)
 	}

--- a/pkg/controller/chk/worker-raft-membership.go
+++ b/pkg/controller/chk/worker-raft-membership.go
@@ -1,0 +1,366 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chk
+
+// Raft-safe CHK rescale — design notes (verified against ClickHouse Keeper
+// source, 23.8..master).
+//
+// Control plane: the operator drives membership through the static
+// raft_configuration XML (enable_reconfiguration=false), NOT the client
+// `reconfig` command. A versioned `reconfig` CAS does not exist in any Keeper
+// version (the version arg is rejected unless -1, and no config version is
+// exposed to read), and the client `reconfig` is optimistic/async and not
+// leader-forwarded. The XML-diff path, by contrast, is applied by the leader
+// only, one server at a time, and serialized by NuRaft — the reliable control
+// plane. Existing clusters already run this mode; no migration needed.
+//
+// The split-brain window this guards: a freshly-started Keeper node loads the
+// full XML config and boots as a voter. Two fresh nodes sharing {0,1,2} can
+// elect a leader between themselves (2/3) while the original node still commits
+// as {0} (1/1) — two quorums. One fresh node alone cannot: it needs an existing
+// member's vote, which a healthy member with a live leader refuses. So the
+// invariant is: the published XML never contains more than one server that is
+// not yet in committed membership (staging, see worker.go), plus
+// <start_as_follower> on joiners as a second guard.
+//
+// Confirmation barrier: `get /keeper/config` returns a node's committed cluster
+// config. A node may lag but can never report a not-yet-committed config, so a
+// positive match is a safe convergence signal (false-negative only, never
+// false-positive). Fail-safe throughout: any barrier timeout / quorum loss /
+// unreachable member returns an error and requeues — the operator never deletes
+// or mutates on an unconfirmed observation.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	apiChk "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse-keeper.altinity.com/v1"
+	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	a "github.com/altinity/clickhouse-operator/pkg/controller/common/announcer"
+	"github.com/altinity/clickhouse-operator/pkg/interfaces"
+	"github.com/altinity/clickhouse-operator/pkg/model"
+	"github.com/altinity/clickhouse-operator/pkg/model/chk/keeper"
+	"github.com/altinity/clickhouse-operator/pkg/util"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// raftBarrierTimeout bounds a single reconcile's wait for the committed
+	// Raft membership to converge to the published XML. On timeout the
+	// reconcile fails and is requeued — fail-safe stuck, nothing is deleted.
+	raftBarrierTimeout = 5 * time.Minute
+	// raftVerifyTimeout is the shorter final-assertion wait used right before
+	// marking the CR Completed (per-step barriers have already passed).
+	raftVerifyTimeout = 30 * time.Second
+	raftPollInterval  = 5 * time.Second
+	fourLetterTimeout = 3 * time.Second
+)
+
+var errRaftNotConverged = errors.New("raft membership has not converged to the published configuration")
+
+// keeperClientAddr returns the "fqdn:port" ZK-client endpoint of the host —
+// the same hostname that is written into the raft XML.
+func (w *worker) keeperClientAddr(host *api.Host) string {
+	return fmt.Sprintf("%s:%d", w.c.namer.Name(interfaces.NameInstanceHostname, host), host.ZKPort.Value())
+}
+
+// publishedMemberIDs returns server ids of hosts currently published in the
+// shared raft XML (i.e. not staged out with TagExclude). Server id == replica
+// index, mirroring getServerId in pkg/model/chk/config/generator.go.
+func publishedMemberIDs(cr api.ICustomResource) map[int]bool {
+	ids := map[int]bool{}
+	cr.WalkHosts(func(host *api.Host) error {
+		if !host.GetReconcileAttributes().IsExclude() {
+			ids[host.GetRuntime().GetAddress().GetReplicaIndex()] = true
+		}
+		return nil
+	})
+	return ids
+}
+
+// membershipObservers returns the hosts whose committed configuration must be
+// checked by a barrier: every published host.
+func (w *worker) membershipObservers(cr api.ICustomResource) (hosts []*api.Host) {
+	cr.WalkHosts(func(host *api.Host) error {
+		if !host.GetReconcileAttributes().IsExclude() {
+			hosts = append(hosts, host)
+		}
+		return nil
+	})
+	return hosts
+}
+
+// waitRaftMembershipConverged polls `get /keeper/config` on every observer
+// host until each one returns exactly the expected id set. Unreachable
+// members or a mismatch keep the barrier closed (fail-safe): a node can
+// report a lagging configuration but never a not-yet-committed one.
+func (w *worker) waitRaftMembershipConverged(
+	ctx context.Context,
+	cr api.ICustomResource,
+	expected map[int]bool,
+	timeout time.Duration,
+) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if util.IsContextDone(ctx) {
+			return ctx.Err()
+		}
+		if w.raftMembershipConverged(ctx, cr, expected) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errRaftNotConverged
+		}
+		util.WaitContextDoneOrTimeout(ctx, raftPollInterval)
+	}
+}
+
+func (w *worker) raftMembershipConverged(ctx context.Context, cr api.ICustomResource, expected map[int]bool) bool {
+	for _, host := range w.membershipObservers(cr) {
+		fqdn := w.c.namer.Name(interfaces.NameInstanceHostname, host)
+		members, err := keeper.GetCommittedMembership(ctx, fqdn, host.ZKPort.Value())
+		if err != nil || !keeper.SameIDs(members, expected) {
+			w.a.V(1).M(host).F().Info(
+				"raft membership not converged on %s: got %v want %v err: %v",
+				fqdn, keeper.MemberIDs(members), expected, err)
+			return false
+		}
+	}
+	return true
+}
+
+// waitRaftFollowersSynced waits until the leader among published hosts
+// reports zk_synced_followers >= expectedVoters-1 (the freshly added member
+// has caught up with the log). No-op for single-member clusters.
+func (w *worker) waitRaftFollowersSynced(
+	ctx context.Context,
+	cr api.ICustomResource,
+	expectedVoters int,
+	timeout time.Duration,
+) error {
+	if expectedVoters < 2 {
+		return nil
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		if util.IsContextDone(ctx) {
+			return ctx.Err()
+		}
+		if w.raftFollowersSynced(ctx, cr, expectedVoters) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errRaftNotConverged
+		}
+		util.WaitContextDoneOrTimeout(ctx, raftPollInterval)
+	}
+}
+
+func (w *worker) raftFollowersSynced(ctx context.Context, cr api.ICustomResource, expectedVoters int) bool {
+	for _, host := range w.membershipObservers(cr) {
+		addr := w.keeperClientAddr(host)
+		role, err := keeper.GetRole(ctx, addr, fourLetterTimeout)
+		if err != nil || role != keeper.RoleLeader {
+			continue
+		}
+		synced, err := keeper.GetSyncedFollowers(ctx, addr, fourLetterTimeout)
+		if err != nil {
+			return false
+		}
+		return synced >= expectedVoters-1
+	}
+	// No leader found among published hosts
+	return false
+}
+
+// crIsSecureOnlyKeeper reports whether EVERY Keeper host has its plaintext
+// client port closed (!IsInsecure()) — the same condition under which
+// Generator.getPlaintextListenerRemoval strips the static <tcp_port>. For such a
+// CR nothing listens on the plaintext ZKPort, so every new Raft gate (the
+// committed-membership barrier, the follower-sync barrier and the purge barrier)
+// — all of which read /keeper/config and 4LW over that plaintext port — can
+// never connect.
+//
+// The operator cannot fall back to the secure port either: dialing
+// tcp_port_secure with the vendored go-zookeeper client requires a client
+// certificate + key (its TLS path is mutual-TLS only), and a CHK's Keeper TLS is
+// configured entirely by user-supplied server-side <openSSL> XML from which the
+// operator can derive no client identity. No client TLS material is provisioned
+// to the controller today (see pkg/controller/chi/worker-zk-integration.go,
+// which skips TLS ZK dials for the same reason). Callers therefore detect this
+// case and DEGRADE the gates to pre-branch behavior (unverified rescale) rather
+// than looping Aborted forever. Real TLS observation is a documented follow-up.
+func crIsSecureOnlyKeeper(cr api.ICustomResource) bool {
+	anyHost := false
+	allPlaintextClosed := true
+	cr.WalkHosts(func(host *api.Host) error {
+		anyHost = true
+		// A nil host carries no posture; treat it conservatively as "not closed"
+		// so a phantom host never trips the secure-only degradation.
+		if host == nil || host.IsInsecure() {
+			allPlaintextClosed = false
+		}
+		return nil
+	})
+	return anyHost && allPlaintextClosed
+}
+
+// warnRaftGatesSkippedSecureOnly records — loudly — that a Raft
+// rescale-safety gate was skipped for a secure-only Keeper. It always emits a
+// (k8s-deduplicated) Warning event (visible in `kubectl describe`), and — when
+// the operator config has `status.fields.actions` enabled (off by default) —
+// also pushes a Status.Actions entry. The Warning event alone guarantees the
+// degradation is observable regardless of that config flag.
+func (w *worker) warnRaftGatesSkippedSecureOnly(cr api.ICustomResource, gate string) {
+	msg := fmt.Sprintf(
+		"secure-only Keeper: skipping Raft %s — the operator cannot read /keeper/config or 4LW over the closed plaintext port and has no TLS client material to dial the secure port; rescale-safety is NOT verified (pre-branch behavior). See docs/chk-rescale-raft-safety-v3.md.",
+		gate)
+	w.a.WithEvent(cr, a.EventActionReconcile, a.EventReasonRaftMembershipUnverified).
+		WithActions(cr).
+		M(cr).F().Warning(msg)
+}
+
+// hostJoinsEstablishedCluster mirrors the staging condition of
+// stageNewHostsForRaftJoin: the host is joining a cluster that already existed
+// on a prior successful reconcile. Keyed off the CR ancestor (stable across the
+// reconcile), NOT the mutable per-host statuses — see api.CRHasEstablishedCluster.
+func hostJoinsEstablishedCluster(host *api.Host) bool {
+	return api.CRHasEstablishedCluster(host.GetCR())
+}
+
+// removedHosts collects hosts being removed by the current action plan
+// (their objects come from the ancestor CR, so runtime addresses and names
+// are resolvable).
+func removedHosts(cr *apiChk.ClickHouseKeeperInstallation) (hosts []*api.Host) {
+	ap := cr.EnsureRuntime().ActionPlan
+	if ap == nil {
+		return nil
+	}
+	ap.WalkRemoved(
+		func(cluster api.ICluster) {
+			cluster.WalkHosts(func(host *api.Host) error {
+				hosts = append(hosts, host)
+				return nil
+			})
+		},
+		func(shard api.IShard) {
+			shard.WalkHosts(func(host *api.Host) error {
+				hosts = append(hosts, host)
+				return nil
+			})
+		},
+		func(host *api.Host) {
+			hosts = append(hosts, host)
+		},
+	)
+	return hosts
+}
+
+// prepareRaftScaleDown moves Raft leadership off the hosts being removed
+// BEFORE the shrunk raft XML is published: `rqld` on the lowest-ordinal
+// surviving host (23.8-compatible). Best-effort: Keeper can remove a leader
+// on its own (it yields leadership first); the proactive transfer just avoids
+// that riskier path, so failures here only log a warning. The actual safety
+// fence is the purge barrier in clean().
+func (w *worker) prepareRaftScaleDown(ctx context.Context, cr *apiChk.ClickHouseKeeperInstallation) {
+	removed := removedHosts(cr)
+	if len(removed) == 0 {
+		return
+	}
+
+	// Is the current leader among the removed hosts?
+	leaderRemoved := false
+	for _, host := range removed {
+		role, err := keeper.GetRole(ctx, w.keeperClientAddr(host), fourLetterTimeout)
+		if err == nil && role == keeper.RoleLeader {
+			leaderRemoved = true
+			break
+		}
+	}
+	if !leaderRemoved {
+		return
+	}
+
+	// Ask the lowest-ordinal survivor to take leadership over.
+	survivors := w.membershipObservers(cr)
+	if len(survivors) == 0 {
+		return
+	}
+	target := survivors[0]
+	w.a.V(1).M(cr).F().Info("scale-down: transferring raft leadership to surviving host %s", target.GetName())
+	if _, err := keeper.RequestLeadership(ctx, w.keeperClientAddr(target), fourLetterTimeout); err != nil {
+		w.a.V(1).M(cr).F().Warning("rqld to %s failed: %v", target.GetName(), err)
+		return
+	}
+	// Poll until a survivor is the leader (bounded, best-effort).
+	deadline := time.Now().Add(1 * time.Minute)
+	for time.Now().Before(deadline) && !util.IsContextDone(ctx) {
+		role, err := keeper.GetRole(ctx, w.keeperClientAddr(target), fourLetterTimeout)
+		if err == nil && (role == keeper.RoleLeader || role == keeper.RoleStandalone) {
+			return
+		}
+		util.WaitContextDoneOrTimeout(ctx, raftPollInterval)
+	}
+	w.a.V(1).M(cr).F().Warning("leadership did not move to a survivor in time; relying on Keeper's own leader-removal handling")
+}
+
+// raftSafeToPurge is the purge-time safety invariant: a StatefulSet or PVC
+// belonging to a Keeper member may only be deleted once every published
+// member reports committed Raft membership equal to the published set.
+//
+// The gate is keyed off what `reg` is actually about to delete, not off the
+// transient ActionPlan: on a stopped CR, Task 6's IsStopped short-circuit
+// lets finalizeReconcileAndMarkCompleted advance the ancestor before the
+// removal is committed, so by the next pass ActionPlan.GetRemovedHostsNum()
+// can already read 0 even though the STS/PVC purge is still pending — an
+// ActionPlan-keyed trigger would wave that purge through unchecked. Likewise
+// after an operator crash/restart mid scale-down, the in-memory ActionPlan is
+// gone but an orphaned STS/PVC can still be sitting in `reg`. Keying off the
+// purge set itself is correct in both cases.
+//
+// reg containing no StatefulSet/PVC entries means nothing raft-critical is
+// about to be deleted (only ConfigMaps/Services/Secrets/PDBs, say) — those
+// purge freely, at no barrier cost on routine reconciles. Otherwise the
+// barrier must pass. When the cluster is stopped or unreachable this
+// intentionally blocks ALL purge (fail-safe stuck) until the barrier can run
+// again and actually observe convergence.
+func (w *worker) raftSafeToPurge(ctx context.Context, cr api.ICustomResource, reg *model.Registry) bool {
+	raftCritical := false
+	reg.Walk(func(entityType model.EntityType, _ meta.Object) {
+		if entityType == model.StatefulSet || entityType == model.PVC {
+			raftCritical = true
+		}
+	})
+	if !raftCritical {
+		return true
+	}
+	if cr.IsStopped() {
+		// A stopped CR has its observers down: convergence is unobservable, so
+		// don't burn the full waitRaftMembershipConverged timeout every pass.
+		// Fail-safe is preserved (purge stays blocked); on unstop, discovery
+		// re-finds the orphan and this gate runs the barrier again for real.
+		return false
+	}
+	if crIsSecureOnlyKeeper(cr) {
+		// Secure-only Keeper: the barrier cannot connect (plaintext port closed,
+		// no operator TLS client material). Blocking would orphan the STS/PVC
+		// forever; degrade to pre-branch behavior (allow the purge, unverified).
+		w.warnRaftGatesSkippedSecureOnly(cr, "purge barrier")
+		return true
+	}
+	return w.waitRaftMembershipConverged(ctx, cr, publishedMemberIDs(cr), raftBarrierTimeout) == nil
+}

--- a/pkg/controller/chk/worker-reconciler-chk.go
+++ b/pkg/controller/chk/worker-reconciler-chk.go
@@ -131,6 +131,7 @@ func (w *worker) reconcileCR(ctx context.Context, old, new *apiChk.ClickHouseKee
 		if errors.Is(err, common.ErrCRUDAbort) {
 			metrics.CRReconcilesAborted(ctx, new)
 		}
+		return err
 	} else {
 		// Reconcile successful
 		// Post-process added items
@@ -140,6 +141,30 @@ func (w *worker) reconcileCR(ctx context.Context, old, new *apiChk.ClickHouseKee
 		}
 
 		w.clean(ctx, new)
+
+		// Completed means convergence: the committed Raft membership must
+		// equal the desired set on every member (v3 invariant 6). By this
+		// point no host is staged, so publishedMemberIDs == desired ids.
+		// A stopped CR has all pods scaled down — nothing to observe; skip
+		// the gate (mirrors waitForIPAddresses's stopped-CR short-circuit).
+		if !new.IsStopped() {
+			if crIsSecureOnlyKeeper(new) {
+				// Secure-only Keeper: the gate reads /keeper/config over the closed
+				// plaintext port and can never pass. Degrade to pre-branch behavior
+				// (mark Completed without convergence verification) rather than loop
+				// Aborted forever. Loudly recorded via a Warning event + status action.
+				w.warnRaftGatesSkippedSecureOnly(new, "membership convergence gate")
+			} else if err := w.waitRaftMembershipConverged(ctx, new, publishedMemberIDs(new), raftVerifyTimeout); err != nil {
+				w.a.WithEvent(new, a.EventActionReconcile, a.EventReasonReconcileFailed).
+					WithError(new).
+					M(new).F().
+					Error("raft membership not converged for CR %s: %v", util.NamespaceNameString(new), err)
+				w.markReconcileCompletedUnsuccessfully(ctx, new, common.ErrCRUDAbort)
+				metrics.CRReconcilesAborted(ctx, new)
+				return err
+			}
+		}
+
 		w.addToMonitoring(new)
 		w.waitForIPAddresses(ctx, new)
 		w.finalizeReconcileAndMarkCompleted(ctx, new)
@@ -261,6 +286,10 @@ func (w *worker) reconcileCRAuxObjectsPreliminary(ctx context.Context, cr *apiCh
 
 	w.a.V(2).M(cr).S().P()
 	defer w.a.V(2).M(cr).E().P()
+
+	// On scale-down, move leadership off the departing hosts BEFORE the
+	// shrunk raft XML is published (v3 design, scale-down step 2).
+	w.prepareRaftScaleDown(ctx, cr)
 
 	// CR common ConfigMap without added hosts
 	cr.GetRuntime().LockCommonConfig()
@@ -802,11 +831,15 @@ func (w *worker) reconcileHostMain(ctx context.Context, host *api.Host) error {
 			Warning("Reconcile Host Main - unable to reconcile PVC. Host: %s Err: %v", host.GetName(), err)
 	}
 
-	// Finalize main reconcile with domain activities
+	// Finalize main reconcile with domain activities.
+	// A failed membership barrier is fatal for the host reconcile: the next
+	// host must not be published until this one is committed (v3 invariant 2).
 	if err := w.reconcileHostMainDomain(ctx, host); err != nil {
+		metrics.HostReconcilesErrors(ctx, host.GetCR())
 		w.a.V(1).
 			M(host).F().
-			Warning("Reconcile Host Main - unable to reconcile domain reconcile. Host: %s Err: %v", host.GetName(), err)
+			Warning("Reconcile Host Main - raft membership barrier failed. Host: %s Err: %v", host.GetName(), err)
+		return err
 	}
 
 	return nil
@@ -841,18 +874,50 @@ func (w *worker) reconcileHostPVCs(ctx context.Context, host *api.Host) storage.
 }
 
 func (w *worker) reconcileHostMainDomain(ctx context.Context, host *api.Host) error {
-	// Should we wait for host to startup
-	wait := false
-
-	if host.GetReconcileAttributes().GetStatus().Is(types.ObjectStatusRequested) {
-		wait = true
+	if !host.GetReconcileAttributes().GetStatus().Is(types.ObjectStatusRequested) {
+		return nil
 	}
 
-	// Wait for host to startup; respect ctx cancellation so the worker
-	// unblocks on controller shutdown instead of running out the timer.
-	if wait {
+	if !hostJoinsEstablishedCluster(host) {
+		// Fresh-cluster bootstrap: all peers start together and elect a leader
+		// via standard NuRaft bootstrap; there is no pre-existing committed
+		// membership to observe. Keep the legacy pacing wait.
 		util.WaitContextDoneOrTimeout(ctx, 7*time.Second)
+		return nil
 	}
+
+	// A stopped CR has all pods scaled to 0 — the barriers can never observe
+	// them, so skip rather than burn the full timeout every reconcile. Mirrors
+	// the Completed gate's stopped short-circuit; on unstop the barriers run
+	// normally.
+	if host.GetCR().IsStopped() {
+		return nil
+	}
+
+	// Secure-only Keeper: both the committed-membership barrier (/keeper/config
+	// over ZK) and the follower-sync barrier (mntr 4LW) target the closed
+	// plaintext port, and the operator has no TLS client material for the secure
+	// port. Skip both rather than fail every reconcile — degrades to pre-branch
+	// (join proceeds unverified). Loudly recorded via a Warning event + status action.
+	if crIsSecureOnlyKeeper(host.GetCR()) {
+		w.warnRaftGatesSkippedSecureOnly(host.GetCR(), "join barriers")
+		return nil
+	}
+
+	// The host has just been published into the shared raft XML and its pod
+	// has started: wait until the leader commits it into the Raft
+	// configuration and it catches up with the log. Fail-safe: on timeout the
+	// reconcile aborts (requeue), no destructive action is taken.
+	expected := publishedMemberIDs(host.GetCR())
+	if err := w.waitRaftMembershipConverged(ctx, host.GetCR(), expected, raftBarrierTimeout); err != nil {
+		w.a.V(1).M(host).F().Warning("host %s was not committed into raft membership: %v", host.GetName(), err)
+		return err
+	}
+	if err := w.waitRaftFollowersSynced(ctx, host.GetCR(), len(expected), raftBarrierTimeout); err != nil {
+		w.a.V(1).M(host).F().Warning("raft followers not synced after adding host %s: %v", host.GetName(), err)
+		return err
+	}
+	w.a.V(1).M(host).F().Info("host %s committed into raft membership %v and synced", host.GetName(), expected)
 	return nil
 }
 

--- a/pkg/controller/chk/worker.go
+++ b/pkg/controller/chk/worker.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"time"
 
+	apps "k8s.io/api/apps/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	log "github.com/altinity/clickhouse-operator/pkg/announcer"
@@ -55,6 +57,11 @@ type worker struct {
 	normalizer    *normalizer.Normalizer
 	task          *common.Task
 	stsReconciler *statefulset.Reconciler
+
+	// stsGetterFn, when set, overrides the live StatefulSet lookup used by
+	// hostSTSConfirmedAbsent. Tests inject NotFound / transient-error responses
+	// here; production leaves it nil and hits w.c.kube.STS().
+	stsGetterFn func(ctx context.Context, host *api.Host) (*apps.StatefulSet, error)
 
 	start time.Time
 }
@@ -405,7 +412,68 @@ func (w *worker) setHostStatusesPreliminary(ctx context.Context, cr *apiChk.Clic
 		}
 	})
 
+	w.stageNewHostsForRaftJoin(ctx, cr)
+
 	w.logHosts(cr)
+}
+
+// stageNewHostsForRaftJoin marks newly requested hosts with TagExclude when
+// they join an established cluster, so the shared raft XML never contains
+// more than one not-yet-committed server (split-brain guard: two fresh
+// voters can elect a leader between themselves). Fresh-cluster bootstrap
+// (no established cluster) is left untouched: full static XML at once.
+//
+// "Established cluster" is keyed off the CR ancestor (the last-completed spec
+// already had hosts), NOT off mutable per-host statuses — see
+// api.CRHasEstablishedCluster.
+//
+// A host is staged (excluded from the shared XML) ONLY while its StatefulSet
+// does not yet exist. A Requested host whose STS already exists was already
+// created on a prior pass (committed, or mid-join): it must stay published so
+// the preliminary raft-XML rewrite does not drop it. Excluding it would
+// republish a shorter membership and make Keeper (XML-diff mode) REMOVE a
+// committed voter, then re-add it — churn on every interrupted reconcile. The
+// STS-existence signal is host.Runtime.CurStatefulSet, populated by fillCurSTS
+// during buildCR (which runs before this).
+func (w *worker) stageNewHostsForRaftJoin(ctx context.Context, cr *apiChk.ClickHouseKeeperInstallation) {
+	if !api.CRHasEstablishedCluster(cr) {
+		return
+	}
+	cr.WalkHosts(func(host *api.Host) error {
+		if host.GetReconcileAttributes().GetStatus().Is(types.ObjectStatusRequested) && w.hostSTSConfirmedAbsent(ctx, host) {
+			w.a.V(1).M(host).Info("Stage new host for one-at-a-time raft join: %s", host.GetName())
+			host.GetReconcileAttributes().SetExclude()
+		}
+		return nil
+	})
+}
+
+// hostSTSConfirmedAbsent reports whether the host's StatefulSet is DEFINITIVELY
+// absent from the API server. host.Runtime.CurStatefulSet is populated by
+// fillCurSTS, which swallows every Get error — so a nil there can mean a genuine
+// NotFound OR a transient apiReader error. Staging a host whose STS actually
+// exists would drop a committed voter from the shared raft XML (the exact
+// churn stageNewHostsForRaftJoin prevents), so we must not treat an ambiguous
+// nil as "absent". When CurStatefulSet is nil we re-probe directly and stage
+// only on an explicit NotFound; any other error keeps the host published
+// (conservative: no churn on a flaky read).
+func (w *worker) hostSTSConfirmedAbsent(ctx context.Context, host *api.Host) bool {
+	if host.Runtime.CurStatefulSet != nil {
+		// STS is known to exist.
+		return false
+	}
+	_, err := w.stsGetter(ctx, host)
+	return apiErrors.IsNotFound(err)
+}
+
+// stsGetter fetches a host's StatefulSet from the API server. It is a small
+// indirection so staging tests can inject NotFound / transient-error responses
+// without a full kube client. When unset it falls back to the live kube client.
+func (w *worker) stsGetter(ctx context.Context, host *api.Host) (*apps.StatefulSet, error) {
+	if w.stsGetterFn != nil {
+		return w.stsGetterFn(ctx, host)
+	}
+	return w.c.kube.STS().Get(ctx, host)
 }
 
 // Log hosts statuses
@@ -442,13 +510,12 @@ func (w *worker) createTemplated(c *apiChk.ClickHouseKeeperInstallation, _opts .
 
 // getRaftGeneratorOptions build base set of RaftOptions
 func (w *worker) getRaftGeneratorOptions() *commonConfig.HostSelector {
-	// Raft specifies to exclude:
-	// 1. all newly added hosts
-	// 2. all explicitly excluded hosts
+	// Exclude from the shared raft XML all hosts staged for one-at-a-time
+	// join (TagExclude, set by stageNewHostsForRaftJoin). They are published
+	// individually by includeHostIntoRaftCluster, each behind a
+	// committed-membership barrier. See docs/chk-rescale-raft-safety-v3.md.
 	return commonConfig.NewHostSelector().ExcludeReconcileAttributes(
-		types.NewReconcileAttributes(),
-		//SetAdd().
-		//SetExclude(),
+		types.NewReconcileAttributes().SetExclude(),
 	)
 }
 

--- a/pkg/controller/chk/worker_raft_secure_test.go
+++ b/pkg/controller/chk/worker_raft_secure_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+)
+
+// secureHost builds a host with an explicit per-host `insecure` posture, so the
+// test exercises Host.IsInsecure() without a wired cluster fallback.
+func secureHost(name string, idx int, insecure bool) *api.Host {
+	h := stagingHost(name, idx, types.ObjectStatusFound, true)
+	h.Insecure = types.NewStringBool(insecure)
+	return h
+}
+
+// TestCRIsSecureOnlyKeeper pins the secure-only detection that drives the
+// Batch C fallback: the new Raft gates are skipped only when EVERY host has its
+// plaintext client port closed (mirrors Generator.getPlaintextListenerRemoval).
+func TestCRIsSecureOnlyKeeper(t *testing.T) {
+	t.Run("all hosts plaintext-closed => secure-only", func(t *testing.T) {
+		cr := stagingCR(0, secureHost("k0", 0, false), secureHost("k1", 1, false), secureHost("k2", 2, false))
+		require.True(t, crIsSecureOnlyKeeper(cr))
+	})
+
+	t.Run("plaintext-open hosts => not secure-only", func(t *testing.T) {
+		// A legacy CHK resolves IsInsecure()==true, so it is never mis-detected as
+		// secure-only and the new Raft gates keep running for it.
+		cr := stagingCR(0, secureHost("k0", 0, true), secureHost("k1", 1, true))
+		require.False(t, crIsSecureOnlyKeeper(cr))
+	})
+
+	t.Run("mixed: one host still plaintext-open => not secure-only", func(t *testing.T) {
+		cr := stagingCR(0, secureHost("k0", 0, false), secureHost("k1", 1, true))
+		require.False(t, crIsSecureOnlyKeeper(cr))
+	})
+}

--- a/pkg/controller/chk/worker_raft_staging_test.go
+++ b/pkg/controller/chk/worker_raft_staging_test.go
@@ -1,0 +1,153 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apiChk "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse-keeper.altinity.com/v1"
+	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+)
+
+// stsGetterNotFound models an API server that authoritatively reports the
+// StatefulSet as absent (the genuine "host was never created" case).
+func stsGetterNotFound(_ context.Context, host *api.Host) (*apps.StatefulSet, error) {
+	return nil, apiErrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "statefulsets"}, host.GetName())
+}
+
+// stsGetterTransientError models a transient apiReader failure (timeout, 500,
+// connection refused) — NOT a NotFound. A host must never be staged on this.
+func stsGetterTransientError(_ context.Context, _ *api.Host) (*apps.StatefulSet, error) {
+	return nil, apiErrors.NewInternalError(errors.New("apiserver temporarily unavailable"))
+}
+
+// stagingHost builds a host with a given reconcile status and optional existing
+// StatefulSet (hasSTS models host.Runtime.CurStatefulSet, populated by fillCurSTS).
+func stagingHost(name string, replicaIdx int, status types.ObjectStatus, hasSTS bool) *api.Host {
+	h := &api.Host{Name: name}
+	h.GetRuntime().GetAddress().SetReplicaIndex(replicaIdx)
+	h.GetReconcileAttributes().SetStatus(status)
+	if hasSTS {
+		h.Runtime.CurStatefulSet = &apps.StatefulSet{}
+	}
+	return h
+}
+
+// stagingCR wires the given hosts into a single cluster/shard and, when
+// ancestorHostCount > 0, marks the CR as having an established ancestor cluster
+// of that size (mirrors a prior successful reconcile).
+func stagingCR(ancestorHostCount int, hosts ...*api.Host) *apiChk.ClickHouseKeeperInstallation {
+	build := func(hs []*api.Host) *apiChk.ClickHouseKeeperInstallation {
+		cr := &apiChk.ClickHouseKeeperInstallation{}
+		cr.Spec.Configuration = apiChk.NewConfiguration()
+		cr.Spec.Configuration.Clusters = []*apiChk.Cluster{
+			{
+				Layout: &apiChk.ChkClusterLayout{
+					Shards: []*apiChk.ChkShard{
+						{Hosts: hs},
+					},
+				},
+			},
+		}
+		return cr
+	}
+	cr := build(hosts)
+	if ancestorHostCount > 0 {
+		ancestorHosts := make([]*api.Host, ancestorHostCount)
+		for i := range ancestorHosts {
+			ancestorHosts[i] = stagingHost("ancestor", i, types.ObjectStatusFound, true)
+		}
+		cr.SetAncestor(build(ancestorHosts))
+	}
+	return cr
+}
+
+// TestStageNewHostsForRaftJoin pins the two coupled safety rules:
+//   - B2: staging only runs for an established cluster (ancestor has hosts); a
+//     fresh install (no ancestor) bootstraps with the full static XML.
+//   - B1: within an established cluster, only a Requested host whose STS does
+//     NOT yet exist is staged (excluded). A Requested host whose STS already
+//     exists (committed or mid-join) must stay published, or the preliminary
+//     raft-XML rewrite would drop a committed voter.
+func TestStageNewHostsForRaftJoin(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("fresh install (no ancestor) stages nothing", func(t *testing.T) {
+		w := &worker{stsGetterFn: stsGetterNotFound}
+		h0 := stagingHost("keeper-0", 0, types.ObjectStatusRequested, false)
+		h1 := stagingHost("keeper-1", 1, types.ObjectStatusRequested, false)
+		h2 := stagingHost("keeper-2", 2, types.ObjectStatusRequested, false)
+		cr := stagingCR(0, h0, h1, h2)
+
+		w.stageNewHostsForRaftJoin(ctx, cr)
+
+		require.False(t, h0.GetReconcileAttributes().IsExclude())
+		require.False(t, h1.GetReconcileAttributes().IsExclude())
+		require.False(t, h2.GetReconcileAttributes().IsExclude())
+	})
+
+	t.Run("scale-up first pass: STS-absent Requested hosts are staged", func(t *testing.T) {
+		w := &worker{stsGetterFn: stsGetterNotFound}
+		h0 := stagingHost("keeper-0", 0, types.ObjectStatusFound, true)
+		h1 := stagingHost("keeper-1", 1, types.ObjectStatusRequested, false)
+		h2 := stagingHost("keeper-2", 2, types.ObjectStatusRequested, false)
+		cr := stagingCR(1, h0, h1, h2)
+
+		w.stageNewHostsForRaftJoin(ctx, cr)
+
+		require.False(t, h0.GetReconcileAttributes().IsExclude(), "established host must stay published")
+		require.True(t, h1.GetReconcileAttributes().IsExclude(), "STS-absent joining host is staged")
+		require.True(t, h2.GetReconcileAttributes().IsExclude(), "STS-absent joining host is staged")
+	})
+
+	t.Run("interrupted retry: Requested host WITH an STS is NOT staged", func(t *testing.T) {
+		w := &worker{stsGetterFn: stsGetterNotFound}
+		// host1 committed {0,1} on pass 1 (STS exists) but reappears Requested on
+		// the retry pass; host2 never got created. host1 must stay published so
+		// the preliminary rewrite keeps {0,1} and Keeper removes no committed voter.
+		h0 := stagingHost("keeper-0", 0, types.ObjectStatusFound, true)
+		h1 := stagingHost("keeper-1", 1, types.ObjectStatusRequested, true)
+		h2 := stagingHost("keeper-2", 2, types.ObjectStatusRequested, false)
+		cr := stagingCR(1, h0, h1, h2)
+
+		w.stageNewHostsForRaftJoin(ctx, cr)
+
+		require.False(t, h1.GetReconcileAttributes().IsExclude(), "already-created voter must NOT be re-staged")
+		require.True(t, h2.GetReconcileAttributes().IsExclude(), "still-absent host is staged")
+	})
+
+	t.Run("transient STS error: Requested host is NOT staged", func(t *testing.T) {
+		// fillCurSTS swallows a transient apiReader error into a nil CurStatefulSet.
+		// A direct re-probe that returns a non-NotFound error must leave the host
+		// published — staging it could drop a committed voter (the churn B1 prevents).
+		w := &worker{stsGetterFn: stsGetterTransientError}
+		h0 := stagingHost("keeper-0", 0, types.ObjectStatusFound, true)
+		h1 := stagingHost("keeper-1", 1, types.ObjectStatusRequested, false)
+		cr := stagingCR(1, h0, h1)
+
+		w.stageNewHostsForRaftJoin(ctx, cr)
+
+		require.False(t, h1.GetReconcileAttributes().IsExclude(),
+			"a Requested host whose STS presence is uncertain (transient error) must NOT be staged")
+	})
+}

--- a/pkg/controller/common/announcer/event-emitter.go
+++ b/pkg/controller/common/announcer/event-emitter.go
@@ -78,6 +78,15 @@ const (
 	// CHK reconcile completing but decides not to trigger a CHI reconcile because the resolved
 	// zookeeper endpoints have not changed.
 	EventReasonKeeperUpdateNoEndpointChange = "KeeperUpdateNoEndpointChange"
+
+	// EventReasonRaftMembershipUnverified fires when the operator SKIPS the Raft
+	// rescale-safety gates (committed-membership barrier, follower-sync barrier,
+	// purge barrier) for a secure-only Keeper. Those gates read /keeper/config and
+	// 4LW over the plaintext client port, which a fully-secure Keeper does not
+	// open; the operator has no TLS client material to dial the secure port today,
+	// so it degrades to pre-gate behavior (unverified rescale) rather than looping
+	// Aborted. See docs/chk-rescale-raft-safety-v3.md (secure-only limitation).
+	EventReasonRaftMembershipUnverified = "RaftMembershipUnverified"
 )
 
 type EventEmitter struct {

--- a/pkg/model/chk/config/generator.go
+++ b/pkg/model/chk/config/generator.go
@@ -20,6 +20,7 @@ import (
 
 	log "github.com/altinity/clickhouse-operator/pkg/announcer"
 	chi "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
 	"github.com/altinity/clickhouse-operator/pkg/interfaces"
 	"github.com/altinity/clickhouse-operator/pkg/model/common/config"
 	"github.com/altinity/clickhouse-operator/pkg/util"
@@ -88,6 +89,9 @@ func (c *Generator) getRaftConfig(selector *config.HostSelector) string {
 			util.Iline(raft, i, "    <id>%d</id>", getServerId(host))
 			util.Iline(raft, i, "    <hostname>%s</hostname>", c.namer.Name(interfaces.NameInstanceHostname, host))
 			util.Iline(raft, i, "    <port>%d</port>", host.RaftPort.Value())
+			if isJoiningEstablishedCluster(c.cr, host) {
+				util.Iline(raft, i, "    <start_as_follower>true</start_as_follower>")
+			}
 			if host.IsSecure() {
 				util.Iline(raft, i, "    <secure>1</secure>")
 			}
@@ -187,4 +191,22 @@ func (c *Generator) getPlaintextListenerRemoval() string {
 
 func getServerId(host *chi.Host) int {
 	return host.GetRuntime().GetAddress().GetReplicaIndex()
+}
+
+// isJoiningEstablishedCluster reports whether the host is a newly requested
+// member being added to a cluster that already has established members.
+// Such a host must not initiate elections on first boot (split-brain guard,
+// see docs/chk-rescale-raft-safety-v3.md, Fact 3). On fresh-cluster bootstrap
+// (all hosts new) the flag must NOT be emitted: NuRaft requires at least one
+// server able to start as leader.
+func isJoiningEstablishedCluster(cr chi.ICustomResource, host *chi.Host) bool {
+	if !host.GetReconcileAttributes().GetStatus().Is(types.ObjectStatusRequested) {
+		return false
+	}
+	// "Established" is keyed off the CR ancestor (the cluster already existed on a
+	// prior successful reconcile), NOT off mutable per-host statuses, which flip
+	// during the sequential host loop and would make a fresh multi-node bootstrap
+	// mis-emit start_as_follower on a later host — NuRaft forbids all-followers.
+	// See api.CRHasEstablishedCluster.
+	return chi.CRHasEstablishedCluster(cr)
 }

--- a/pkg/model/chk/config/generator_raft_test.go
+++ b/pkg/model/chk/config/generator_raft_test.go
@@ -1,0 +1,140 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	chi "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+	"github.com/altinity/clickhouse-operator/pkg/interfaces"
+)
+
+// fakeNamer resolves NameInstanceHostname to the host name for test purposes.
+type fakeNamer struct {
+	interfaces.INameManager
+}
+
+func (f *fakeNamer) Name(what interfaces.NameType, params ...any) string {
+	host := params[0].(*chi.Host)
+	return host.GetName()
+}
+
+func raftHost(name string, replicaIdx int, status types.ObjectStatus) *chi.Host {
+	// HostSecure carries an explicit (personal) resolved value so IsSecure()
+	// short-circuits without dereferencing GetCluster()/GetCR() — mirrors
+	// insecureHost() in listeners_test.go, which keeps the same unit test
+	// self-contained without a real cluster/CR wired into host.Runtime.
+	h := &chi.Host{
+		Name: name,
+		HostSecure: chi.HostSecure{
+			Insecure: types.NewStringBool(true),
+			Secure:   types.NewStringBool(false),
+		},
+	}
+	h.GetRuntime().GetAddress().SetReplicaIndex(replicaIdx)
+	h.RaftPort = types.NewInt32(9444)
+	h.GetReconcileAttributes().SetStatus(status)
+	return h
+}
+
+func TestRaftConfigStartAsFollowerOnJoin(t *testing.T) {
+	// Scale-up of an established 1-node cluster (ancestor has host 0) to 2 nodes:
+	// member 0 established + member 1 joining. The joining host must
+	// start_as_follower. "Established" is keyed off the ancestor, not off the
+	// per-host statuses.
+	cr := &fakeCR{
+		hosts: []*chi.Host{
+			raftHost("keeper-0", 0, types.ObjectStatusFound),
+			raftHost("keeper-1", 1, types.ObjectStatusRequested),
+		},
+		ancestorHosts: []*chi.Host{
+			raftHost("keeper-0", 0, types.ObjectStatusFound),
+		},
+	}
+	g := NewGenerator(cr, &fakeNamer{}, &GeneratorOptions{})
+	xml := g.getRaftConfig(nil)
+
+	// Joining host is marked start_as_follower, established host is not
+	require.Contains(t, xml, "<start_as_follower>true</start_as_follower>")
+	require.Equal(t, 1, strings.Count(xml, "<start_as_follower>true</start_as_follower>"))
+	require.Contains(t, xml, "keeper-0")
+	require.Contains(t, xml, "keeper-1")
+}
+
+func TestRaftConfigNoStartAsFollowerOnBootstrap(t *testing.T) {
+	// Fresh cluster (no ancestor): ALL hosts are new. NuRaft forbids all servers
+	// being start_as_follower — none must be emitted. Even though host 0 could
+	// flip to a non-Requested status mid-loop, the ancestor-keyed classification
+	// keeps every host a bootstrap member.
+	cr := &fakeCR{hosts: []*chi.Host{
+		raftHost("keeper-0", 0, types.ObjectStatusRequested),
+		raftHost("keeper-1", 1, types.ObjectStatusRequested),
+	}}
+	g := NewGenerator(cr, &fakeNamer{}, &GeneratorOptions{})
+	xml := g.getRaftConfig(nil)
+	require.NotContains(t, xml, "start_as_follower")
+}
+
+// TestRaftConfigBootstrapIgnoresMutatedStatuses reproduces the fresh-3-node
+// scenario that previously deadlocked: the sequential host loop marks host 0
+// Created (non-Requested) before host 1 is generated. A status-keyed
+// classification would then treat host 1 as "joining an established cluster"
+// and emit start_as_follower on it (and drive a membership barrier that never
+// converges). With no ancestor, all three must remain bootstrap members.
+func TestRaftConfigBootstrapIgnoresMutatedStatuses(t *testing.T) {
+	cr := &fakeCR{hosts: []*chi.Host{
+		raftHost("keeper-0", 0, types.ObjectStatusCreated),
+		raftHost("keeper-1", 1, types.ObjectStatusRequested),
+		raftHost("keeper-2", 2, types.ObjectStatusRequested),
+	}}
+	g := NewGenerator(cr, &fakeNamer{}, &GeneratorOptions{})
+	xml := g.getRaftConfig(nil)
+	require.NotContains(t, xml, "start_as_follower",
+		"fresh install (no ancestor) must never emit start_as_follower even after host 0 flips to Created")
+}
+
+// TestIsJoiningEstablishedCluster pins the classification directly: a Requested
+// host is "joining" iff the CR has an ancestor with hosts (established cluster),
+// and never on a fresh install regardless of sibling statuses.
+func TestIsJoiningEstablishedCluster(t *testing.T) {
+	joining := raftHost("keeper-1", 1, types.ObjectStatusRequested)
+	found := raftHost("keeper-0", 0, types.ObjectStatusFound)
+
+	t.Run("ancestor with hosts -> Requested host is joining", func(t *testing.T) {
+		cr := &fakeCR{
+			hosts:         []*chi.Host{found, joining},
+			ancestorHosts: []*chi.Host{found},
+		}
+		require.True(t, isJoiningEstablishedCluster(cr, joining))
+	})
+
+	t.Run("no ancestor -> bootstrap even with a non-Requested sibling", func(t *testing.T) {
+		created := raftHost("keeper-0", 0, types.ObjectStatusCreated)
+		cr := &fakeCR{hosts: []*chi.Host{created, joining}}
+		require.False(t, isJoiningEstablishedCluster(cr, joining))
+	})
+
+	t.Run("non-Requested host is never joining", func(t *testing.T) {
+		cr := &fakeCR{
+			hosts:         []*chi.Host{found},
+			ancestorHosts: []*chi.Host{found},
+		}
+		require.False(t, isJoiningEstablishedCluster(cr, found))
+	})
+}

--- a/pkg/model/chk/config/listeners_test.go
+++ b/pkg/model/chk/config/listeners_test.go
@@ -24,11 +24,17 @@ import (
 )
 
 // fakeCR is a minimal ICustomResource stub exercising the WalkHosts-based
-// getPlaintextListenerRemoval. Only WalkHosts is needed; the embedded interface
+// getPlaintextListenerRemoval and the ancestor-based raft-join classification.
+// Only WalkHosts / GetAncestor / HostsCount are needed; the embedded interface
 // satisfies the type at compile time and panics on any unexpected call.
+//
+// ancestorHosts models the last-completed spec: nil means a fresh install (no
+// ancestor / bootstrap), a non-nil slice means an established cluster of that
+// size. See api.CRHasEstablishedCluster.
 type fakeCR struct {
 	chi.ICustomResource
-	hosts []*chi.Host
+	hosts         []*chi.Host
+	ancestorHosts []*chi.Host
 }
 
 func (f *fakeCR) WalkHosts(fn func(host *chi.Host) error) []error {
@@ -37,6 +43,17 @@ func (f *fakeCR) WalkHosts(fn func(host *chi.Host) error) []error {
 		errs = append(errs, fn(h))
 	}
 	return errs
+}
+
+func (f *fakeCR) HostsCount() int {
+	return len(f.hosts)
+}
+
+func (f *fakeCR) GetAncestor() chi.ICustomResource {
+	if f.ancestorHosts == nil {
+		return nil
+	}
+	return &fakeCR{hosts: f.ancestorHosts}
 }
 
 func secureHost(securePort int32) *chi.Host {

--- a/pkg/model/chk/keeper/client.go
+++ b/pkg/model/chk/keeper/client.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keeper
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Member is one entry of the committed Raft cluster configuration as
+// serialized by Keeper into the special znode `/keeper/config`:
+//
+//	server.1=host:9444;participant;1
+type Member struct {
+	ID       int
+	Endpoint string
+	Learner  bool
+	Priority int
+}
+
+// ParseClusterConfig parses the payload of `get /keeper/config`.
+// Unknown lines are skipped; a malformed `server.` line is an error.
+func ParseClusterConfig(data string) ([]Member, error) {
+	var members []Member
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "server.") {
+			continue
+		}
+		idAndRest := strings.SplitN(strings.TrimPrefix(line, "server."), "=", 2)
+		if len(idAndRest) != 2 {
+			return nil, fmt.Errorf("malformed server line: %q", line)
+		}
+		id, err := strconv.Atoi(idAndRest[0])
+		if err != nil {
+			return nil, fmt.Errorf("malformed server id in line: %q", line)
+		}
+		parts := strings.Split(idAndRest[1], ";")
+		m := Member{ID: id, Endpoint: parts[0], Priority: 1}
+		if len(parts) > 1 {
+			m.Learner = parts[1] == "learner"
+		}
+		if len(parts) > 2 {
+			if p, err := strconv.Atoi(parts[2]); err == nil {
+				m.Priority = p
+			}
+		}
+		members = append(members, m)
+	}
+	return members, nil
+}
+
+// MemberIDs returns the set of member ids.
+func MemberIDs(members []Member) map[int]bool {
+	ids := map[int]bool{}
+	for _, m := range members {
+		ids[m.ID] = true
+	}
+	return ids
+}
+
+// SameIDs reports whether the member list is exactly the expected id set.
+func SameIDs(members []Member, expected map[int]bool) bool {
+	ids := MemberIDs(members)
+	if len(ids) != len(expected) {
+		return false
+	}
+	for id := range expected {
+		if !ids[id] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/model/chk/keeper/client_test.go
+++ b/pkg/model/chk/keeper/client_test.go
@@ -1,0 +1,110 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keeper
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseClusterConfig(t *testing.T) {
+	data := "server.0=chk-test-keeper-0-0.ns.svc:9444;participant;1\n" +
+		"server.2=chk-test-keeper-0-2.ns.svc:9444;learner;0\n"
+	members, err := ParseClusterConfig(data)
+	require.NoError(t, err)
+	require.Len(t, members, 2)
+	require.Equal(t, 0, members[0].ID)
+	require.Equal(t, "chk-test-keeper-0-0.ns.svc:9444", members[0].Endpoint)
+	require.False(t, members[0].Learner)
+	require.Equal(t, 1, members[0].Priority)
+	require.Equal(t, 2, members[1].ID)
+	require.True(t, members[1].Learner)
+}
+
+func TestParseClusterConfigTolerant(t *testing.T) {
+	// no type/priority suffixes, trailing newline, junk lines
+	members, err := ParseClusterConfig("server.1=host:9444\n\nsomething-else\n")
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	require.Equal(t, map[int]bool{1: true}, MemberIDs(members))
+}
+
+func TestParseClusterConfigMalformed(t *testing.T) {
+	_, err := ParseClusterConfig("server.x=host:9444;participant;1")
+	require.Error(t, err)
+}
+
+func TestSameIDs(t *testing.T) {
+	members, _ := ParseClusterConfig("server.0=a:1;participant;1\nserver.1=b:1;participant;1\n")
+	require.True(t, SameIDs(members, map[int]bool{0: true, 1: true}))
+	require.False(t, SameIDs(members, map[int]bool{0: true}))
+	require.False(t, SameIDs(members, map[int]bool{0: true, 1: true, 2: true}))
+}
+
+// startFake4LW starts a TCP listener answering canned 4lw responses.
+func startFake4LW(t *testing.T, responses map[string]string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 4)
+				if _, err := c.Read(buf); err != nil {
+					return
+				}
+				_, _ = c.Write([]byte(responses[string(buf)]))
+			}(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func TestGetRole(t *testing.T) {
+	addr := startFake4LW(t, map[string]string{
+		"srvr": "ClickHouse Keeper version: v25.8\nMode: leader\nNode count: 5\n",
+	})
+	role, err := GetRole(context.Background(), addr, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, RoleLeader, role)
+}
+
+func TestGetRoleNotServing(t *testing.T) {
+	addr := startFake4LW(t, map[string]string{
+		"srvr": "This instance is not currently serving requests\n",
+	})
+	role, err := GetRole(context.Background(), addr, time.Second)
+	require.Error(t, err)
+	require.Equal(t, RoleUnknown, role)
+}
+
+func TestGetSyncedFollowers(t *testing.T) {
+	addr := startFake4LW(t, map[string]string{
+		"mntr": "zk_version\tv25.8\nzk_followers\t2\nzk_synced_followers\t2\n",
+	})
+	n, err := GetSyncedFollowers(context.Background(), addr, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+}

--- a/pkg/model/chk/keeper/fourletter.go
+++ b/pkg/model/chk/keeper/fourletter.go
@@ -1,0 +1,95 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keeper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Role of a Keeper node as reported by the `srvr` four-letter command.
+type Role string
+
+const (
+	RoleLeader     Role = "leader"
+	RoleFollower   Role = "follower"
+	RoleObserver   Role = "observer"
+	RoleStandalone Role = "standalone"
+	RoleUnknown    Role = "unknown"
+)
+
+// FourLetterWord sends a 4lw command (srvr, mntr, rqld, ...) over a raw TCP
+// connection to the Keeper client port and returns the response.
+func FourLetterWord(ctx context.Context, addr string, cmd string, timeout time.Duration) (string, error) {
+	d := net.Dialer{Timeout: timeout}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	if _, err := conn.Write([]byte(cmd)); err != nil {
+		return "", err
+	}
+	data, err := io.ReadAll(conn)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// GetRole reports the Raft role via `srvr` ("Mode: <role>" line).
+// A node with no live leader answers "This instance is not currently serving
+// requests" — that surfaces as RoleUnknown with an error.
+func GetRole(ctx context.Context, addr string, timeout time.Duration) (Role, error) {
+	out, err := FourLetterWord(ctx, addr, "srvr", timeout)
+	if err != nil {
+		return RoleUnknown, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "Mode: ") {
+			return Role(strings.TrimSpace(strings.TrimPrefix(line, "Mode: "))), nil
+		}
+	}
+	return RoleUnknown, fmt.Errorf("no Mode in srvr response from %s: %q", addr, out)
+}
+
+// RequestLeadership asks the node at addr to become the Raft leader (`rqld`,
+// present since 23.8). Best-effort: transport success does not guarantee the
+// transfer; callers must poll GetRole afterwards.
+func RequestLeadership(ctx context.Context, addr string, timeout time.Duration) (string, error) {
+	return FourLetterWord(ctx, addr, "rqld", timeout)
+}
+
+// GetSyncedFollowers parses `mntr` zk_synced_followers (reported by the
+// leader only).
+func GetSyncedFollowers(ctx context.Context, addr string, timeout time.Duration) (int, error) {
+	out, err := FourLetterWord(ctx, addr, "mntr", timeout)
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "zk_synced_followers" {
+			return strconv.Atoi(fields[1])
+		}
+	}
+	return 0, fmt.Errorf("no zk_synced_followers in mntr response from %s", addr)
+}

--- a/pkg/model/chk/keeper/membership.go
+++ b/pkg/model/chk/keeper/membership.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keeper
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+	"github.com/altinity/clickhouse-operator/pkg/model/zookeeper"
+)
+
+// GetCommittedMembership reads the committed Raft configuration from the
+// Keeper node at host:port via the special znode `/keeper/config`.
+//
+// The read is served from that node's local committed state: it can lag behind
+// the leader but can never show a configuration that has not been committed,
+// so a positive match against the expected set is safe to use as a
+// convergence barrier. A node without a live leader refuses the session
+// entirely (ZCONNECTIONLOSS) — that surfaces as an error, which callers treat
+// as "barrier not passed".
+func GetCommittedMembership(ctx context.Context, host string, port int32) ([]Member, error) {
+	conn := zookeeper.NewConnection(
+		api.NewZookeeperNodes(api.ZookeeperNode{Host: host, Port: types.NewInt32(port)}),
+		&zookeeper.ConnectionParams{MaxRetriesNum: 1},
+	)
+	defer conn.Close()
+	data, _, err := conn.Get(ctx, "/keeper/config")
+	if err != nil {
+		return nil, fmt.Errorf("get /keeper/config from %s:%d: %w", host, port, err)
+	}
+	return ParseClusterConfig(string(data))
+}

--- a/pkg/model/common/config/generator_options_selector_test.go
+++ b/pkg/model/common/config/generator_options_selector_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	chi "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+)
+
+// Documents the contract the CHK staged-raft mechanism relies on:
+// a selector excluding TagExclude drops exactly the hosts that carry the tag,
+// regardless of their object status.
+func TestHostSelectorExcludesByExcludeTag(t *testing.T) {
+	selector := NewHostSelector().ExcludeReconcileAttributes(
+		types.NewReconcileAttributes().SetExclude(),
+	)
+
+	staged := &chi.Host{}
+	staged.GetReconcileAttributes().SetStatus(types.ObjectStatusRequested).SetExclude()
+
+	published := &chi.Host{}
+	published.GetReconcileAttributes().SetStatus(types.ObjectStatusRequested)
+
+	found := &chi.Host{}
+	found.GetReconcileAttributes().SetStatus(types.ObjectStatusFound)
+
+	require.False(t, selector.Include(staged), "staged host must be excluded from raft XML")
+	require.True(t, selector.Include(published), "un-staged new host must be included")
+	require.True(t, selector.Include(found), "established host must be included")
+
+	staged.GetReconcileAttributes().UnsetExclude()
+	require.True(t, selector.Include(staged), "host must be included after include-into-raft unsets the tag")
+}

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -3,6 +3,7 @@ import time
 import yaml
 import threading
 import re
+import subprocess
 
 from e2e.retry_sleep import retry_sleep
 
@@ -7715,6 +7716,50 @@ def test_020003_2(self):
         delete_test_namespace()
 
 
+def keeper_pod_name(chk, replica):
+    return f"chk-{chk}-keeper-0-{replica}-0"
+
+
+def get_keeper_raft_members(chk, replica):
+    """Committed raft member ids as seen by one keeper pod via /keeper/config."""
+    out = kubectl.launch(
+        f"exec {keeper_pod_name(chk, replica)} -- "
+        f"clickhouse-keeper-client -p 2181 -q \"get '/keeper/config'\"",
+        ok_to_fail=True,
+    )
+    return sorted(
+        int(line.split("=")[0].split(".")[1])
+        for line in out.splitlines()
+        if line.startswith("server.")
+    )
+
+
+def get_keeper_mode(chk, replica):
+    out = kubectl.launch(
+        f"exec {keeper_pod_name(chk, replica)} -- bash -c "
+        f"\"exec 3<>/dev/tcp/127.0.0.1/2181; printf srvr >&3; timeout 3 cat <&3\"",
+        ok_to_fail=True,
+    )
+    for line in out.splitlines():
+        if line.startswith("Mode: "):
+            return line[len("Mode: "):].strip()
+    return "unknown"
+
+
+def check_keeper_membership(chk, expected_ids, note=""):
+    """Every expected member must report exactly the expected committed set,
+    and exactly one of them must be leader/standalone."""
+    with Then(f"keeper committed membership is {expected_ids} {note}"):
+        for i in expected_ids:
+            for attempt in retries(timeout=300, delay=10):
+                with attempt:
+                    members = get_keeper_raft_members(chk, i)
+                    assert members == sorted(expected_ids), \
+                        f"pod {i} reports raft members {members}, expected {sorted(expected_ids)}"
+        leaders = [i for i in expected_ids if get_keeper_mode(chk, i) in ("leader", "standalone")]
+        assert len(leaders) == 1, f"expected exactly one leader, got {leaders}"
+
+
 @TestScenario
 @Tags("HEAVY")
 @Name("test_020005. Clickhouse-keeper scale-up/scale-down")
@@ -7739,6 +7784,8 @@ def test_020005(self):
                 "do_not_delete": 1,
             },
         )
+
+    check_keeper_membership(chk, [0], note="after install")
 
     with Given("CHI with 2 replicas"):
         kubectl.create_and_check(
@@ -7765,6 +7812,8 @@ def test_020005(self):
         kubectl.wait_field('pod', 'chk-test-052-chk-keeper-0-1-0', '.status.containerStatuses[0].ready', 'true', retries=10)
         kubectl.wait_field('pod', 'chk-test-052-chk-keeper-0-2-0', '.status.containerStatuses[0].ready', 'true', retries=10)
 
+    check_keeper_membership(chk, [0, 1, 2], note="after scale-up")
+
     check_replication(chi, {0, 1}, 2)
 
     with Then("Rescale CHK back to 1 replica"):
@@ -7776,7 +7825,44 @@ def test_020005(self):
             },
         )
 
+    check_keeper_membership(chk, [0], note="after scale-down")
+
     check_replication(chi, {0, 1}, 5)
+
+    with Finally("I clean up"):
+        delete_test_namespace()
+
+
+@TestScenario
+@Tags("HEAVY")
+@Name("test_020005_1. Clickhouse-keeper scale-down blocks safely without quorum")
+def test_020005_1(self):
+    """Scale-down must not delete pods while removals cannot be committed."""
+    create_shell_namespace_clickhouse_template()
+
+    chk_manifest_3 = "manifests/chk/test-052-chk-rescale-3.yaml"
+    chk = yaml_manifest.get_name(util.get_full_path(chk_manifest_3))
+
+    with Given("Install 3-replica CHK"):
+        kubectl.create_and_check(
+            manifest=chk_manifest_3, kind="chk",
+            check={"pod_count": 3, "do_not_delete": 1},
+        )
+    check_keeper_membership(chk, [0, 1, 2], note="after install")
+
+    with When("Two of three keepers are down (no quorum for removal commit)"):
+        with When("keepers 1 and 2 are deleted"):
+            kubectl.launch(f"delete pod {keeper_pod_name(chk, 1)} {keeper_pod_name(chk, 2)} --wait=false")
+        with And("Scale-down is requested while quorum is unavailable"):
+            # Apply directly (not create_and_check) -- the operator is expected to
+            # block on the removal barrier and never reach status Completed here.
+            kubectl.launch(f"apply -f {util.get_full_path('manifests/chk/test-052-chk-rescale-1.yaml')}", ok_to_fail=True)
+
+    with Then("Operator does not delete the STS of members whose removal is not committed"):
+        # The scale-down barrier holds while removals cannot commit; STSs stay.
+        time.sleep(60)
+        sts_count = kubectl.get_count("sts", chk=chk)
+        assert sts_count == 3, f"expected 3 STS while removal is not committed, got {sts_count}"
 
     with Finally("I clean up"):
         delete_test_namespace()

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -9,7 +9,6 @@ xfails = {
     # test_operator.py
     "/regression/e2e.test_operator/test_010021*": [(Fail, "Storage test is flaky on github")],
     "/regression/e2e.test_operator/test_010082_1*": [(Fail, "Canary via CHIT injection does not work")],
-    "/regression/e2e.test_operator/test_020005*": [(Fail, "Keeper scale-up/scale-down is flaky")],
 }
 
 


### PR DESCRIPTION
Make CHK scale-up/scale-down Raft-safe by replacing the fixed post-create sleep and the all-at-once XML publish with staged, verified membership changes.

Problem: on rescale the operator published a raft_configuration with every desired server at once and only waited a fixed 7s, never confirming committed Raft membership. Two freshly-started Keeper nodes could form a quorum between themselves while the original node still believed it was the whole cluster — a split-brain window. Scale-down deleted StatefulSets/PVCs with no barrier confirming the member had actually left committed membership.

Approach (hardened staged XML; source-verified against Keeper 23.8..master — versioned `reconfig` CAS does not exist in any version, and the XML-diff mode is the reliable control plane):
- Publish new members one at a time, each behind a committed-membership barrier read from the `/keeper/config` znode plus a leader `mntr` synced-followers barrier. Never more than one not-yet-committed server in the published XML (split-brain guard). Emit `<start_as_follower>` for members joining an established cluster.
- Gate CHK `Completed` on committed membership == desired.
- Scale-down: transfer leadership (`rqld`) off departing members, then gate StatefulSet/PVC purge on confirmed committed removal.
- Lease leader election for the CHK controller manager.
- Fail-safe: any barrier timeout / quorum loss requeues without deleting or mutating anything.

Adds a keeper observe client (`pkg/model/chk/keeper`), the controller barriers (`pkg/controller/chk/worker-raft-membership.go`), and e2e coverage including a deterministic split-brain demonstration (RED on the pre-fix operator, GREEN on this branch, across Keeper 23.8/24.8/25.8). 

It contains 6 commits to make review simpler. Check one commit after another.