### PR TITLE
helm: add keeper-metrics ServiceMonitor

### DIFF
--- a/deploy/helm/clickhouse-operator/README.md
+++ b/deploy/helm/clickhouse-operator/README.md
@@ -133,7 +133,14 @@ crdHook:
 | serviceMonitor.clickhouseMetrics.metricRelabelings | list | `[]` |  |
 | serviceMonitor.clickhouseMetrics.relabelings | list | `[]` |  |
 | serviceMonitor.clickhouseMetrics.scrapeTimeout | string | `""` |  |
-| serviceMonitor.enabled | bool | `false` | ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) In serviceMonitor will be created two endpoints ch-metrics on port 8888 and op-metrics # 9999. Ypu can specify interval, scrapeTimeout, relabelings, metricRelabelings for each endpoint below |
+| serviceMonitor.enabled | bool | `false` | ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) In serviceMonitor will be created two endpoints ch-metrics on port 8888 and op-metrics # 9999 and separate ServiceMonitor for keeper-metrics. You can specify interval, scrapeTimeout, relabelings, metricRelabelings for each endpoint below |
+| serviceMonitor.keeperMetrics.enabled | bool | `true` | create separate ServiceMonitor for scrape native ClickHouse Keeper prometheus endpoint from every keeper service managed by operator (matched by `clickhouse-keeper.altinity.com/app: chop` label). Keeper shall expose prometheus endpoint via `prometheus/*` settings in CHK manifest and named port in serviceTemplate |
+| serviceMonitor.keeperMetrics.interval | string | `"30s"` |  |
+| serviceMonitor.keeperMetrics.metricRelabelings | list | `[]` |  |
+| serviceMonitor.keeperMetrics.namespaceSelector | object | `{"any":true}` | namespaces where prometheus-operator will discover keeper services, `any: true` means all namespaces |
+| serviceMonitor.keeperMetrics.port | string | `"metrics"` | name of the port in keeper Service which expose native keeper prometheus endpoint |
+| serviceMonitor.keeperMetrics.relabelings | list | `[]` |  |
+| serviceMonitor.keeperMetrics.scrapeTimeout | string | `""` |  |
 | serviceMonitor.operatorMetrics.interval | string | `"30s"` |  |
 | serviceMonitor.operatorMetrics.metricRelabelings | list | `[]` |  |
 | serviceMonitor.operatorMetrics.relabelings | list | `[]` |  |

--- a/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/clickhouse-operator/templates/servicemonitor.yaml
@@ -47,4 +47,40 @@ spec:
   selector:
     matchLabels:
       {{- include "altinity-clickhouse-operator.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.keeperMetrics.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ printf "%s-keeper-metrics" (include "altinity-clickhouse-operator.fullname" .) }}
+  namespace: {{ include "altinity-clickhouse-operator.namespace" . }}
+  labels:
+    {{- include "altinity-clickhouse-operator.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+  annotations: {{ include "altinity-clickhouse-operator.annotations" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: {{ .Values.serviceMonitor.keeperMetrics.port }} # native keeper prometheus endpoint, requires prometheus/* settings in CHK and `metrics` port in serviceTemplate
+      {{- with .Values.serviceMonitor.keeperMetrics.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.keeperMetrics.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.keeperMetrics.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.keeperMetrics.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    {{- toYaml .Values.serviceMonitor.keeperMetrics.namespaceSelector | nindent 4 }}
+  selector:
+    matchLabels:
+      clickhouse-keeper.altinity.com/app: chop
+{{- end }}
 {{- end }}

--- a/deploy/helm/clickhouse-operator/values.schema.json
+++ b/deploy/helm/clickhouse-operator/values.schema.json
@@ -979,8 +979,37 @@
                     }
                 },
                 "enabled": {
-                    "description": "ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) In serviceMonitor will be created two endpoints ch-metrics on port 8888 and op-metrics # 9999. Ypu can specify interval, scrapeTimeout, relabelings, metricRelabelings for each endpoint below",
+                    "description": "ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) In serviceMonitor will be created two endpoints ch-metrics on port 8888 and op-metrics # 9999 and separate ServiceMonitor for keeper-metrics. You can specify interval, scrapeTimeout, relabelings, metricRelabelings for each endpoint below",
                     "type": "boolean"
+                },
+                "keeperMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "create separate ServiceMonitor for scrape native ClickHouse Keeper prometheus endpoint from every keeper service managed by operator (matched by `clickhouse-keeper.altinity.com/app: chop` label). Keeper shall expose prometheus endpoint via `prometheus/*` settings in CHK manifest and named port in serviceTemplate",
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "namespaceSelector": {
+                            "description": "namespaces where prometheus-operator will discover keeper services, `any: true` means all namespaces",
+                            "type": "object"
+                        },
+                        "port": {
+                            "description": "name of the port in keeper Service which expose native keeper prometheus endpoint",
+                            "type": "string"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "operatorMetrics": {
                     "type": "object",

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -200,7 +200,7 @@ podSecurityContext: {}
 topologySpreadConstraints: []
 serviceMonitor:
   # serviceMonitor.enabled -- ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator)
-  # In serviceMonitor will be created two endpoints ch-metrics on port 8888 and op-metrics # 9999. Ypu can specify interval, scrapeTimeout, relabelings, metricRelabelings for each endpoint below
+  # In serviceMonitor will be created two endpoints ch-metrics on port 8888 and op-metrics # 9999 and separate ServiceMonitor for keeper-metrics. You can specify interval, scrapeTimeout, relabelings, metricRelabelings for each endpoint below
   enabled: false
   # serviceMonitor.additionalLabels -- additional labels for service monitor
   additionalLabels: {}
@@ -221,6 +221,22 @@ serviceMonitor:
     # serviceMonitor.relabelings for op-metrics endpoint -- Prometheus [RelabelConfigs] to apply to samples before scraping
     relabelings: []
     # serviceMonitor.metricRelabelings  for op-metrics endpoint -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestio
+    metricRelabelings: []
+  keeperMetrics:
+    # serviceMonitor.keeperMetrics.enabled -- create separate ServiceMonitor for scrape native ClickHouse Keeper prometheus endpoint from every keeper service managed by operator (matched by `clickhouse-keeper.altinity.com/app: chop` label). Keeper shall expose prometheus endpoint via `prometheus/*` settings in CHK manifest and named port in serviceTemplate
+    enabled: true
+    # serviceMonitor.keeperMetrics.port -- name of the port in keeper Service which expose native keeper prometheus endpoint
+    port: metrics
+    # serviceMonitor.keeperMetrics.namespaceSelector -- namespaces where prometheus-operator will discover keeper services, `any: true` means all namespaces
+    namespaceSelector:
+      any: true
+    # serviceMonitor.interval for keeper-metrics endpoint --
+    interval: 30s
+    # serviceMonitor.scrapeTimeout for keeper-metrics endpoint -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+    scrapeTimeout: ""
+    # serviceMonitor.relabelings for keeper-metrics endpoint -- Prometheus [RelabelConfigs] to apply to samples before scraping
+    relabelings: []
+    # serviceMonitor.metricRelabelings for keeper-metrics endpoint -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestio
     metricRelabelings: []
 # configs -- clickhouse operator configs
 # @default -- check the `values.yaml` file for the config content (auto-generated from latest operator release)


### PR DESCRIPTION
Fixes #2038

`serviceMonitor.enabled` created a ServiceMonitor with only `ch-metrics` and `op-metrics` endpoints, so native Keeper prometheus metrics were not scraped.

Since the existing ServiceMonitor selector targets the operator's own service, this adds a second ServiceMonitor `<fullname>-keeper-metrics` under the same `serviceMonitor.enabled` flag:

- selector: `clickhouse-keeper.altinity.com/app: chop` (label set by the operator on every keeper service)
- endpoint port name: `metrics` (configurable via `serviceMonitor.keeperMetrics.port`)
- `namespaceSelector: {any: true}` by default (CHK resources usually live outside the operator namespace), configurable
- opt-out via `serviceMonitor.keeperMetrics.enabled=false`, plus the usual `interval`, `scrapeTimeout`, `relabelings`, `metricRelabelings` knobs

Keeper itself must expose the prometheus endpoint via `prometheus/*` settings in the CHK manifest and a named `metrics` port in its serviceTemplate. Clusters without Keeper are unaffected — the selector matches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)