### PR TITLE
chore(helm): Switch to official registry for kubectl image by default

### DIFF
--- a/deploy/helm/clickhouse-operator/README.md
+++ b/deploy/helm/clickhouse-operator/README.md
@@ -83,7 +83,7 @@ crdHook:
 | crdHook.containerSecurityContext | object | `{}` | container security context for CRD installation job check `kubectl explain pod.spec.containers.securityContext` for details |
 | crdHook.enabled | bool | `true` | enable automatic CRD installation/update via pre-install/pre-upgrade hooks when disabled, CRDs must be installed manually using kubectl apply |
 | crdHook.image.pullPolicy | string | `"IfNotPresent"` | image pull policy for CRD installation job |
-| crdHook.image.repository | string | `"bitnami/kubectl"` | image repository for CRD installation job |
+| crdHook.image.repository | string | `"registry.k8s.io/kubectl"` | image repository for CRD installation job |
 | crdHook.image.tag | string | `"latest"` | image tag for CRD installation job |
 | crdHook.imagePullSecrets | list | `[]` | image pull secrets for CRD installation job possible value format `[{"name":"your-secret-name"}]`, check `kubectl explain pod.spec.imagePullSecrets` for details |
 | crdHook.nodeSelector | object | `{}` | node selector for CRD installation job |

--- a/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
+++ b/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
@@ -53,15 +53,16 @@ spec:
         image: "{{ .Values.crdHook.image.repository }}:{{ .Values.crdHook.image.tag }}"
         imagePullPolicy: {{ .Values.crdHook.image.pullPolicy | default "IfNotPresent" }}
         command:
-          - kubectl
-        args:
-          - apply
-          - --server-side=true
-          - --force-conflicts
-          - -f
-          - /crds/1
-          - -f
-          - /crds/2
+        - /bin/sh
+        - -c
+        - |
+        set -e
+        echo "Installing/Updating ClickHouse Operator CRDs..."
+        for crd_file in /crds/*/*.yaml; do
+        echo "Applying $(basename $crd_file)..."
+        kubectl apply --server-side=true --force-conflicts -f "$crd_file"
+        done
+        echo "CRD installation completed successfully"
         volumeMounts:
         - name: crds-1
           mountPath: /crds/1

--- a/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
+++ b/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
@@ -53,16 +53,15 @@ spec:
         image: "{{ .Values.crdHook.image.repository }}:{{ .Values.crdHook.image.tag }}"
         imagePullPolicy: {{ .Values.crdHook.image.pullPolicy | default "IfNotPresent" }}
         command:
-        - /bin/sh
-        - -c
-        - |
-          set -e
-          echo "Installing/Updating ClickHouse Operator CRDs..."
-          for crd_file in /crds/*/*.yaml; do
-            echo "Applying $(basename $crd_file)..."
-            kubectl apply --server-side=true --force-conflicts -f "$crd_file"
-          done
-          echo "CRD installation completed successfully"
+          - kubectl
+        args:
+          - apply
+          - --server-side=true
+          - --force-conflicts
+          - -f
+          - /crds/1
+          - -f
+          - /crds/2
         volumeMounts:
         - name: crds-1
           mountPath: /crds/1

--- a/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
+++ b/deploy/helm/clickhouse-operator/templates/hooks/crd-install-job.yaml
@@ -56,13 +56,13 @@ spec:
         - /bin/sh
         - -c
         - |
-        set -e
-        echo "Installing/Updating ClickHouse Operator CRDs..."
-        for crd_file in /crds/*/*.yaml; do
-        echo "Applying $(basename $crd_file)..."
-        kubectl apply --server-side=true --force-conflicts -f "$crd_file"
-        done
-        echo "CRD installation completed successfully"
+          set -e
+          echo "Installing/Updating ClickHouse Operator CRDs..."
+          for crd_file in /crds/*/*.yaml; do
+            echo "Applying $(basename $crd_file)..."
+            kubectl apply --server-side=true --force-conflicts -f "$crd_file"
+          done
+          echo "CRD installation completed successfully"
         volumeMounts:
         - name: crds-1
           mountPath: /crds/1

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -13,9 +13,9 @@ crdHook:
   enabled: true
   image:
     # crdHook.image.repository -- image repository for CRD installation job
-    repository: bitnami/kubectl
+    repository: registry.k8s.io/kubectl
     # crdHook.image.tag -- image tag for CRD installation job
-    tag: "latest"
+    tag: "v1.36.2"
     # crdHook.image.pullPolicy -- image pull policy for CRD installation job
     pullPolicy: IfNotPresent
   # crdHook.imagePullSecrets -- image pull secrets for CRD installation job
@@ -154,10 +154,10 @@ podLabels: {}
 # podAnnotations -- annotations to add to the clickhouse-operator pod, check `kubectl explain pod.spec.annotations` for details
 # @default -- check the `values.yaml` file
 podAnnotations:
-  prometheus.io/port: '8888'
-  prometheus.io/scrape: 'true'
-  clickhouse-operator-metrics/port: '9999'
-  clickhouse-operator-metrics/scrape: 'true'
+  prometheus.io/port: "8888"
+  prometheus.io/scrape: "true"
+  clickhouse-operator-metrics/port: "9999"
+  clickhouse-operator-metrics/scrape: "true"
 # watchNamespaces -- namespaces where the operator watches for ClickHouseInstallation resources.
 # Sets config.yaml watch.namespaces.include (the exclude list is not exposed here). If empty, the
 # operator watches only its own namespace (or all namespaces when running in kube-system).

--- a/deploy/helm/clickhouse-operator/values.yaml
+++ b/deploy/helm/clickhouse-operator/values.yaml
@@ -15,7 +15,7 @@ crdHook:
     # crdHook.image.repository -- image repository for CRD installation job
     repository: registry.k8s.io/kubectl
     # crdHook.image.tag -- image tag for CRD installation job
-    tag: "v1.36.2"
+    tag: "latest"
     # crdHook.image.pullPolicy -- image pull policy for CRD installation job
     pullPolicy: IfNotPresent
   # crdHook.imagePullSecrets -- image pull secrets for CRD installation job


### PR DESCRIPTION
## Motivation

Bitnami does not maintain their images anymore and they will soon be taken offline: we need to switch the default kubectl image for this Helm chart to a maintained registry that will continue to be available for pulls. 
Source: https://github.com/bitnami/containers/issues/83267

The official k8s registry seems like the best place to get a kubectl image.

There is one added maintenance burden though: the k8s registry does not keep a `latest` or `release` tag, so we'll have to keep this image tag up-to-date with recent patches.

If you are interested, I could help with configuring Renovate for this repository to keep this image tag up to date with patches automatically.

## Important items to consider before making a Pull Request
Please check items PR complies to:
* [x] All commits in the PR are squashed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr) 
* [x] The PR is made into dedicated `next-release` branch, **not into** `master` branch<sup>1</sup>. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#how-to-make-pr)
* [x] The PR is signed. [More info](https://github.com/Altinity/clickhouse-operator/blob/master/CONTRIBUTING.md#sign-your-work)


--

<sup>1</sup> If you feel your PR does not affect any Go-code or any testable functionality (for example, PR contains docs only or supplementary materials), PR can be made into `master` branch, but it has to be confirmed by project's maintainer.
