### PR TITLE
fix: reset stale ClickHouse HTTP pools after connection failures

### DIFF
--- a/pkg/model/clickhouse/connection.go
+++ b/pkg/model/clickhouse/connection.go
@@ -19,10 +19,17 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
 	goch "github.com/mailru/go-clickhouse/v2"
 
 	log "github.com/altinity/clickhouse-operator/pkg/announcer"
@@ -33,6 +40,17 @@ import (
 
 // const clickHouseDriverName = "clickhouse"
 const clickHouseDriverName = "chhttp"
+
+// Keep a finite lifetime as defense in depth for connections that never
+// surface an error. Connection-class failures reset the pools immediately.
+const defaultDBConnectionMaxLifetime = 10 * time.Minute
+
+type dbOpener func(driverName, dataSourceName string) (*sql.DB, error)
+
+type poolInitialization struct {
+	done chan struct{}
+	err  error
+}
 
 // init registers the legacy `tlsSettingsLegacy` DSN key with an insecure
 // TLS config for pre-0.27.1 back-compat. Under FIPS-enforced startup the
@@ -52,6 +70,9 @@ type Connection struct {
 	params      *EndpointConnectionParams
 	dbPrimary   *sql.DB
 	dbSecondary *sql.DB
+	poolMutex   sync.RWMutex
+	poolInit    *poolInitialization
+	openDB      dbOpener
 	l           log.Announcer
 }
 
@@ -60,6 +81,7 @@ func NewConnection(params *EndpointConnectionParams) *Connection {
 	// Do not establish connection immediately, do it in l lazy manner
 	return &Connection{
 		params: params,
+		openDB: sql.Open,
 		l:      log.New(),
 	}
 
@@ -82,23 +104,28 @@ func (c *Connection) SetLog(l log.Announcer) *Connection {
 	return c
 }
 
-// connect performs connect
-func (c *Connection) connect(ctx context.Context) {
+// openPools creates and verifies a new pair of ClickHouse pools without
+// publishing them to the connection. Callers can therefore perform the slow
+// network work without holding poolMutex.
+func (c *Connection) openPools(ctx context.Context) (*sql.DB, *sql.DB, error) {
 	// ClickHouse connection may have custom TLS options specified
 	c.setupTLSAdvanced()
 
 	c.l.V(2).Info("Establishing connection: %s", c.params.GetDSNWithHiddenCredentials())
-	dbPrimaryConn, err := sql.Open(clickHouseDriverName, c.params.GetDSN())
+	dbPrimaryConn, err := c.openDB(clickHouseDriverName, c.params.GetDSN())
 	if err != nil {
 		c.l.V(1).F().Error("FAILED Open(%s). Err: %v", c.params.GetDSNWithHiddenCredentials(), err)
-		return
+		return nil, nil, err
 	}
+	configureDBConnectionPool(dbPrimaryConn, defaultDBConnectionMaxLifetime)
 
-	dbSecondaryConn, err := sql.Open(clickHouseDriverName, c.params.GetDSNLogQueries())
+	dbSecondaryConn, err := c.openDB(clickHouseDriverName, c.params.GetDSNLogQueries())
 	if err != nil {
 		c.l.V(1).F().Error("FAILED Open2(%s). Err: %v", c.params.GetDSNWithHiddenCredentials(), err)
-		return
+		closePools(dbPrimaryConn, nil)
+		return nil, nil, err
 	}
+	configureDBConnectionPool(dbSecondaryConn, defaultDBConnectionMaxLifetime)
 
 	// Ping should have timeout
 	pingCtxPrimary, cancel1 := context.WithTimeout(c.ensureCtx(ctx), c.params.GetConnectTimeout())
@@ -106,9 +133,8 @@ func (c *Connection) connect(ctx context.Context) {
 
 	if err := dbPrimaryConn.PingContext(pingCtxPrimary); err != nil {
 		c.l.V(1).F().Error("FAILED Ping(%s). Err: %v", c.params.GetDSNWithHiddenCredentials(), err)
-		_ = dbPrimaryConn.Close()
-		_ = dbSecondaryConn.Close()
-		return
+		closePools(dbPrimaryConn, dbSecondaryConn)
+		return nil, nil, err
 	}
 
 	pingCtxSecondary, cancel2 := context.WithTimeout(c.ensureCtx(ctx), c.params.GetConnectTimeout())
@@ -116,13 +142,24 @@ func (c *Connection) connect(ctx context.Context) {
 
 	if err := dbSecondaryConn.PingContext(pingCtxSecondary); err != nil {
 		c.l.V(1).F().Error("FAILED Ping2(%s). Err: %v", c.params.GetDSNWithHiddenCredentials(), err)
-		_ = dbPrimaryConn.Close()
-		_ = dbSecondaryConn.Close()
-		return
+		closePools(dbPrimaryConn, dbSecondaryConn)
+		return nil, nil, err
 	}
 
-	c.dbPrimary = dbPrimaryConn
-	c.dbSecondary = dbSecondaryConn
+	return dbPrimaryConn, dbSecondaryConn, nil
+}
+
+func configureDBConnectionPool(db *sql.DB, maxLifetime time.Duration) {
+	db.SetConnMaxLifetime(maxLifetime)
+}
+
+func closePools(primary, secondary *sql.DB) {
+	if primary != nil {
+		_ = primary.Close()
+	}
+	if secondary != nil && secondary != primary {
+		_ = secondary.Close()
+	}
 }
 
 func setupTLSBasic() {
@@ -283,16 +320,158 @@ func parseRootCAs(certString string, l log.Announcer) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-// ensureConnected ensures connection is set
-func (c *Connection) ensureConnected(ctx context.Context) bool {
+// currentDB returns a stable snapshot of the requested pool. Callers never
+// retain the lock while performing SQL or network I/O.
+func (c *Connection) currentDB(logQueries bool) *sql.DB {
+	c.poolMutex.RLock()
+	defer c.poolMutex.RUnlock()
+
+	if logQueries {
+		return c.dbSecondary
+	}
+	return c.dbPrimary
+}
+
+// startPoolInitialization returns the in-flight initialization or starts one.
+// Publishing and generation changes are protected by poolMutex, while opening
+// and pinging the database connections happen asynchronously without the lock.
+func (c *Connection) startPoolInitialization() *poolInitialization {
+	c.poolMutex.Lock()
 	if c.dbPrimary != nil {
-		c.l.V(2).F().Info("Already connected: %s", c.params.GetDSNWithHiddenCredentials())
+		c.poolMutex.Unlock()
+		return nil
+	}
+	if c.poolInit != nil {
+		init := c.poolInit
+		c.poolMutex.Unlock()
+		return init
+	}
+
+	init := &poolInitialization{done: make(chan struct{})}
+	c.poolInit = init
+	c.poolMutex.Unlock()
+
+	go func() {
+		primary, secondary, err := c.openPools(context.Background())
+
+		c.poolMutex.Lock()
+		if err == nil && c.dbPrimary == nil {
+			c.dbPrimary, c.dbSecondary = primary, secondary
+			primary, secondary = nil, nil
+		}
+		init.err = err
+		if c.poolInit == init {
+			c.poolInit = nil
+		}
+		close(init.done)
+		c.poolMutex.Unlock()
+
+		// A concurrent generation may already have won publication. Do not leak
+		// the verified-but-unused pair in that case.
+		closePools(primary, secondary)
+	}()
+
+	return init
+}
+
+// db returns the requested pool, initializing both pools once when necessary.
+// Initialization is shared per host, but each waiter can stop waiting as soon
+// as its own context is canceled. The initializer uses bounded Ping contexts
+// in openPools and may finish publishing a healthy pool for other callers.
+func (c *Connection) db(ctx context.Context, logQueries bool) (*sql.DB, error) {
+	if db := c.currentDB(logQueries); db != nil {
+		return db, nil
+	}
+
+	init := c.startPoolInitialization()
+
+	if init != nil {
+		waitCtx := c.ensureCtx(ctx)
+		select {
+		case <-waitCtx.Done():
+			return nil, waitCtx.Err()
+		case <-init.done:
+			if init.err != nil {
+				return nil, init.err
+			}
+		}
+	}
+
+	db := c.currentDB(logQueries)
+	if db == nil {
+		return nil, errors.New("ClickHouse connection pool is unavailable")
+	}
+	return db, nil
+}
+
+// resetPoolsIfCurrent atomically detaches both pools only when failedDB still
+// belongs to the active generation. A delayed failure from an older operation
+// must not tear down pools that another retry has already created.
+func (c *Connection) resetPoolsIfCurrent(failedDB *sql.DB) bool {
+	c.poolMutex.Lock()
+	if failedDB == nil || (failedDB != c.dbPrimary && failedDB != c.dbSecondary) {
+		c.poolMutex.Unlock()
+		return false
+	}
+
+	primary, secondary := c.dbPrimary, c.dbSecondary
+	c.dbPrimary, c.dbSecondary = nil, nil
+	c.poolMutex.Unlock()
+
+	c.l.V(1).F().Info("Resetting ClickHouse connection pools after connection-class failure: %s", c.params.GetDSNWithHiddenCredentials())
+	closePools(primary, secondary)
+	return true
+}
+
+// isConnectionFailure distinguishes failures for which retaining pooled HTTP
+// transports is unsafe from normal ClickHouse query errors. The original error
+// is always returned; invalidation only affects the next operator retry.
+func isConnectionFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var clickHouseErr *goch.Error
+	if errors.As(err, &clickHouseErr) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) ||
+		errors.Is(err, driver.ErrBadConn) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
 		return true
 	}
 
-	c.connect(ctx)
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"transport failed",
+		"failed to read response",
+		"upstream connect error",
+		"no healthy upstream",
+		"upstream request timeout",
+		"connection reset",
+		"connection refused",
+		"broken pipe",
+		"unexpected eof",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
 
-	return c.dbPrimary != nil
+// shouldResetPools excludes cancellation imposed by the caller. An internal
+// query timeout or a transport failure still invalidates the active generation.
+func shouldResetPools(err error, callerCtx context.Context) bool {
+	callerCanceled := callerCtx != nil && callerCtx.Err() != nil
+	contextFailure := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	if callerCanceled && contextFailure {
+		return false
+	}
+	return isConnectionFailure(err)
 }
 
 // QueryContext runs given sql query on behalf of specified context
@@ -301,10 +480,11 @@ func (c *Connection) QueryContext(ctx context.Context, sql string) (*QueryResult
 		return nil, nil
 	}
 
-	if !c.ensureConnected(ctx) {
+	db, err := c.db(ctx, false)
+	if err != nil {
 		s := fmt.Sprintf("FAILED connect(%s) for SQL: %s", c.params.GetDSNWithHiddenCredentials(), sql)
 		c.l.V(1).F().Error(s)
-		return nil, errors.New(s)
+		return nil, fmt.Errorf("%s: %w", s, err)
 	}
 
 	if util.IsContextDone(ctx) {
@@ -314,9 +494,12 @@ func (c *Connection) QueryContext(ctx context.Context, sql string) (*QueryResult
 	// Query should have timeout
 	queryCtx, cancel := context.WithTimeout(c.ensureCtx(ctx), c.params.GetQueryTimeout())
 
-	rows, err := c.dbPrimary.QueryContext(queryCtx, sql)
+	rows, err := db.QueryContext(queryCtx, sql)
 	if err != nil {
 		cancel()
+		if shouldResetPools(err, ctx) {
+			c.resetPoolsIfCurrent(db)
+		}
 		s := fmt.Sprintf("FAILED Query(%s) %v for SQL: %s", c.params.GetDSNWithHiddenCredentials(), err, sql)
 		c.l.V(1).F().Error(s)
 		return nil, err
@@ -356,22 +539,21 @@ func (c *Connection) Exec(_ctx context.Context, sql string, opts *QueryOptions) 
 	ctx, cancel := c.ctx(_ctx, opts)
 	defer cancel()
 
-	if !c.ensureConnected(ctx) {
+	db, err := c.db(ctx, opts.GetLogQueries())
+	if err != nil {
 		cancel()
 		s := fmt.Sprintf("FAILED connect(%s) for SQL: %s", c.params.GetDSNWithHiddenCredentials(), sql)
 		c.l.V(1).F().Error(s)
-		return errors.New(s)
+		return fmt.Errorf("%s: %w", s, err)
 	}
 
-	db := c.dbPrimary
-	if opts.GetLogQueries() {
-		db = c.dbSecondary
-	}
-
-	_, err := db.ExecContext(ctx, sql)
+	_, err = db.ExecContext(ctx, sql)
 
 	if err != nil {
 		cancel()
+		if shouldResetPools(err, _ctx) {
+			c.resetPoolsIfCurrent(db)
+		}
 		c.l.V(1).F().Error("FAILED Exec(%s) %v for SQL: %s", c.params.GetDSNWithHiddenCredentials(), err, sql)
 		return err
 	}

--- a/pkg/model/clickhouse/connection_pool_test.go
+++ b/pkg/model/clickhouse/connection_pool_test.go
@@ -1,0 +1,347 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clickhouse
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	goch "github.com/mailru/go-clickhouse/v2"
+	"github.com/stretchr/testify/require"
+)
+
+var testDriverID atomic.Uint64
+
+type countingDriver struct {
+	opens  atomic.Int64
+	closes atomic.Int64
+	ping   func(context.Context) error
+}
+
+func (d *countingDriver) Open(string) (driver.Conn, error) {
+	d.opens.Add(1)
+	return &countingConn{driver: d}, nil
+}
+
+type countingConn struct {
+	driver *countingDriver
+}
+
+func (*countingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *countingConn) Close() error {
+	c.driver.closes.Add(1)
+	return nil
+}
+
+func (*countingConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *countingConn) Ping(ctx context.Context) error {
+	if c.driver.ping != nil {
+		return c.driver.ping(ctx)
+	}
+	return nil
+}
+
+func registerCountingDriver(t *testing.T) (string, *countingDriver) {
+	t.Helper()
+
+	name := fmt.Sprintf("clickhouse-connection-test-%d", testDriverID.Add(1))
+	d := &countingDriver{}
+	sql.Register(name, d)
+	return name, d
+}
+
+func TestConfigureDBConnectionPoolRecyclesExpiredConnections(t *testing.T) {
+	driverName, d := registerCountingDriver(t)
+	db, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	configureDBConnectionPool(db, 10*time.Millisecond)
+	require.NoError(t, db.PingContext(context.Background()))
+	require.Equal(t, int64(1), d.opens.Load())
+
+	require.Eventually(t, func() bool {
+		if db.PingContext(context.Background()) != nil {
+			return false
+		}
+		return d.opens.Load() >= 2 && db.Stats().MaxLifetimeClosed >= 1
+	}, time.Second, 10*time.Millisecond)
+	require.GreaterOrEqual(t, d.closes.Load(), int64(1))
+}
+
+func TestDBInitializesSharedConnectionOnce(t *testing.T) {
+	driverName, d := registerCountingDriver(t)
+	params := NewEndpointConnectionParams("http", "clickhouse.test", "user", "password", "", 8123)
+	connection := NewConnection(params)
+
+	var openCalls atomic.Int64
+	connection.openDB = func(string, string) (*sql.DB, error) {
+		openCalls.Add(1)
+		return sql.Open(driverName, "")
+	}
+
+	const goroutines = 20
+	start := make(chan struct{})
+	results := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := connection.db(context.Background(), false)
+			results <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for err := range results {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(2), openCalls.Load(), "only the primary and secondary pools should be opened")
+	require.Equal(t, int64(2), d.opens.Load(), "only the two Ping calls should establish driver connections")
+
+	require.NoError(t, connection.dbPrimary.Close())
+	require.NoError(t, connection.dbSecondary.Close())
+}
+
+func TestDBWaiterCanCancelWithoutDiscardingInitialization(t *testing.T) {
+	driverName, d := registerCountingDriver(t)
+	pingStarted := make(chan struct{})
+	releasePing := make(chan struct{})
+	var signalOnce sync.Once
+	d.ping = func(ctx context.Context) error {
+		signalOnce.Do(func() { close(pingStarted) })
+		select {
+		case <-releasePing:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	connection := NewConnection(NewEndpointConnectionParams("http", "clickhouse.test", "user", "password", "", 8123))
+	var openCalls atomic.Int64
+	connection.openDB = func(string, string) (*sql.DB, error) {
+		openCalls.Add(1)
+		return sql.Open(driverName, "")
+	}
+
+	initialized := make(chan error, 1)
+	go func() {
+		_, err := connection.db(context.Background(), false)
+		initialized <- err
+	}()
+	<-pingStarted
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := connection.db(waitCtx, false)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	close(releasePing)
+	require.NoError(t, <-initialized)
+	require.NotNil(t, connection.currentDB(false))
+	require.NotNil(t, connection.currentDB(true))
+	require.Equal(t, int64(2), openCalls.Load(), "the canceled waiter must share, not duplicate, initialization")
+	require.NoError(t, connection.dbPrimary.Close())
+	require.NoError(t, connection.dbSecondary.Close())
+}
+
+type operationDriver struct {
+	execErr error
+	execs   atomic.Int64
+	closes  atomic.Int64
+}
+
+func (d *operationDriver) Open(string) (driver.Conn, error) {
+	return &operationConn{driver: d}, nil
+}
+
+type operationConn struct {
+	driver *operationDriver
+}
+
+func (*operationConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *operationConn) Close() error {
+	c.driver.closes.Add(1)
+	return nil
+}
+
+func (*operationConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*operationConn) Ping(context.Context) error {
+	return nil
+}
+
+func (c *operationConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	c.driver.execs.Add(1)
+	if c.driver.execErr != nil {
+		return nil, c.driver.execErr
+	}
+	return driver.RowsAffected(0), nil
+}
+
+func newOperationDB(t *testing.T, d *operationDriver) *sql.DB {
+	t.Helper()
+	name := fmt.Sprintf("clickhouse-operation-test-%d", testDriverID.Add(1))
+	sql.Register(name, d)
+	db, err := sql.Open(name, "")
+	require.NoError(t, err)
+	return db
+}
+
+func TestConnectionFailureResetsPoolsForNextRetryWithoutReplaying(t *testing.T) {
+	failedErr := context.DeadlineExceeded
+	oldPrimaryDriver := &operationDriver{execErr: failedErr}
+	oldSecondaryDriver := &operationDriver{}
+	newPrimaryDriver := &operationDriver{}
+	newSecondaryDriver := &operationDriver{}
+	dbs := []*sql.DB{
+		newOperationDB(t, oldPrimaryDriver),
+		newOperationDB(t, oldSecondaryDriver),
+		newOperationDB(t, newPrimaryDriver),
+		newOperationDB(t, newSecondaryDriver),
+	}
+
+	params := NewEndpointConnectionParams("http", "clickhouse.test", "user", "password", "", 8123)
+	connection := NewConnection(params)
+	var openIndex atomic.Int64
+	connection.openDB = func(string, string) (*sql.DB, error) {
+		index := int(openIndex.Add(1) - 1)
+		if index >= len(dbs) {
+			return nil, errors.New("unexpected pool open")
+		}
+		return dbs[index], nil
+	}
+
+	err := connection.Exec(context.Background(), "SELECT 1", NewQueryOptions())
+	require.ErrorIs(t, err, failedErr)
+	require.Equal(t, int64(1), oldPrimaryDriver.execs.Load(), "a failed statement must not be replayed")
+	require.Nil(t, connection.dbPrimary)
+	require.Nil(t, connection.dbSecondary)
+	require.Equal(t, int64(1), oldPrimaryDriver.closes.Load())
+	require.Equal(t, int64(1), oldSecondaryDriver.closes.Load())
+
+	require.NoError(t, connection.Exec(context.Background(), "SELECT 1", NewQueryOptions()))
+	require.Equal(t, int64(4), openIndex.Load(), "the next retry must create a fresh pool pair")
+	require.Equal(t, int64(1), newPrimaryDriver.execs.Load())
+	require.NoError(t, connection.dbPrimary.Close())
+	require.NoError(t, connection.dbSecondary.Close())
+}
+
+func TestClickHouseErrorKeepsCurrentPools(t *testing.T) {
+	clickHouseErr := &goch.Error{Code: 62, Message: "syntax error"}
+	primaryDriver := &operationDriver{execErr: clickHouseErr}
+	secondaryDriver := &operationDriver{}
+	primaryDB := newOperationDB(t, primaryDriver)
+	secondaryDB := newOperationDB(t, secondaryDriver)
+	dbs := []*sql.DB{primaryDB, secondaryDB}
+
+	params := NewEndpointConnectionParams("http", "clickhouse.test", "user", "password", "", 8123)
+	connection := NewConnection(params)
+	var openIndex atomic.Int64
+	connection.openDB = func(string, string) (*sql.DB, error) {
+		return dbs[int(openIndex.Add(1)-1)], nil
+	}
+
+	err := connection.Exec(context.Background(), "broken SQL", NewQueryOptions())
+	require.ErrorIs(t, err, clickHouseErr)
+	require.Same(t, primaryDB, connection.dbPrimary)
+	require.Same(t, secondaryDB, connection.dbSecondary)
+	require.Equal(t, int64(2), openIndex.Load())
+	require.Zero(t, primaryDriver.closes.Load())
+	require.Zero(t, secondaryDriver.closes.Load())
+	require.NoError(t, primaryDB.Close())
+	require.NoError(t, secondaryDB.Close())
+}
+
+func TestCallerCancellationKeepsCurrentPools(t *testing.T) {
+	primaryDriver := &operationDriver{}
+	secondaryDriver := &operationDriver{}
+	primaryDB := newOperationDB(t, primaryDriver)
+	secondaryDB := newOperationDB(t, secondaryDriver)
+	dbs := []*sql.DB{primaryDB, secondaryDB}
+
+	connection := NewConnection(NewEndpointConnectionParams("http", "clickhouse.test", "user", "password", "", 8123))
+	var openIndex atomic.Int64
+	connection.openDB = func(string, string) (*sql.DB, error) {
+		return dbs[int(openIndex.Add(1)-1)], nil
+	}
+	_, err := connection.db(context.Background(), false)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = connection.Exec(ctx, "SELECT 1", NewQueryOptions())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Same(t, primaryDB, connection.currentDB(false))
+	require.Same(t, secondaryDB, connection.currentDB(true))
+	require.Zero(t, primaryDriver.closes.Load())
+	require.Zero(t, secondaryDriver.closes.Load())
+	require.NoError(t, primaryDB.Close())
+	require.NoError(t, secondaryDB.Close())
+}
+
+func TestOldGenerationFailureDoesNotResetReplacementPools(t *testing.T) {
+	oldPrimary := newOperationDB(t, &operationDriver{})
+	newPrimary := newOperationDB(t, &operationDriver{})
+	newSecondary := newOperationDB(t, &operationDriver{})
+	connection := NewConnection(NewEndpointConnectionParams("http", "clickhouse.test", "", "", "", 8123))
+	connection.dbPrimary = newPrimary
+	connection.dbSecondary = newSecondary
+
+	require.False(t, connection.resetPoolsIfCurrent(oldPrimary))
+	require.Same(t, newPrimary, connection.dbPrimary)
+	require.Same(t, newSecondary, connection.dbSecondary)
+	require.NoError(t, oldPrimary.Close())
+	require.NoError(t, newPrimary.Close())
+	require.NoError(t, newSecondary.Close())
+}
+
+func TestConnectionFailureClassification(t *testing.T) {
+	require.True(t, isConnectionFailure(context.DeadlineExceeded))
+	require.True(t, isConnectionFailure(io.ErrUnexpectedEOF))
+	require.True(t, isConnectionFailure(errors.New("clickhouse: upstream connect error or disconnect/reset before headers")))
+	require.False(t, isConnectionFailure(&goch.Error{Code: 60, Message: "table already exists"}))
+	require.False(t, isConnectionFailure(errors.New("application validation failed")))
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, shouldResetPools(context.Canceled, canceledCtx))
+	require.True(t, shouldResetPools(errors.New("upstream connect error"), canceledCtx))
+	require.True(t, shouldResetPools(context.DeadlineExceeded, context.Background()))
+}


### PR DESCRIPTION
# Reset stale ClickHouse HTTP pools after connection-class failures

## Reproduction and verification guide

This is PR-description metadata, not repository documentation. It describes an
A/B test of the same storage reconciliation:

1. run the released operator as a negative control;
2. run the proposed image as the positive test; and
3. require a real connection failure in the positive run so the new pool-reset
   branch is exercised.

The test uses one Keeper and a native `ClickHouseInstallation` with one shard
and two replicas. Adding a second PVC to both hosts makes the operator replace
the ClickHouse pods sequentially, then reconnect to the replacement IPs over
HTTP port 8123 through an injected Istio proxy.

### Prerequisites

- Docker, `kubectl`, Helm, minikube, and `istioctl`
- a normal Git clone of the pull-request checkout
- a default StorageClass that dynamically provisions `ReadWriteOnce` PVCs

The test was verified with minikube v1.38.1, Kubernetes v1.34.0, Istio v1.29.4,
and a three-node Docker profile. Use a dedicated profile because cleanup deletes
the profile.

### 1. Create the local mesh

```bash
minikube start \
  --profile chop-pool-reset \
  --nodes 3 \
  --cpus 2 \
  --memory 2200mb \
  --disk-size 5g
minikube profile chop-pool-reset

istioctl install --set profile=minimal -y

kubectl create namespace pool-reset-repro
kubectl apply -f deploy/helm/clickhouse-operator/crds/
kubectl label namespace pool-reset-repro istio-injection=enabled
```

Install CRDs before enabling injection, so the Helm CRD hook does not receive a
sidecar. Install the stock operator in the injected namespace:

```bash
helm upgrade --install clickhouse-operator \
  ./deploy/helm/clickhouse-operator \
  --namespace pool-reset-repro \
  --set fullnameOverride=clickhouse-operator \
  --set crdHook.enabled=false \
  --set metrics.enabled=false \
  --set operator.image.repository=altinity/clickhouse-operator \
  --set operator.image.tag=0.27.3 \
  --set operator.image.pullPolicy=IfNotPresent

kubectl rollout status deployment/clickhouse-operator \
  --namespace pool-reset-repro --timeout=5m
kubectl get pods --namespace pool-reset-repro
istioctl proxy-status | grep clickhouse-operator
```

The operator must show both the application and `istio-proxy` ready. With
Istio native sidecars, `istio-proxy` appears under
`.status.initContainerStatuses`, not `.status.containerStatuses`.

### 2. Apply the baseline

Save this as `/tmp/pool-reset-baseline.yaml`:

```yaml
apiVersion: clickhouse-keeper.altinity.com/v1
kind: ClickHouseKeeperInstallation
metadata:
  name: pool-reset-keeper
  namespace: pool-reset-repro
spec:
  defaults:
    templates:
      podTemplate: keeper
      volumeClaimTemplate: keeper-data
  configuration:
    clusters:
      - name: keeper
        layout:
          replicasCount: 1
    settings:
      keeper_server/tcp_port: "2181"
  templates:
    podTemplates:
      - name: keeper
        spec:
          containers:
            - name: clickhouse-keeper
              image: clickhouse/clickhouse-keeper:25.8
              imagePullPolicy: IfNotPresent
    volumeClaimTemplates:
      - name: keeper-data
        reclaimPolicy: Delete
        spec:
          accessModes: [ReadWriteOnce]
          resources:
            requests:
              storage: 256Mi
---
apiVersion: clickhouse.altinity.com/v1
kind: ClickHouseInstallation
metadata:
  name: pool-reset-repro
  namespace: pool-reset-repro
spec:
  defaults:
    storageManagement:
      provisioner: StatefulSet
    templates:
      podTemplate: pool-reset-pod
  configuration:
    zookeeper:
      keeper:
        name: pool-reset-keeper
      session_timeout_ms: 30000
      operation_timeout_ms: 10000
    users:
      default/networks/ip: [0.0.0.0/0, "::/0"]
      # Transparent interception can make the source appear as loopback rather
      # than as the generated operator Pod IP.
      clickhouse_operator/networks/ip: [0.0.0.0/0, "::/0"]
    clusters:
      - name: test
        templates:
          podTemplate: pool-reset-pod
        layout:
          shardsCount: 1
          replicasCount: 2
  templates:
    podTemplates:
      - name: pool-reset-pod
        spec:
          affinity:
            podAntiAffinity:
              requiredDuringSchedulingIgnoredDuringExecution:
                - labelSelector:
                    matchLabels:
                      clickhouse.altinity.com/chi: pool-reset-repro
                  topologyKey: kubernetes.io/hostname
          containers:
            - name: clickhouse-pod
              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
              imagePullPolicy: IfNotPresent
              volumeMounts:
                - name: data
                  mountPath: /var/lib/clickhouse
    volumeClaimTemplates:
      - name: data
        reclaimPolicy: Delete
        spec:
          accessModes: [ReadWriteOnce]
          resources:
            requests:
              storage: 1Gi
```

Apply it and wait for a real reconciliation transition. Do not test only for
`Completed` immediately after `kubectl apply`: the previous status may still be
visible briefly and produce a false pass.

```bash
kubectl apply -f /tmp/pool-reset-baseline.yaml

until [ "$(kubectl get chi pool-reset-repro -n pool-reset-repro \
  -o jsonpath='{.status.status}')" = InProgress ]; do sleep 2; done
until [ "$(kubectl get chi pool-reset-repro -n pool-reset-repro \
  -o jsonpath='{.status.status}')" = Completed ]; do
  kubectl get chi pool-reset-repro -n pool-reset-repro
  sleep 10
done

kubectl get pods,pvc -n pool-reset-repro -o wide
```

Keeper and both ClickHouse pods must be ready. Record both original replica IPs:

```bash
for replica in 0 1; do
  kubectl get pod "chi-pool-reset-repro-test-0-${replica}-0" \
    -n pool-reset-repro \
    -o custom-columns=NAME:.metadata.name,IP:.status.podIP,NODE:.spec.nodeName
done
```

Use a unique suffix for each A/B run. This prevents retained Keeper data from a
local provisioner from causing `REPLICA_ALREADY_EXISTS` and contaminating the
second test.

```bash
RUN_ID=negative

kubectl exec -n pool-reset-repro \
  chi-pool-reset-repro-test-0-0-0 -c clickhouse-pod -- \
  clickhouse-client --multiquery --query "
    CREATE DATABASE IF NOT EXISTS pool_reset ON CLUSTER 'test';
    CREATE TABLE pool_reset.replica_probe_${RUN_ID} ON CLUSTER 'test'
    (
      marker String,
      observed_at DateTime64(3) DEFAULT now64(3)
    )
    ENGINE = ReplicatedMergeTree(
      '/clickhouse/tables/{shard}/pool_reset/replica_probe_${RUN_ID}',
      '{replica}'
    )
    ORDER BY observed_at;
    INSERT INTO pool_reset.replica_probe_${RUN_ID} (marker)
    VALUES ('before-volume-update');
  "
```

Verify both replicas before changing storage:

```bash
for replica in 0 1; do
  kubectl exec -n pool-reset-repro \
    "chi-pool-reset-repro-test-0-${replica}-0" -c clickhouse-pod -- \
    clickhouse-client --query "
      SELECT database, table, is_readonly, is_session_expired,
             queue_size, absolute_delay, total_replicas, active_replicas
      FROM system.replicas
      WHERE database = 'pool_reset'
        AND table = 'replica_probe_${RUN_ID}'
    "
done
```

Expected values are `is_readonly=0`, `is_session_expired=0`, `queue_size=0`,
`absolute_delay=0`, `total_replicas=2`, and `active_replicas=2`.

### 3. Define the storage update

Create `/tmp/pool-reset-with-reserved.yaml` by copying the CHI portion of the
baseline and making these additions:

```yaml
spec:
  configuration:
    settings:
      storage_configuration/disks/reserved/path: /var/lib/clickhouse-reserved/
  templates:
    podTemplates:
      - name: pool-reset-pod
        spec:
          containers:
            - name: clickhouse-pod
              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
              imagePullPolicy: IfNotPresent
              command:
                - /bin/bash
                - -c
                - chown clickhouse:clickhouse /var/lib/clickhouse-reserved && /entrypoint.sh
              volumeMounts:
                - name: data
                  mountPath: /var/lib/clickhouse
                - name: reserved
                  mountPath: /var/lib/clickhouse-reserved
    volumeClaimTemplates:
      - name: data
        reclaimPolicy: Delete
        spec:
          accessModes: [ReadWriteOnce]
          resources:
            requests:
              storage: 1Gi
      - name: reserved
        reclaimPolicy: Delete
        spec:
          accessModes: [ReadWriteOnce]
          resources:
            requests:
              storage: 1Gi
```

Keep all other CHI fields identical to the baseline. This is a merge-style
illustration; the file submitted to `kubectl apply` must be the complete CHI.

### 4. Negative control

Start following stock-operator logs in one terminal:

```bash
kubectl logs --follow -n pool-reset-repro deployment/clickhouse-operator \
  -c altinity-clickhouse-operator
```

Apply the complete storage-update manifest in another terminal:

```bash
NEGATIVE_START=$(date -u +%FT%TZ)
kubectl apply -f /tmp/pool-reset-with-reserved.yaml
kubectl get chi,pods,pvc -n pool-reset-repro --watch
```

The control reproduces the issue when:

- a ClickHouse pod is replaced and ready at a new IP;
- its EndpointSlice contains only the new IP;
- the operator-side proxy still shows the old active destination, commonly
  alongside the new destination for an `ORIGINAL_DST` cluster;
- the CHI remains `InProgress`; and
- stock-operator logs repeat connection timeouts across retry intervals.

```bash
kubectl get endpointslice -n pool-reset-repro \
  -l kubernetes.io/service-name=chi-pool-reset-repro-test-0-0 -o wide

istioctl proxy-config endpoints deployment/clickhouse-operator \
  -n pool-reset-repro \
  --cluster 'outbound|8123||chi-pool-reset-repro-test-0-0.pool-reset-repro.svc.cluster.local'

kubectl logs -n pool-reset-repro deployment/clickhouse-operator \
  -c altinity-clickhouse-operator --since-time="${NEGATIVE_START}" |
  grep -E 'context deadline exceeded|upstream connection|retry.go'
```

For `ORIGINAL_DST`, `proxy-config endpoints` reports active destinations rather
than authoritative service membership and may be empty until traffic exists.
EndpointSlice is authoritative. The stale old active destination is diagnostic
evidence of the retained connection, not a requirement that EDS itself be stale.

Save evidence, then restart the stock operator only to end the negative control:

```bash
kubectl logs -n pool-reset-repro deployment/clickhouse-operator \
  -c altinity-clickhouse-operator --since-time="${NEGATIVE_START}" \
  > /tmp/pool-reset-negative.log

istioctl proxy-config endpoints deployment/clickhouse-operator \
  -n pool-reset-repro > /tmp/pool-reset-negative-endpoints.txt

kubectl rollout restart deployment/clickhouse-operator -n pool-reset-repro
kubectl rollout status deployment/clickhouse-operator \
  -n pool-reset-repro --timeout=5m
```

An operator restart is recovery for the control, not a passing result.

### 5. Reset the test installation

```bash
kubectl delete chi pool-reset-repro -n pool-reset-repro
kubectl delete chk pool-reset-keeper -n pool-reset-repro
kubectl wait --for=delete chi/pool-reset-repro \
  -n pool-reset-repro --timeout=5m
kubectl wait --for=delete chk/pool-reset-keeper \
  -n pool-reset-repro --timeout=5m
kubectl get pvc -n pool-reset-repro
```

Wait until the claims disappear. Still use a different `RUN_ID` in the positive
test because some local storage implementations can retain underlying Keeper
data beyond Kubernetes object deletion.

### 6. Build and install the proposed image

```bash
docker build \
  --file dockerfile/operator/Dockerfile \
  --tag clickhouse-operator:pool-reset-fix .

minikube image load --profile chop-pool-reset \
  clickhouse-operator:pool-reset-fix

helm upgrade clickhouse-operator \
  ./deploy/helm/clickhouse-operator \
  --namespace pool-reset-repro \
  --reuse-values \
  --set operator.image.repository=clickhouse-operator \
  --set operator.image.tag=pool-reset-fix \
  --set operator.image.pullPolicy=Never

kubectl rollout status deployment/clickhouse-operator \
  -n pool-reset-repro --timeout=5m
kubectl get deployment/clickhouse-operator -n pool-reset-repro \
  -o jsonpath='{.spec.template.spec.containers[?(@.name=="altinity-clickhouse-operator")].image}{"\n"}'
```

The build command expects a normal clone. A linked Git worktree may need a
temporary full clone because Docker cannot follow a `.git` pointer outside the
build context.

Reapply the baseline, wait for `InProgress` and then `Completed`, recreate the
probe with `RUN_ID=positive`, and repeat the prechecks.

### 7. Positive test

Record old pod IPs and all operator-side restart counts, including the native
sidecar status:

```bash
kubectl get pods -n pool-reset-repro -o wide
kubectl get pod -n pool-reset-repro \
  -l app.kubernetes.io/instance=clickhouse-operator \
  -o jsonpath='{range .items[*].status.initContainerStatuses[*]}{.name}{" restarts="}{.restartCount}{"\n"}{end}{range .items[*].status.containerStatuses[*]}{.name}{" restarts="}{.restartCount}{"\n"}{end}'
```

Apply the complete update and require a transition before accepting completion:

```bash
POSITIVE_START=$(date -u +%FT%TZ)
kubectl apply -f /tmp/pool-reset-with-reserved.yaml

until [ "$(kubectl get chi pool-reset-repro -n pool-reset-repro \
  -o jsonpath='{.status.status}')" = InProgress ]; do sleep 2; done
until [ "$(kubectl get chi pool-reset-repro -n pool-reset-repro \
  -o jsonpath='{.status.status}')" = Completed ]; do
  kubectl get chi,pods,pvc -n pool-reset-repro
  sleep 10
done

kubectl logs -n pool-reset-repro deployment/clickhouse-operator \
  -c altinity-clickhouse-operator --since-time="${POSITIVE_START}" |
  grep -E 'Resetting ClickHouse connection pools|context deadline exceeded|upstream connection|FAILED attempt'
```

The positive test passes only when:

- both ClickHouse replicas receive new IPs and become ready;
- the same connection-class failure is observed;
- it is followed by `Resetting ClickHouse connection pools after connection-class failure`;
- reconciliation advances across both hosts and reaches `Completed`;
- both new PVCs are bound; and
- neither the operator nor its sidecar restarts.

A run that completes without a connection failure is healthy, but it does not
exercise the new branch; repeat the positive transition when explicit branch
coverage is required.

### 8. Post-verification

```bash
for replica in 0 1; do
  kubectl exec -n pool-reset-repro \
    "chi-pool-reset-repro-test-0-${replica}-0" -c clickhouse-pod -- \
    clickhouse-client --multiquery --query "
      SELECT count(), groupArray(marker)
      FROM pool_reset.replica_probe_positive;

      SELECT database, table, is_readonly, is_session_expired,
             queue_size, absolute_delay, total_replicas, active_replicas
      FROM system.replicas
      WHERE database = 'pool_reset'
        AND table = 'replica_probe_positive';

      SELECT name, path
      FROM system.disks
      WHERE name = 'reserved';
    "
done

kubectl get pod -n pool-reset-repro \
  -l app.kubernetes.io/instance=clickhouse-operator \
  -o jsonpath='{range .items[*].status.initContainerStatuses[*]}{.name}{" restarts="}{.restartCount}{"\n"}{end}{range .items[*].status.containerStatuses[*]}{.name}{" restarts="}{.restartCount}{"\n"}{end}'
```

Expected results on both replicas:

- marker count `1` with `before-volume-update`;
- replica state `0,0,0,0,2,2`;
- disk `reserved` at `/var/lib/clickhouse-reserved/`; and
- zero operator and `istio-proxy` restarts.

Generate fresh operator-side traffic before checking active proxy destinations:

```bash
for replica in 0 1; do
  kubectl exec -n pool-reset-repro deployment/clickhouse-operator \
    -c altinity-clickhouse-operator -- \
    curl -sS -m 5 \
    "http://chi-pool-reset-repro-test-0-${replica}.pool-reset-repro.svc.cluster.local:8123/ping"

  istioctl proxy-config endpoints deployment/clickhouse-operator \
    -n pool-reset-repro \
    --cluster "outbound|8123||chi-pool-reset-repro-test-0-${replica}.pool-reset-repro.svc.cluster.local"
done
```

Both pings must return `Ok.` and each active destination must be the current pod
IP rather than the pre-update IP.

### 9. Cleanup

```bash
minikube delete --profile chop-pool-reset
```

## Verified A/B result

The guide was executed on 2026-08-19.

Negative control (`altinity/clickhouse-operator:0.27.3`, Git SHA `6c412fd`):

- replica 0 changed from `10.244.2.4` to `10.244.2.6`;
- EndpointSlice contained only `10.244.2.6`;
- the operator proxy retained active destinations for both `10.244.2.4:8123`
  and `10.244.2.6:8123`;
- the CHI remained `InProgress`, with only one reserved PVC created;
- `QueryContext` and `Exec` timeouts repeated across retry intervals; and
- no pool-reset log was emitted.

Positive test (Git SHA `5ebefb7b6`):

- replica 0 changed `10.244.2.10` to `10.244.2.11`;
- replica 1 changed `10.244.0.3` to `10.244.0.4`;
- the same `context deadline exceeded` failure occurred;
- the operator emitted the pool-reset message, recovered after one outer retry,
  reconciled both replicas, and reached `Completed`;
- both reserved PVCs were bound and both `reserved` disks were visible;
- replicated data remained available with state `0,0,0,0,2,2`;
- operator, native Istio sidecar, and ClickHouse restart counts remained zero;
  and
- after fresh pings, the operator proxy showed only the two current pod IPs.


