### PR TITLE
Cleanup versions in tests

### DIFF
--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node-256M-for-test-only.yaml
@@ -384,7 +384,7 @@ spec:
       containers:
         - name: clickhouse-keeper
           imagePullPolicy: Always
-          image: "clickhouse/clickhouse-keeper:latest-alpine"
+          image: "clickhouse/clickhouse-keeper:25.8"
           resources:
             requests:
               memory: "256M"

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-1-node.yaml
@@ -363,7 +363,7 @@ spec:
       containers:
         - name: clickhouse-keeper
           imagePullPolicy: Always
-          image: "clickhouse/clickhouse-keeper:latest-alpine"
+          image: "clickhouse/clickhouse-keeper:25.8"
           resources:
             requests:
               memory: "256M"

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes-256M-for-test-only.yaml
@@ -384,7 +384,7 @@ spec:
       containers:
         - name: clickhouse-keeper
           imagePullPolicy: Always
-          image: "clickhouse/clickhouse-keeper:latest-alpine"
+          image: "clickhouse/clickhouse-keeper:25.8"
           resources:
             requests:
               memory: "256M"

--- a/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
+++ b/deploy/clickhouse-keeper/clickhouse-keeper-manually/clickhouse-keeper-3-nodes.yaml
@@ -363,7 +363,7 @@ spec:
       containers:
         - name: clickhouse-keeper
           imagePullPolicy: Always
-          image: "clickhouse/clickhouse-keeper:latest-alpine"
+          image: "clickhouse/clickhouse-keeper:25.8"
           resources:
             requests:
               memory: "256M"

--- a/pkg/controller/chi/worker-reconciler-chi_test.go
+++ b/pkg/controller/chi/worker-reconciler-chi_test.go
@@ -58,7 +58,7 @@ func hostWith(cur, desired *apps.StatefulSet) *api.Host {
 // ClickHouse needs to pick up new settings).
 func TestHostRequiresStatefulSetRollout(t *testing.T) {
 	same := sts("altinity/clickhouse-server:25.8")
-	other := sts("altinity/clickhouse-server:25.8.16.10001.altinitystable")
+	other := sts("altinity/clickhouse-server:25.8.28.10001.altinitystable")
 
 	t.Run("nil host", func(t *testing.T) {
 		require.False(t, hostRequiresStatefulSetRollout(nil))

--- a/tests/e2e/manifests/chi/test-005-acm.yaml
+++ b/tests/e2e/manifests/chi/test-005-acm.yaml
@@ -13,7 +13,7 @@ spec:
           fsGroup: 101
         containers:
         - name: clickhouse-pod
-          image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+          image: altinity/clickhouse-server:25.8.28.10001.altinitystable
           ports:
           - name: http
             containerPort: 8123

--- a/tests/e2e/manifests/chi/test-009-operator-upgrade-2.yaml
+++ b/tests/e2e/manifests/chi/test-009-operator-upgrade-2.yaml
@@ -64,7 +64,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               ports:
                 - name: http
                   containerPort: 8123

--- a/tests/e2e/manifests/chi/test-021-1-rescale-volume-01.yaml
+++ b/tests/e2e/manifests/chi/test-021-1-rescale-volume-01.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-1-rescale-volume-02-enlarge-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-1-rescale-volume-02-enlarge-disk.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-1-rescale-volume-03-add-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-1-rescale-volume-03-add-disk.yaml
@@ -38,7 +38,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-1-rescale-volume-04-decrease-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-1-rescale-volume-04-decrease-disk.yaml
@@ -38,7 +38,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-2-rescale-volume-01.yaml
+++ b/tests/e2e/manifests/chi/test-021-2-rescale-volume-01.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-2-rescale-volume-02-enlarge-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-2-rescale-volume-02-enlarge-disk.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-2-rescale-volume-03-add-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-2-rescale-volume-03-add-disk.yaml
@@ -40,7 +40,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-021-2-rescale-volume-04-decrease-disk.yaml
+++ b/tests/e2e/manifests/chi/test-021-2-rescale-volume-04-decrease-disk.yaml
@@ -40,7 +40,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-024-template-annotations-2.yaml
+++ b/tests/e2e/manifests/chi/test-024-template-annotations-2.yaml
@@ -16,7 +16,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+          image: altinity/clickhouse-server:25.8.28.10001.altinitystable
     volumeClaimTemplates:
     - name: default-volumeclaim-template
       reclaimPolicy: Delete

--- a/tests/e2e/manifests/chi/test-024-template-annotations.yaml
+++ b/tests/e2e/manifests/chi/test-024-template-annotations.yaml
@@ -14,7 +14,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+          image: altinity/clickhouse-server:25.8.28.10001.altinitystable
     volumeClaimTemplates:
     - name: default-volumeclaim-template
       reclaimPolicy: Delete

--- a/tests/e2e/manifests/chi/test-026-mixed-replicas.yaml
+++ b/tests/e2e/manifests/chi/test-026-mixed-replicas.yaml
@@ -54,7 +54,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
       - name: multi-volume
         spec:
           securityContext:
@@ -63,7 +63,7 @@ spec:
             fsGroup: 101
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               volumeMounts:
                 - name: disk1
                   mountPath: /var/lib/clickhouse

--- a/tests/e2e/manifests/chi/test-029-distribution.yaml
+++ b/tests/e2e/manifests/chi/test-029-distribution.yaml
@@ -9,7 +9,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+          image: altinity/clickhouse-server:25.8.28.10001.altinitystable
       podDistribution:
       - scope: ClickHouseInstallation
         type: ClickHouseAntiAffinity
@@ -17,7 +17,7 @@ spec:
       spec:
         containers:
         - name: clickhouse-pod
-          image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+          image: altinity/clickhouse-server:25.8.28.10001.altinitystable
       podDistribution:
       - scope: ClickHouseInstallation
         type: ReplicaAntiAffinity

--- a/tests/e2e/manifests/chi/test-030008-permissive-non-fips.yaml
+++ b/tests/e2e/manifests/chi/test-030008-permissive-non-fips.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10002.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
   defaults:
     templates:
       podTemplate: non-fips

--- a/tests/e2e/manifests/chi/test-030008-runtime-decoy.yaml
+++ b/tests/e2e/manifests/chi/test-030008-runtime-decoy.yaml
@@ -16,13 +16,13 @@ spec:
     podTemplates:
       # Tag contains "fips" (admission passes) but image is the stable binary
       # (runtime SELECT version() lacks "fips"). Create the alias before the test:
-      #   docker tag altinity/clickhouse-server:25.8.16.10002.altinitystable \
-      #     altinity/clickhouse-server:25.8.16.10002.altinityfips-decoy
+      #   docker tag altinity/clickhouse-server:25.8.28.10001.altinitystable \
+      #     altinity/clickhouse-server:25.8.28.10001.altinityfips-decoy
       - name: decoy
         spec:
           containers:
             - name: clickhouse
-              image: altinity/clickhouse-server:25.8.16.10002.altinityfips-decoy
+              image: altinity/clickhouse-server:25.8.28.10001.altinityfips-decoy
               # Synthetic local-only alias (exists on no registry). The test loads
               # it into minikube via `minikube image load`; Never stops the kubelet
               # from attempting a registry pull (which would ImagePullBackOff).

--- a/tests/e2e/manifests/chi/test-034-client.yaml
+++ b/tests/e2e/manifests/chi/test-034-client.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   containers:
     - name: clickhouse-client
-      image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+      image: altinity/clickhouse-server:25.8.28.10001.altinitystable
       command: [ "/bin/sh", "-c", "sleep 3600" ]
       volumeMounts:
       - name: client-config

--- a/tests/e2e/manifests/chi/test-035-2-sustained-not-ready.yaml
+++ b/tests/e2e/manifests/chi/test-035-2-sustained-not-ready.yaml
@@ -15,9 +15,9 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
             - name: readiness-flap
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               command:
                 - "/bin/bash"
                 - "-c"

--- a/tests/e2e/manifests/chi/test-035-auto-recovery-1.yaml
+++ b/tests/e2e/manifests/chi/test-035-auto-recovery-1.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               # sleep 90s before starting clickhouse — forces reconcile to time out
               # and abort, but pod becomes Ready shortly after. Operator should
               # auto-recover reconcile once pod is Ready.

--- a/tests/e2e/manifests/chi/test-035-auto-recovery-2.yaml
+++ b/tests/e2e/manifests/chi/test-035-auto-recovery-2.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10002.altinitystable # Increment version number
+              image: clickhouse/clickhouse-server:26.3 # Upgrade from altinity stable 25.8
               # sleep 90s before starting clickhouse — forces reconcile to time out
               # and abort, but pod becomes Ready shortly after. Operator should
               # auto-recover reconcile once pod is Ready.

--- a/tests/e2e/manifests/chi/test-044-0-slow-propagation.yaml
+++ b/tests/e2e/manifests/chi/test-044-0-slow-propagation.yaml
@@ -24,4 +24,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable

--- a/tests/e2e/manifests/chi/test-044-1-slow-propagation.yaml
+++ b/tests/e2e/manifests/chi/test-044-1-slow-propagation.yaml
@@ -26,12 +26,12 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
       - name: slow-replica
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               command:
                 - "/bin/bash"
                 - "-c"

--- a/tests/e2e/manifests/chit/test-023-auto-templates-1.yaml
+++ b/tests/e2e/manifests/chit/test-023-auto-templates-1.yaml
@@ -17,7 +17,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable            
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable            
               env:
                 - name: TEST_ENV_FROM_CHIT_1
                   value: TEST_ENV_FROM_CHIT_1_VALUE

--- a/tests/e2e/manifests/chit/tpl-clickhouse-23.3.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-23.3.yaml
@@ -13,5 +13,5 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: clickhouse/clickhouse-server:23.3
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               imagePullPolicy: IfNotPresent

--- a/tests/e2e/manifests/chit/tpl-clickhouse-23.8.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-23.8.yaml
@@ -13,5 +13,5 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: clickhouse/clickhouse-server:23.8
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               imagePullPolicy: IfNotPresent

--- a/tests/e2e/manifests/chit/tpl-clickhouse-backups-fake.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-backups-fake.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: clickhouse/clickhouse-server:23.8
+              image: clickhouse/clickhouse-server:25.8
 
             - name: clickhouse-backup
               image: nginx:latest

--- a/tests/e2e/manifests/chit/tpl-clickhouse-backups.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-backups.yaml
@@ -25,7 +25,7 @@ spec:
             fsGroup: 101
           containers:
             - name: clickhouse-pod
-              image: clickhouse/clickhouse-server:23.8
+              image: clickhouse/clickhouse-server:25.8
               command:
                 - clickhouse-server
                 - --config-file=/etc/clickhouse-server/config.xml

--- a/tests/e2e/manifests/chit/tpl-clickhouse-stable.yaml
+++ b/tests/e2e/manifests/chit/tpl-clickhouse-stable.yaml
@@ -13,6 +13,6 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: altinity/clickhouse-server:25.8.16.10001.altinitystable
+              image: altinity/clickhouse-server:25.8.28.10001.altinitystable
               imagePullPolicy: IfNotPresent
 

--- a/tests/e2e/manifests/chit/tpl-test-031.yaml
+++ b/tests/e2e/manifests/chit/tpl-test-031.yaml
@@ -16,4 +16,4 @@ spec:
         spec:
           containers:
             - name: clickhouse-pod
-              image: clickhouse/clickhouse-server:23.8
+              image: clickhouse/clickhouse-server:25.8

--- a/tests/e2e/settings.py
+++ b/tests/e2e/settings.py
@@ -60,10 +60,7 @@ clickhouse_template = (
     # "manifests/chit/tpl-clickhouse-23.3.yaml"
     # "manifests/chit/tpl-clickhouse-23.8.yaml"
 )
-clickhouse_template_old = "manifests/chit/tpl-clickhouse-23.3.yaml"
-
 clickhouse_version = get_ch_version(clickhouse_template)
-clickhouse_version_old = get_ch_version(clickhouse_template_old)
 
 keeper_type = os.getenv("KEEPER_TYPE") if "KEEPER_TYPE" in os.environ else "zookeeper" # zookeeper | clickhouse_keeper
 

--- a/tests/e2e/steps.py
+++ b/tests/e2e/steps.py
@@ -162,10 +162,8 @@ def set_settings(self):
     # self.context.clickhouse_template = "manifests/chit/tpl-clickhouse-23.3.yaml"
     # self.context.clickhouse_template = "manifests/chit/tpl-clickhouse-23.8.yaml"
     self.context.clickhouse_template = define("clickhouse_template",  os.getenv("CLICKHOUSE_TEMPLATE") if "CLICKHOUSE_TEMPLATE" in os.environ else "manifests/chit/tpl-clickhouse-stable.yaml")
-    self.context.clickhouse_template_old = define("clickhouse_template_old", "manifests/chit/tpl-clickhouse-23.3.yaml")
 
     self.context.clickhouse_version = define("clickhouse_version", get_ch_version(test_file=self.context.clickhouse_template))
-    self.context.clickhouse_version_old = define("clickhouse_version_old", get_ch_version(test_file=self.context.clickhouse_template_old))
 
     self.context.prometheus_namespace = define("prometheus_namespace", "prometheus")
     self.context.prometheus_operator_version = define("prometheus_operator_version", "0.68")

--- a/tests/e2e/test_common.sh
+++ b/tests/e2e/test_common.sh
@@ -46,7 +46,6 @@ NO_CLEANUP="${NO_CLEANUP:-""}"
 # NOTE: Keep this list in sync with images referenced from:
 #   - tests/e2e/manifests/**/*.yaml                   (test-specific manifests)
 #   - tests/e2e/manifests/chit/tpl-clickhouse-stable.yaml   (default CLICKHOUSE_TEMPLATE)
-#   - tests/e2e/manifests/chit/tpl-clickhouse-23.3.yaml     (clickhouse_template_old)
 #   - tests/e2e/manifests/chk/*.yaml                  (keeper tests, incl. FIPS)
 # Intentionally EXCLUDED from preload (verified — do not re-add):
 #   - Meant-to-fail / decoy images (preloading them would defeat the test that rejects them):
@@ -65,8 +64,6 @@ NO_CLEANUP="${NO_CLEANUP:-""}"
 # parallel and skips images already present — and removes that whole class of flake.
 PRELOAD_IMAGES_ALL=(
     # ClickHouse server versions used in manifests and templates
-    "clickhouse/clickhouse-server:23.3"        # clickhouse_template_old + older-version compat tests
-    "clickhouse/clickhouse-server:23.8"
     "clickhouse/clickhouse-server:24.3"        # also base for 24.3-broken rollback tests; test-017-multi-version (metrics)
     "clickhouse/clickhouse-server:24.8"        # test-017-multi-version (metrics)
     "clickhouse/clickhouse-server:25.3"
@@ -74,13 +71,12 @@ PRELOAD_IMAGES_ALL=(
     "clickhouse/clickhouse-server:26.3"
     "clickhouse/clickhouse-server:latest"
     # Altinity builds (default stable template + FIPS)
-    "altinity/clickhouse-server:25.8.16.10001.altinitystable"  # default clickhouse_template
-    "altinity/clickhouse-server:25.8.16.10002.altinitystable"  # test_010035 auto-recovery upgrade target (manifests/chi/test-035-auto-recovery-2.yaml)
+    "altinity/clickhouse-server:25.8.28.10001.altinitystable"  # default clickhouse_template
     "altinity/clickhouse-server:25.3.8.30001.altinityfips"     # FIPS CHI (e.g. manifests/chk/test-020008-chi-fips.yaml)
     # ClickHouse Keeper versions
     "clickhouse/clickhouse-keeper:25.3"
     "clickhouse/clickhouse-keeper:25.8"
-    "clickhouse/clickhouse-keeper:latest-alpine"  # test_clickhouse_keeper_rescale (deploy/clickhouse-keeper/clickhouse-keeper-manually/...-for-test-only.yaml)
+    "clickhouse/clickhouse-keeper:26.3"
     "altinity/clickhouse-keeper:25.3.8.30001.altinityfips"
     # Zookeeper
     "docker.io/zookeeper:3.8.4"

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -9564,8 +9564,8 @@ def test_030008(self):
         cleanup_admission_only_chi(chi=chi_case_insensitive)
 
     with When("runtime decoy image alias is prepared"):
-        decoy_tag = "altinity/clickhouse-server:25.8.16.10002.altinityfips-decoy"
-        stable_tag = "altinity/clickhouse-server:25.8.16.10002.altinitystable"
+        decoy_tag = "altinity/clickhouse-server:25.8.28.10001.altinityfips-decoy"
+        stable_tag = "altinity/clickhouse-server:25.8.28.10001.altinitystable"
         tag_result = subprocess.run(
             ["docker", "tag", stable_tag, decoy_tag],
             capture_output=True,


### PR DESCRIPTION
Bump altinity stable ClickHouse images to 25.8.28, drop legacy 23.x
