### PR TITLE
Fix CHI ZK root-path ensure logic

### DIFF
--- a/pkg/controller/chi/worker-reconciler-chi.go
+++ b/pkg/controller/chi/worker-reconciler-chi.go
@@ -842,7 +842,7 @@ func (w *worker) reconcileCluster(ctx context.Context, cluster *api.Cluster) err
 	if err := w.reconcileClusterPodDisruptionBudget(ctx, cluster); err != nil {
 		return err
 	}
-	if err := w.reconcileClusterZookeeperRootPath(cluster); err != nil {
+	if err := w.reconcileClusterZookeeperRootPath(ctx, cluster); err != nil {
 		return err
 	}
 

--- a/pkg/controller/chi/worker-zk-integration.go
+++ b/pkg/controller/chi/worker-zk-integration.go
@@ -15,13 +15,15 @@
 package chi
 
 import (
+	"context"
+
 	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
 	"github.com/altinity/clickhouse-operator/pkg/chop"
 	a "github.com/altinity/clickhouse-operator/pkg/controller/common/announcer"
 	"github.com/altinity/clickhouse-operator/pkg/model/zookeeper"
 )
 
-func (w *worker) reconcileClusterZookeeperRootPath(cluster *api.Cluster) error {
+func (w *worker) reconcileClusterZookeeperRootPath(ctx context.Context, cluster *api.Cluster) error {
 	// Cluster ZK path reconciliation is optional
 	if !shouldReconcileClusterZookeeperPath(cluster) {
 		// Nothing to reconcile
@@ -48,7 +50,9 @@ func (w *worker) reconcileClusterZookeeperRootPath(cluster *api.Cluster) error {
 		M(cluster.GetCR()).F().
 		Info("Confirm ZK is configured for cluster %s/%s/%s", cluster.GetCR().GetNamespace(), cluster.GetCR().GetName(), cluster.GetName())
 
-	ensureZkPath(cluster)
+	if err := ensureZkPath(ctx, cluster); err != nil {
+		return err
+	}
 
 	w.a.V(1).
 		WithEvent(cluster.GetCR(), a.EventActionCreate, a.EventReasonCreateCompleted).
@@ -77,7 +81,7 @@ func clusterZookeeperRequiresTLSDial(cluster *api.Cluster) bool {
 	return false
 }
 
-func ensureZkPath(cluster *api.Cluster) {
+func ensureZkPath(ctx context.Context, cluster *api.Cluster) error {
 	// Plumb cluster-level security.zookeeper.tls.{minVersion,verify} into the
 	// ZK dial. Defaults preserve current behavior (Go default TLS version,
 	// strict verify since RootCAs+ServerName are always set). CHOP-config
@@ -100,8 +104,9 @@ func ensureZkPath(cluster *api.Cluster) {
 	}
 	conn := zookeeper.NewConnection(cluster.Zookeeper.Nodes, params)
 	path := zookeeper.NewPathManager(conn)
-	path.Ensure(cluster.Zookeeper.Root)
-	path.Close()
+	err := path.Ensure(ctx, cluster.Zookeeper.Root)
+	_ = path.Close()
+	return err
 }
 
 func shouldReconcileClusterZookeeperPath(cluster *api.Cluster) bool {
@@ -111,6 +116,23 @@ func shouldReconcileClusterZookeeperPath(cluster *api.Cluster) bool {
 	}
 	if cluster.Zookeeper.IsEmpty() {
 		// Nothing to reconcile
+		return false
+	}
+
+	// Same generation as the last completed ancestor with no pending action-plan
+	// work means this pass is recovery-only (#1704 unhealthy / stuck hosts, or
+	// similar). The ZK root was already ensured when the generation last changed;
+	// re-dialing a down ensemble only floods dial timeouts. Spec changes bump
+	// generation (or leave action-plan work) and still ensure.
+	cr := cluster.GetCR()
+	if cr == nil {
+		return true
+	}
+	ancestor := cr.GetAncestorT()
+	ap := cr.EnsureRuntime().ActionPlan
+	if ancestor != nil &&
+		ancestor.GetGeneration() == cr.GetGeneration() &&
+		(ap == nil || !ap.HasActionsToDo()) {
 		return false
 	}
 

--- a/pkg/controller/chi/worker-zk-integration_test.go
+++ b/pkg/controller/chi/worker-zk-integration_test.go
@@ -1,0 +1,88 @@
+// Copyright 2019 Altinity Ltd and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chi
+
+import (
+	"testing"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
+	"github.com/altinity/clickhouse-operator/pkg/apis/common/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldReconcileClusterZookeeperPath(t *testing.T) {
+	zkNodes := api.ZookeeperNodes{{Host: "zk", Port: types.NewInt32(2181)}}
+
+	newCluster := func(cr *api.ClickHouseInstallation) *api.Cluster {
+		cluster := &api.Cluster{
+			Zookeeper: &api.ZookeeperConfig{Nodes: zkNodes},
+		}
+		cluster.Runtime.SetCR(cr)
+		return cluster
+	}
+
+	t.Run("stopped CR skips", func(t *testing.T) {
+		cr := &api.ClickHouseInstallation{
+			ObjectMeta: meta.ObjectMeta{Generation: 5},
+			Spec:       api.ChiSpec{Stop: types.NewStringBool(true)},
+		}
+		require.False(t, shouldReconcileClusterZookeeperPath(newCluster(cr)))
+	})
+
+	t.Run("empty zookeeper skips", func(t *testing.T) {
+		cr := &api.ClickHouseInstallation{ObjectMeta: meta.ObjectMeta{Generation: 5}}
+		cluster := &api.Cluster{}
+		cluster.Runtime.SetCR(cr)
+		require.False(t, shouldReconcileClusterZookeeperPath(cluster))
+	})
+
+	t.Run("same generation as ancestor without action-plan work skips", func(t *testing.T) {
+		ancestor := &api.ClickHouseInstallation{ObjectMeta: meta.ObjectMeta{Generation: 5}}
+		cr := &api.ClickHouseInstallation{ObjectMeta: meta.ObjectMeta{Generation: 5}}
+		cr.SetAncestor(ancestor)
+		cr.EnsureRuntime().ActionPlan = api.MakeActionPlan(ancestor, cr)
+		require.False(t, shouldReconcileClusterZookeeperPath(newCluster(cr)))
+	})
+
+	t.Run("generation advanced still reconciles", func(t *testing.T) {
+		ancestor := &api.ClickHouseInstallation{ObjectMeta: meta.ObjectMeta{Generation: 4}}
+		cr := &api.ClickHouseInstallation{ObjectMeta: meta.ObjectMeta{Generation: 5}}
+		cr.SetAncestor(ancestor)
+		cr.EnsureRuntime().ActionPlan = api.MakeActionPlan(ancestor, cr)
+		require.True(t, shouldReconcileClusterZookeeperPath(newCluster(cr)))
+	})
+
+	t.Run("same generation with action-plan work still reconciles", func(t *testing.T) {
+		ancestor := &api.ClickHouseInstallation{
+			ObjectMeta: meta.ObjectMeta{Generation: 5},
+			Spec:       api.ChiSpec{Troubleshoot: types.NewStringBool(false)},
+		}
+		cr := &api.ClickHouseInstallation{
+			ObjectMeta: meta.ObjectMeta{Generation: 5},
+			Spec:       api.ChiSpec{Troubleshoot: types.NewStringBool(true)},
+		}
+		cr.SetAncestor(ancestor)
+		cr.EnsureRuntime().ActionPlan = api.MakeActionPlan(ancestor, cr)
+		require.True(t, cr.EnsureRuntime().ActionPlan.HasActionsToDo())
+		require.True(t, shouldReconcileClusterZookeeperPath(newCluster(cr)))
+	})
+
+	t.Run("no ancestor still reconciles", func(t *testing.T) {
+		cr := &api.ClickHouseInstallation{ObjectMeta: meta.ObjectMeta{Generation: 1}}
+		require.True(t, shouldReconcileClusterZookeeperPath(newCluster(cr)))
+	})
+}

--- a/pkg/model/zookeeper/connection.go
+++ b/pkg/model/zookeeper/connection.go
@@ -46,8 +46,8 @@ type Connection struct {
 	mu         sync.Mutex
 	connection ZKClient
 
-	// retryDelayFn is configurable for testing
-	retryDelayFn func(i int)
+	// retryDelayFn is configurable for testing; must honor ctx cancellation.
+	retryDelayFn func(ctx context.Context, i int) error
 }
 
 // NewConnection creates a new Zookeeper connection with the provided nodes and parameters.
@@ -62,15 +62,14 @@ func NewConnection(nodes api.ZookeeperNodes, _params ...*ConnectionParams) *Conn
 	}
 }
 
-func retryDelayFnLinear() func(int) {
-	return func(i int) {
-		// Progressive delay
-		time.Sleep(time.Duration(i)*time.Second + time.Duration(rand.Int63n(int64(1*time.Second))))
+func retryDelayFnLinear() func(context.Context, int) error {
+	return func(ctx context.Context, i int) error {
+		return sleepContext(ctx, time.Duration(i)*time.Second+time.Duration(rand.Int63n(int64(1*time.Second))))
 	}
 }
 
-func retryDelayFnFlooredCappedLn(floor int, cap int) func(int) {
-	return func(i int) {
+func retryDelayFnFlooredCappedLn(floor int, cap int) func(context.Context, int) error {
+	return func(ctx context.Context, i int) error {
 		// Progressive delay
 		base := int(math.Ceil(math.Log(float64(i + 1))))
 		if base < floor {
@@ -88,7 +87,18 @@ func retryDelayFnFlooredCappedLn(floor int, cap int) func(int) {
 		if jitter > jitterCap {
 			jitter = jitterCap
 		}
-		time.Sleep(time.Duration(base+jitter) * time.Second)
+		return sleepContext(ctx, time.Duration(base+jitter)*time.Second)
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
 	}
 }
 
@@ -162,13 +172,25 @@ func (c *Connection) retry(ctx context.Context, fn func(connection ZKClient) err
 
 	var errs []error
 	for i := 0; i < c.MaxRetriesNum; i++ {
+		if err := ctx.Err(); err != nil {
+			if len(errs) == 0 {
+				return err
+			}
+			return fmt.Errorf("retries cancelled after %d attempt(s): %w", len(errs), errors.Join(append(errs, err)...))
+		}
 		if i > 0 {
-			// Delay before each consequent retry
-			c.retryDelayFn(i)
+			// Delay before each consequent retry (interruptible via ctx)
+			if err := c.retryDelayFn(ctx, i); err != nil {
+				if len(errs) == 0 {
+					return err
+				}
+				return fmt.Errorf("retries cancelled after %d attempt(s): %w", len(errs), errors.Join(append(errs, err)...))
+			}
 		}
 
 		connection, err := c.ensureConnection(ctx)
 		if err != nil {
+			log.Warning("zk connect attempt %d/%d failed: %v", i+1, c.MaxRetriesNum, err)
 			errs = append(errs, fmt.Errorf("retry %d: connection error: %w", i+1, err))
 			continue // Retry
 		}
@@ -186,11 +208,13 @@ func (c *Connection) retry(ctx context.Context, fn func(connection ZKClient) err
 				c.connection = nil
 			}
 			c.mu.Unlock()
+			log.Warning("zk operation attempt %d/%d failed: connection closed: %v", i+1, c.MaxRetriesNum, err)
 			errs = append(errs, fmt.Errorf("retry %d: connection closed: %w", i+1, err))
 			continue // Retry
 		}
 
 		// Collect the errors
+		log.Warning("zk operation attempt %d/%d failed: %v", i+1, c.MaxRetriesNum, err)
 		errs = append(errs, fmt.Errorf("retry %d: %w", i+1, err))
 	}
 
@@ -292,7 +316,7 @@ func (c *Connection) dial(ctx context.Context) (ZKClient, <-chan zk.Event, error
 	ctx, cancel := context.WithTimeout(ctx, c.TimeoutConnect)
 	defer cancel()
 
-	connection, events, err := c.connect(c.nodes.Servers())
+	connection, events, err := c.connect(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -314,13 +338,23 @@ func (c *Connection) dial(ctx context.Context) (ZKClient, <-chan zk.Event, error
 	}
 }
 
-func (c *Connection) connect(servers []string) (ZKClient, <-chan zk.Event, error) {
+func (c *Connection) connect(ctx context.Context) (ZKClient, <-chan zk.Event, error) {
+	servers := c.nodes.Servers()
+	// Resolve under ctx so a stuck/missing DNS name cannot ignore cancel the way
+	// zk.DNSHostProvider.Init (blocking net.LookupHost) does. Each dial attempt is
+	// still bounded by TimeoutConnect; outer retry keeps waiting for ZK to appear.
+	resolvedServers, err := resolveServers(ctx, servers)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	optionsDialer := zk.WithDialer(net.DialTimeout)
 	if c.CertFile != "" && c.KeyFile != "" {
 		if len(servers) > 1 {
 			log.Fatal("This TLS zk code requires that the all the zk servers validate to a single server name.")
 		}
 
+		// TLS ServerName must stay the configured hostname, not a resolved IP.
 		serverName := strings.Split(servers[0], ":")[0]
 
 		log.Info("Using TLS for %s", serverName)
@@ -353,8 +387,47 @@ func (c *Connection) connect(servers []string) (ZKClient, <-chan zk.Event, error
 		})
 	}
 
-	// May need to implement manually &zk.SimpleDNSHostProvider{} from github.com/z-division/go-zookeeper/zk
-	hostProvider := &zk.DNSHostProvider{}
-	optionsDNSHostProvider := zk.WithHostProvider(hostProvider)
-	return zk.Connect(servers, c.TimeoutKeepAlive, optionsDialer, optionsDNSHostProvider)
+	// Pass resolved IP:port strings; zk's default DNSHostProvider.Init only does a
+	// cheap literal lookup on those, so the ctx-aware resolve above remains the
+	// bound that matters for missing/stuck DNS.
+	return zk.Connect(resolvedServers, c.TimeoutKeepAlive, optionsDialer)
+}
+
+// lookupHostFn is overridable in tests.
+var lookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// resolveServers resolves hostnames in host:port server strings using ctx so DNS
+// respects cancel and TimeoutConnect. Returns host:port list with literal addresses
+// for zk.Connect (whose default DNSHostProvider.Init is a cheap no-op on IP literals).
+func resolveServers(ctx context.Context, servers []string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("zk: server list must not be empty")
+	}
+
+	found := make([]string, 0, len(servers))
+	for _, server := range servers {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		host, port, err := net.SplitHostPort(server)
+		if err != nil {
+			return nil, fmt.Errorf("zk: invalid server %q: %w", server, err)
+		}
+		addrs, err := lookupHostFn(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("zk dns lookup %q: %w", host, err)
+		}
+		for _, addr := range addrs {
+			found = append(found, net.JoinHostPort(addr, port))
+		}
+	}
+	if len(found) == 0 {
+		return nil, fmt.Errorf("zk: no hosts found for addresses %q", servers)
+	}
+	return found, nil
 }

--- a/pkg/model/zookeeper/connection_test.go
+++ b/pkg/model/zookeeper/connection_test.go
@@ -3,11 +3,13 @@ package zookeeper
 import (
 	"context"
 	"testing"
+	"time"
 
 	api "github.com/altinity/clickhouse-operator/pkg/apis/clickhouse.altinity.com/v1"
 	"github.com/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConnection_Get(t *testing.T) {
@@ -704,7 +706,7 @@ func TestConnection_Close(t *testing.T) {
 func newTestConnection(nodes api.ZookeeperNodes, client ZKClient, _params ...*ConnectionParams) *Connection {
 	conn := NewConnection(nodes, _params...)
 	conn.connection = client
-	conn.retryDelayFn = func(i int) {} // Disable retry delay for tests
+	conn.retryDelayFn = func(ctx context.Context, i int) error { return nil } // Disable retry delay for tests
 	return conn
 }
 
@@ -731,6 +733,88 @@ func TestShouldRejectAuthScheme(t *testing.T) {
 			assert.Equal(t, tt.want, shouldRejectAuthScheme(tt.rejectDigest, tt.scheme))
 		})
 	}
+}
+
+func TestConnection_retryRespectsContextCancel(t *testing.T) {
+	mockClient := new(MockZKClient)
+	mockClient.On("Get", "/cancel").Return([]byte(nil), (*zk.Stat)(nil), zk.ErrConnectionClosed).Once()
+
+	conn := newTestConnection(api.ZookeeperNodes{}, mockClient, &ConnectionParams{MaxRetriesNum: 30})
+	ctx, cancel := context.WithCancel(context.Background())
+	conn.retryDelayFn = func(ctx context.Context, i int) error {
+		cancel()
+		return ctx.Err()
+	}
+
+	_, _, err := conn.Get(ctx, "/cancel")
+	assert.ErrorIs(t, err, context.Canceled)
+	mockClient.AssertExpectations(t)
+}
+
+func TestResolveServersRespectsContextCancel(t *testing.T) {
+	orig := lookupHostFn
+	defer func() { lookupHostFn = orig }()
+
+	started := make(chan struct{})
+	lookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := resolveServers(ctx, []string{"zookeeper:2181"})
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Contains(t, err.Error(), "zk dns lookup")
+	case <-time.After(2 * time.Second):
+		t.Fatal("resolveServers did not return after cancel")
+	}
+}
+
+func TestResolveServersRespectsDeadline(t *testing.T) {
+	orig := lookupHostFn
+	defer func() { lookupHostFn = orig }()
+
+	lookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := resolveServers(ctx, []string{"zookeeper:2181"})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 2*time.Second, "DNS must not hang past the dial deadline")
+}
+
+func TestResolveServersSuccess(t *testing.T) {
+	orig := lookupHostFn
+	defer func() { lookupHostFn = orig }()
+
+	lookupHostFn = func(ctx context.Context, host string) ([]string, error) {
+		assert.Equal(t, "zookeeper", host)
+		return []string{"10.0.0.1", "10.0.0.2"}, nil
+	}
+
+	got, err := resolveServers(context.Background(), []string{"zookeeper:2181"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.1:2181", "10.0.0.2:2181"}, got)
 }
 
 // MockZKClient is a mock implementation of the ZKClient interface for testing

--- a/pkg/model/zookeeper/path_manager.go
+++ b/pkg/model/zookeeper/path_manager.go
@@ -33,18 +33,17 @@ func NewPathManager(connection *Connection) *PathManager {
 	}
 }
 
-func (p *PathManager) Ensure(path string) {
+func (p *PathManager) Ensure(ctx context.Context, path string) error {
 	// Sanity check
 	path = strings.TrimSpace(path)
 	if len(path) == 0 {
-		return
+		return nil
 	}
 	if path == "/" {
-		return
+		return nil
 	}
 
 	// Params if the zk node to be created on each folder
-	ctx := context.TODO()
 	value := []byte{}
 	flags := int32(0)
 	acl := []zk.ACL{
@@ -60,10 +59,17 @@ func (p *PathManager) Ensure(path string) {
 	pathParts := strings.Split(strings.Trim(path, "/"), "/")
 	subPath := ""
 	for _, folder := range pathParts {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		subPath += "/" + folder
 		if ok, err := p.Connection.Exists(ctx, subPath); !ok {
 			if err != nil {
-				log.Warning("received error while checking zk path: %s err: %v", subPath, err)
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				// Per-attempt failures are already logged in Connection.retry.
+				log.Warning("zk path ensure Exists failed for %s after retries", subPath)
 			}
 		} else {
 			log.Info("zk path already exists: %s", subPath)
@@ -76,7 +82,12 @@ func (p *PathManager) Ensure(path string) {
 		if err == nil {
 			log.Info("zk path created: %s", created)
 		} else {
-			log.Warning("zk path FAILED to create: %s err: %v", subPath, err)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			// Per-attempt failures are already logged in Connection.retry.
+			log.Warning("zk path ensure Create failed for %s after retries", subPath)
 		}
 	}
+	return nil
 }

--- a/tests/e2e/manifests/chi/test-010-zk-init-wrong-host.yaml
+++ b/tests/e2e/manifests/chi/test-010-zk-init-wrong-host.yaml
@@ -1,0 +1,23 @@
+apiVersion: "clickhouse.altinity.com/v1"
+kind: "ClickHouseInstallation"
+
+metadata:
+  name: test-010-zk-init
+
+spec:
+  useTemplates:
+    - name: clickhouse-version
+  configuration:
+    zookeeper: # Add Zookeeper
+      nodes:
+        - host: zookeeper-wrong
+          port: 2181
+          availabilityZone: "my-azone"
+      root: "/clickhouse/test-010-zkroot"
+      session_timeout_ms: 30000
+      operation_timeout_ms: 10000
+    clusters:
+      - name: default
+        layout:
+          shardsCount: 1
+          replicasCount: 1

--- a/tests/e2e/manifests/chi/test-010-zk-service.yaml
+++ b/tests/e2e/manifests/chi/test-010-zk-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  labels:
+    app: zookeeper
+spec:
+  ports:
+    - port: 2181
+      name: client
+    - port: 7000
+      name: prometheus
+  selector:
+    app: clickhouse-keeper
+    what: node

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -716,29 +716,65 @@ def test_010010_1(self):
     create_shell_namespace_clickhouse_template()
     chi = "test-010-zk-init"
 
-    kubectl.create_and_check(
-        manifest="manifests/chi/test-010-zk-init.yaml",
-        check={
-            "apply_templates": {
-                current().context.clickhouse_template,
+    with When("Start ClickHouse with wrong ZooKeeper host"):
+        kubectl.create_and_check(
+            manifest="manifests/chi/test-010-zk-init-wrong-host.yaml",
+            check={
+                "apply_templates": {
+                    current().context.clickhouse_template,
+                    },
+                "do_not_delete": 1,
+                "chi_status": "InProgress"
+                },
+            )
+
+        with Then("Operator should start complaining about connection"):
+            wait_operator_logs(["zk path to be verified"])
+            wait_operator_logs(["no such host"])
+
+        with And("CHI should stay in progress with no pods created (waiting for ZooKeeper)"):
+            assert kubectl.get_chi_status(chi) == "InProgress"
+            assert kubectl.get_count("pod", chi = chi) == 0
+
+    with When("Fix ZooKeeper host but do not start it yet"):
+        lastTaskID = kubectl.get_field("chi", chi, ".status.taskID")
+        kubectl.create_and_check(
+            manifest="manifests/chi/test-010-zk-init.yaml",
+            check={
+                "do_not_delete": 1,
+                "chi_status": "InProgress"
             },
-            "do_not_delete": 1,
-            "chi_status": "InProgress"
-        },
-    )
+        )
+        started = int(time.time()) - 5
+        with Then("Create zookeeper service so it would start resolving"):
+            kubectl.apply(util.get_full_path("manifests/chi/test-010-zk-service.yaml"))
 
-    with Then("CHI should stay in progress with no pods created (waiting for ZooKeeper)"):
-        time.sleep(15)
-        assert kubectl.get_chi_status(chi) == "InProgress"
-        assert kubectl.get_count("pod", chi = chi) == 0
+        with Then("And TaskID should be different to confirm reconcile has restarted"):
+            for i in range(0,10):
+                taskID = kubectl.get_field("chi", chi, ".status.taskID")
+                if taskID != lastTaskID:
+                    break
+                retry_sleep(1, 5, "taskID not updated yet")
+            assert taskID != lastTaskID, error("taskID was not updated")
 
-    util.require_keeper(keeper_type=self.context.keeper_type)
+        with And("Operator should start complaining about connection refused"):
+            wait_operator_logs(["zk path to be verified"], time.time() - started)
+            wait_operator_logs(["connect: connection refused"], time.time() - started)
 
-    kubectl.wait_chi_status(chi, "Completed")
+        with And("CHI should stay in progress with no pods created (waiting for ZooKeeper)"):
+            assert kubectl.get_chi_status(chi) == "InProgress"
+            assert kubectl.get_count("pod", chi = chi) == 0
 
-    with And("ClickHouse should not complain regarding zookeeper path"):
-        out = clickhouse.query_with_error(chi, "select path from system.zookeeper where path = '/' limit 1")
-        assert "/" == out
+    with When("Start ZooKeeper normally"):
+        kubectl.delete_kind("service", "zookeeper")
+        util.require_keeper(keeper_type=self.context.keeper_type)
+
+        with Then("ClickHouse should start healthy"):
+            kubectl.wait_chi_status(chi, "Completed")
+
+        with And("ClickHouse should not complain regarding zookeeper path"):
+            out = clickhouse.query_with_error(chi, "select path from system.zookeeper where path = '/' limit 1")
+            assert "/" == out
 
     with Finally("I clean up"):
         delete_test_namespace()
@@ -6229,19 +6265,32 @@ def test_010061(self):
         delete_test_namespace()
 
 
-def check_operator_logs(markers, since = ""):
+def check_operator_logs(markers, since_s = "", is_assert = True):
     """Check clickhouse-operator pod logs for specific markers.
     since is accpeted as XXs format to filter out recent rows only"""
     operator_pod = kubectl.get_operator_pod(ns=current().context.test_namespace)
-    if since != "":
-        since = f"--since={since}"
+    if since_s != "":
+        since_s = f"--since={since_s}s"
     out = kubectl.launch(
-        f"logs {operator_pod} -c clickhouse-operator {since}",
+        f"logs {operator_pod} -c clickhouse-operator {since_s}",
         ns=current().context.test_namespace,
     )
+    found_markers = []
     for marker in markers:
         with Then(f"operator logs should contain '{marker}'"):
-            assert marker in out, error(f"Marker '{marker}' not found in operator logs")
+            if is_assert:
+                assert marker in out, error(f"Marker '{marker}' not found in operator logs")
+            else:
+                if marker in out and marker not in found_markers:
+                    found_markers.append(marker)
+    return len(found_markers) == len(markers)
+
+def wait_operator_logs(markers, since_s = "", retries = 10):
+    for i in range(0, retries):
+        if check_operator_logs(markers, since_s = since_s, is_assert = False):
+            return
+        retry_sleep(i, 5, "not yet")
+    assert False, error(f"{markers} were not found in operator logs")
 
 
 @TestScenario

--- a/tests/e2e/test_operator.py
+++ b/tests/e2e/test_operator.py
@@ -730,7 +730,7 @@ def test_010010_1(self):
 
         with Then("Operator should start complaining about connection"):
             wait_operator_logs(["zk path to be verified"])
-            wait_operator_logs(["no such host"])
+            wait_operator_logs(['failed: zk dns lookup'])
 
         with And("CHI should stay in progress with no pods created (waiting for ZooKeeper)"):
             assert kubectl.get_chi_status(chi) == "InProgress"


### PR DESCRIPTION
## Summary
- Pass reconcile `ctx` into ZK path ensure for interruptible retries
- Resolve ZK hosts under dial timeout so DNS cannot hang unboundedly; keep long outer retries for slow ZK start.
- Skip ZK root ensure for reconciles on a running cluster.
- Extended `test_010010_1` to check different scenarios.
## Test plan
- [x] `go test ./pkg/model/zookeeper/ ./pkg/controller/chi/ -vet=off -count=1`
- [x] E2E `test_010010_1`