### PR TITLE
fix(controller): propagate error when HostCreateTables fails during table migration

### DIFF
--- a/pkg/controller/chi/worker-migrator.go
+++ b/pkg/controller/chi/worker-migrator.go
@@ -105,6 +105,7 @@ func (w *worker) migrateTables(ctx context.Context, host *api.Host, opts *migrat
 			M(host).F().
 			Error("ERROR add tables failed on shard/host:%d/%d cluster:%s err:%v",
 				host.Runtime.Address.ShardIndex, host.Runtime.Address.ReplicaIndex, host.Runtime.Address.ClusterName, err)
+		return err
 	}
 
 	w.a.V(1).


### PR DESCRIPTION
Fixes #2021

### Problem
In `pkg/controller/chi/worker-migrator.go`, when `HostCreateTables(ctx, host)` failed with an error, `migrateTables` logged the error but did not return it. As a result:
1. It proceeded to log `"Tables added successfully..."` despite table creation failing.
2. It pushed `PushHostTablesCreated` to status, incorrectly marking the host as having tables populated.
3. It returned `nil`, causing reconciler caller routines (`reconcileHostTables` / `reconcileHostMainDomain`) to proceed as if schema migration succeeded.

### Solution
- Return `err` immediately when `w.ensureClusterSchemer(host).HostCreateTables(ctx, host)` fails in `migrateTables`.
- Prevent false `EventReasonCreateCompleted` logging and `PushHostTablesCreated` status updates upon failure.

Signed-off-by: Tyagiquamar <tyagiquamar@gmail.com>
